### PR TITLE
Hide legacy AKI circles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.DS_Store

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,4 @@
+/* Supprimer les anciens ronds AKI */
+.circle, .aki-logo {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- add a .gitignore to keep build artifacts and dependencies out of version control
- add a public stylesheet that hides the legacy AKI circular elements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db9e7a4a7483219d50f8d488e485ab