### PR TITLE
Align V1 navigation and add router redirects for deprecated routes

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -83,53 +83,20 @@ export default function Header() {
           </li>
           <li>
             <Link
-              to="/comparateurs"
+              to="/comparateur"
               className={`flex items-center gap-3 px-6 py-3 text-white hover:bg-blue-700/20 transition-colors border-l-4 ${
-                isActiveRoute('/comparateurs') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
+                isActiveRoute('/comparateur') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
               }`}
               onClick={closeMobileMenu}
             >
-              <span>📊 Comparateurs</span>
+              <span>📊 Comparateur</span>
             </Link>
           </li>
           <li>
             <Link
-              to="/carte-itineraires"
+              to="/observatoire"
               className={`flex items-center gap-3 px-6 py-3 text-white hover:bg-blue-700/20 transition-colors border-l-4 ${
-                isActiveRoute('/carte-itineraires') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
-              }`}
-              onClick={closeMobileMenu}
-            >
-              <span>🗺️ Carte</span>
-            </Link>
-          </li>
-          <li>
-            <Link
-              to="/scanner"
-              className={`flex items-center gap-3 px-6 py-3 text-white hover:bg-blue-700/20 transition-colors border-l-4 ${
-                isActiveRoute('/scanner') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
-              }`}
-              onClick={closeMobileMenu}
-            >
-              <span>📷 Scanner</span>
-            </Link>
-          </li>
-          <li>
-            <Link
-              to="/assistant-ia"
-              className={`flex items-center gap-3 px-6 py-3 text-white hover:bg-blue-700/20 transition-colors border-l-4 ${
-                isActiveRoute('/assistant-ia') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
-              }`}
-              onClick={closeMobileMenu}
-            >
-              <span>🤖 Assistant IA</span>
-            </Link>
-          </li>
-          <li>
-            <Link
-              to="/observatoire-hub"
-              className={`flex items-center gap-3 px-6 py-3 text-white hover:bg-blue-700/20 transition-colors border-l-4 ${
-                isActiveRoute('/observatoire-hub') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
+                isActiveRoute('/observatoire') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
               }`}
               onClick={closeMobileMenu}
             >
@@ -138,56 +105,37 @@ export default function Header() {
           </li>
           <li>
             <Link
-              to="/solidarite"
+              to="/methodologie"
               className={`flex items-center gap-3 px-6 py-3 text-white hover:bg-blue-700/20 transition-colors border-l-4 ${
-                isActiveRoute('/solidarite') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
+                isActiveRoute('/methodologie') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
               }`}
               onClick={closeMobileMenu}
             >
-              <span>🤝 Solidarité</span>
-            </Link>
-          </li>
-          
-          {/* Secondary Navigation */}
-          <li className="px-6 py-2 mt-4">
-            <div className="text-xs uppercase tracking-wide text-slate-400">Plus</div>
-          </li>
-          <li>
-            <Link
-              to="/actualites"
-              className={`flex items-center gap-3 px-6 py-3 text-white hover:bg-blue-700/20 transition-colors border-l-4 ${
-                isActiveRoute('/actualites') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
-              }`}
-              onClick={closeMobileMenu}
-            >
-              <span>📰 Actualités</span>
+              <span>📚 Méthodologie</span>
             </Link>
           </li>
           <li>
             <Link
-              to="/mon-compte"
+              to="/faq"
               className={`flex items-center gap-3 px-6 py-3 text-white hover:bg-blue-700/20 transition-colors border-l-4 ${
-                isActiveRoute('/mon-compte') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
+                isActiveRoute('/faq') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
               }`}
               onClick={closeMobileMenu}
             >
-              <span>👤 Mon Compte</span>
+              <span>❓ FAQ</span>
             </Link>
           </li>
           <li>
             <Link
-              to="/parametres"
+              to="/contact"
               className={`flex items-center gap-3 px-6 py-3 text-white hover:bg-blue-700/20 transition-colors border-l-4 ${
-                isActiveRoute('/parametres') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
+                isActiveRoute('/contact') ? 'border-blue-400 bg-blue-700/10' : 'border-transparent hover:border-blue-400'
               }`}
               onClick={closeMobileMenu}
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
-              <span>Paramètres</span>
+              <span>✉️ Contact</span>
             </Link>
+          </li>
           
           {/* Status Badge in Mobile Menu */}
           <li className="px-6 py-3">
@@ -247,68 +195,41 @@ export default function Header() {
                 onMouseEnter={() => prefetchRoute('/comparateur')}
                 onFocus={() => prefetchRoute('/comparateur')}
               >
-                Comparer
+                Comparateur
               </Link>
               <Link
-                to="/comprendre-prix"
+                to="/observatoire"
                 className={`text-white/90 hover:text-white hover:bg-[color:var(--glass-bg)] px-3 py-2 rounded-lg transition-all ${
-                  isActiveRoute('/comprendre-prix') ? 'bg-[color:var(--glass-bg)] text-white font-semibold' : ''
+                  isActiveRoute('/observatoire') ? 'bg-[color:var(--glass-bg)] text-white font-semibold' : ''
                 }`}
+                onMouseEnter={() => prefetchRoute('/observatoire')}
+                onFocus={() => prefetchRoute('/observatoire')}
               >
-                Comprendre
+                Observatoire
               </Link>
               <Link
-                to="/ocr"
+                to="/methodologie"
                 className={`text-white/90 hover:text-white hover:bg-[color:var(--glass-bg)] px-3 py-2 rounded-lg transition-all ${
-                  isActiveRoute('/ocr') ? 'bg-[color:var(--glass-bg)] text-white font-semibold' : ''
+                  isActiveRoute('/methodologie') ? 'bg-[color:var(--glass-bg)] text-white font-semibold' : ''
                 }`}
-                onMouseEnter={() => prefetchRoute('/scanner')}
-                onFocus={() => prefetchRoute('/scanner')}
               >
-                OCR & Scan
+                Méthodologie
               </Link>
               <Link
-                to="/civic-modules"
+                to="/faq"
                 className={`text-white/90 hover:text-white hover:bg-[color:var(--glass-bg)] px-3 py-2 rounded-lg transition-all ${
-                  isActiveRoute('/civic-modules') ? 'bg-[color:var(--glass-bg)] text-white font-semibold' : ''
+                  isActiveRoute('/faq') ? 'bg-[color:var(--glass-bg)] text-white font-semibold' : ''
                 }`}
               >
-                Participer
+                FAQ
               </Link>
               <Link
-                to="/alertes"
+                to="/contact"
                 className={`text-white/90 hover:text-white hover:bg-[color:var(--glass-bg)] px-3 py-2 rounded-lg transition-all ${
-                  isActiveRoute('/alertes') ? 'bg-[color:var(--glass-bg)] text-white font-semibold' : ''
+                  isActiveRoute('/contact') ? 'bg-[color:var(--glass-bg)] text-white font-semibold' : ''
                 }`}
-                onMouseEnter={() => prefetchRoute('/alertes')}
-                onFocus={() => prefetchRoute('/alertes')}
               >
-                Alertes
-              </Link>
-              <Link
-                to="/mon-compte"
-                className={`text-white/90 hover:text-white hover:bg-[color:var(--glass-bg)] px-3 py-2 rounded-lg transition-all ${
-                  isActiveRoute('/mon-compte') ? 'bg-[color:var(--glass-bg)] text-white font-semibold' : ''
-                }`}
-                onMouseEnter={() => prefetchRoute('/mon-compte')}
-                onFocus={() => prefetchRoute('/mon-compte')}
-              >
-                Mon Compte
-              </Link>
-              <Link
-                to="/parametres"
-                className={`text-white/90 hover:text-white hover:bg-[color:var(--glass-bg)] px-3 py-2 rounded-lg transition-all flex items-center gap-2 ${
-                  isActiveRoute('/parametres') ? 'bg-[color:var(--glass-bg)] text-white font-semibold' : ''
-                }`}
-                title="Paramètres"
-                onMouseEnter={() => prefetchRoute('/parametres')}
-                onFocus={() => prefetchRoute('/parametres')}
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
-                Paramètres
+                Contact
               </Link>
               
               {/* Connection Status Badge */}

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -9,33 +9,14 @@ import { OfflineIndicator } from './OfflineIndicator';
 export default function Layout() {
   const [open, setOpen] = React.useState(false);
 
-  // Navigation principale - Menu simplifié à 7 entrées principales
-  // Chaque hub regroupe plusieurs fonctionnalités sous un seul point d'entrée
+  // Navigation principale - V1 officielle (6 entrées)
   const navItems = [
     { path: '/', label: 'Accueil', icon: '🏠' },
-    { path: '/comparateurs', label: 'Comparateurs', icon: '📊' },
-    { path: '/carte-itineraires', label: 'Carte', icon: '🗺️' },
-    { path: '/scanner', label: 'Scanner', icon: '📷' },
-    { path: '/assistant-ia', label: 'Assistant IA', icon: '🤖' },
-    { path: '/observatoire-hub', label: 'Observatoire', icon: '📈' },
-    { path: '/solidarite', label: 'Solidarité', icon: '🤝' },
-  ];
-
-  // Navigation secondaire - Accessible depuis le footer et menu mobile
-  const secondaryNavItems = [
-    { path: '/actualites', label: 'Actualités' },
-    { path: '/pricing', label: 'Tarifs' },
-    { path: '/presse', label: 'Presse' },
-    { path: '/mon-compte', label: 'Mon espace' },
-    { path: '/contact', label: 'Contact' },
-  ];
-
-  const publicNavItems = [
-    { path: '/methodologie', label: 'Méthodologie' },
-    { path: '/transparence', label: 'Transparence' },
-    { path: '/donnees-publiques', label: 'Données publiques' },
-    { path: '/presse', label: 'Presse' },
-    { path: '/mentions-legales', label: 'Mentions légales' },
+    { path: '/comparateur', label: 'Comparateur', icon: '📊' },
+    { path: '/observatoire', label: 'Observatoire', icon: '📈' },
+    { path: '/methodologie', label: 'Méthodologie', icon: '📚' },
+    { path: '/faq', label: 'FAQ', icon: '❓' },
+    { path: '/contact', label: 'Contact', icon: '✉️' },
   ];
 
   return (
@@ -110,37 +91,6 @@ export default function Layout() {
               ))}
             </div>
             
-            <div className="border-t border-slate-700 py-2">
-              <div className="px-6 py-2 text-xs uppercase tracking-wide text-slate-400">
-                Plus
-              </div>
-              {secondaryNavItems.map((item) => (
-                <NavLink
-                  key={item.path}
-                  to={item.path}
-                  className="block px-6 py-3 text-slate-200 hover:bg-slate-800 text-sm"
-                  onClick={() => setOpen(false)}
-                >
-                  {item.label}
-                </NavLink>
-              ))}
-            </div>
-            
-            <div className="border-t border-slate-700 py-2">
-              <div className="px-6 py-2 text-xs uppercase tracking-wide text-slate-400">
-                Données publiques
-              </div>
-              {publicNavItems.map((item) => (
-                <NavLink
-                  key={item.path}
-                  to={item.path}
-                  className="block px-6 py-3 text-slate-200 hover:bg-slate-800 text-sm"
-                  onClick={() => setOpen(false)}
-                >
-                  {item.label}
-                </NavLink>
-              ))}
-            </div>
           </div>
         )}
       </header>

--- a/src/components/__tests__/Layout.test.jsx
+++ b/src/components/__tests__/Layout.test.jsx
@@ -26,12 +26,13 @@ describe('Layout Component', () => {
 
   it('should render desktop navigation links', () => {
     renderLayout();
-    expect(screen.getByRole('link', { name: /comparateurs/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /comparateur/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /observatoire/i })).toBeInTheDocument();
   });
 
-  it('should render OCR & Scan navigation link', () => {
+  it('should render Methodologie navigation link', () => {
     renderLayout();
-    expect(screen.getByRole('link', { name: /scanner/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /méthodologie/i })).toBeInTheDocument();
   });
 
   it('should render mobile menu button', () => {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -167,20 +167,24 @@ ReactDOM.createRoot(document.getElementById('root')).render(
                 <Route path='/' element={<Layout />}>
                   <Route index element={<Home />} />
                   <Route path='chat' element={<ChatIALocal />} />
-                  <Route path='scan' element={<ScanOCR />} />
+                  <Route path='scan' element={<Navigate to="/observatoire" replace />} />
                   <Route path='scanner/*' element={<ScanOCR />} />
                   <Route path='scan-ean' element={<ScanEAN />} />
                   <Route path='comparaison-enseignes' element={<ComparaisonEnseignes />} />
                   <Route path='comparateur' element={<Comparateur />} />
                   <Route path='comparateurs/*' element={<Comparateurs />} />
                   <Route path='comparaison' element={<Navigate to="/comparateur" replace />} />
+                  <Route path='comparateur-vols' element={<Navigate to="/observatoire" replace />} />
+                  <Route path='comparateur-bateaux' element={<Navigate to="/observatoire" replace />} />
                   <Route path='recherche-produits' element={<RechercheProduits />} />
+                  <Route path='recherche-prix/*' element={<Navigate to="/observatoire" replace />} />
                   <Route path='carte' element={<Carte />} />
                   <Route path='carte-itineraires/*' element={<Carte />} />
                   <Route path='actualites' element={<ComingSoon title="Actualités" />} />
                   <Route path='alertes' element={<Alertes />} />
                   <Route path='a-propos' element={<APropos />} />
                   <Route path='methodologie' element={<Methodologie />} />
+                  <Route path='donnees-publiques' element={<Navigate to="/observatoire" replace />} />
                   <Route path='mentions-legales' element={<MentionsLegales />} />
                   <Route path='mon-compte' element={<MonCompte />} />
                   <Route path='parametres' element={<Settings />} />
@@ -189,6 +193,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
                   <Route path='reset-password' element={<ResetPassword />} />
                   <Route path='comprendre-prix' element={<ComprendrePrix />} />
                   <Route path='contribuer-prix' element={<ContribuerPrix />} />
+                  <Route path='contribuer' element={<Navigate to="/observatoire" replace />} />
                   <Route path='signaler-abus' element={<SignalerAbus />} />
                   <Route path='pricing' element={<ComingSoon title="Tarifs" />} />
                   <Route path='solidarite' element={<ComingSoon title="Solidarité" />} />
@@ -207,6 +212,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
                   <Route path='dossier-media' element={<DossierMedia />} />
                   <Route path='presse' element={<Presse />} />
                   <Route path='historique-prix' element={<HistoriquePrix />} />
+                  <Route path='historique-prix-new' element={<Navigate to="/observatoire" replace />} />
                   <Route path='alertes-prix' element={<AlertesPrix />} />
                   <Route path='budget-vital' element={<BudgetVital />} />
                   <Route path='faux-bons-plans' element={<FauxBonsPlan />} />
@@ -216,8 +222,13 @@ ReactDOM.createRoot(document.getElementById('root')).render(
                   <Route path='civic-modules' element={<CivicModules />} />
                   <Route path='evaluation-cosmetique' element={<EvaluationCosmetique />} />
                   <Route path='observatoire' element={<Observatoire />} />
+                  <Route path='observatoire-prix' element={<Navigate to="/observatoire" replace />} />
                   <Route path='observatoire-hub' element={<ComingSoon title="Observatoire" />} />
                   <Route path='observatoire/methodologie' element={<ObservatoryMethodology />} />
+                  <Route path='observatoire-vivant' element={<Navigate to="/observatoire" replace />} />
+                  <Route path='inflation' element={<Navigate to="/observatoire" replace />} />
+                  <Route path='ocr' element={<Navigate to="/observatoire" replace />} />
+                  <Route path='ocr/history' element={<Navigate to="/observatoire" replace />} />
                   <Route path='comparateur-citoyen' element={<ComparateurCitoyen />} />
                   <Route path=':territory/scanner' element={<TerritoryScanner />} />
                   <Route path=':territory/comparateurs' element={<TerritoryComparateurs />} />


### PR DESCRIPTION
### Motivation
- Stabilize the V1 navigation to the official, minimal set of routes and remove ambiguity in the menu. 
- Ensure deprecated or non-ready routes never surface to users and always redirect to the official observatory hub. 
- Keep changes limited to navigation, redirections and minimal test updates to match the V1 policy.

### Description
- Simplified the primary navigation to the official V1 entries (Accueil, Comparateur, Observatoire, Méthodologie, FAQ, Contact) by updating `src/components/Layout.jsx` and `src/components/Header.jsx`. 
- Removed secondary/public menu entries from the visible menu and unified desktop and mobile labels to the V1 set in `Header.jsx` (desktop + mobile). 
- Added client-side router redirects to map deprecated/hidden routes to `/observatoire` using `<Navigate to="/observatoire" replace />` in `src/main.jsx` for routes such as `/scan`, `/comparateur-vols`, `/comparateur-bateaux`, `/recherche-prix/*`, `/donnees-publiques`, `/contribuer`, `/historique-prix-new`, `/observatoire-prix`, `/observatoire-vivant`, `/inflation`, `/ocr`, `/ocr/history` and others documented in the rollout. 
- Updated navigation test expectations to match the new labels in `src/components/__tests__/Layout.test.jsx` (assertions for `comparateur`, `observatoire`, `méthodologie`, etc.).

### Testing
- Started a local dev server with `npm run dev` as a smoke test and Vite reported ready, indicating the app builds and serves successfully. (Succeeded) 
- Ran a headless browser script to load the local app and capture a full-page screenshot via Playwright, producing `artifacts/v1-nav.png` to visually verify the menu changes. (Succeeded) 
- Unit/integration test files were adjusted to match the new navigation labels but `vitest` or full test suite was not executed in this rollout, so automated test suite status was not changed locally. (Not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fd9f7a5d8832187a37276d48162a4)

## Summary by Sourcery

Align the app’s navigation with the official V1 menu and redirect deprecated routes to the observatory hub.

New Features:
- Expose a simplified primary navigation limited to Accueil, Comparateur, Observatoire, Méthodologie, FAQ and Contact across desktop and mobile.

Enhancements:
- Unify header and layout navigation items around the new V1 route structure and labels, removing legacy secondary and public menu sections.

Tests:
- Update layout navigation tests to assert the presence of the new V1 menu entries instead of deprecated links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation Updates**
  * Streamlined the main navigation menu with a revised set of options and updated labels
  * Reorganized navigation routes across both mobile and desktop interfaces for clearer structure
  * Consolidated related navigation items and removed secondary menu sections
  * Old navigation paths automatically redirect to their new destinations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->