### PR TITLE
Ajouter actions rapides, indices contextuels et file hors‑ligne pour ScanEAN

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, NavLink, Outlet } from 'react-router-dom';
+import { Link, NavLink, Outlet, useLocation } from 'react-router-dom';
 import '../styles/layout.css';
 import { Menu, X } from 'lucide-react';
 import TiPanierButton from './TiPanierButton';
@@ -9,7 +9,98 @@ import SkipLinks from './a11y/SkipLinks';
 import A11ySettingsPanel from './a11y/A11ySettingsPanel';
 
 export default function Layout() {
+  const location = useLocation();
   const [open, setOpen] = React.useState(false);
+  const [showScrollTop, setShowScrollTop] = React.useState(false);
+  const [focusMode, setFocusMode] = React.useState(() => localStorage.getItem('focusMode') === 'true');
+  const [showPalette, setShowPalette] = React.useState(false);
+  const [paletteQuery, setPaletteQuery] = React.useState('');
+  const [showShortcuts, setShowShortcuts] = React.useState(false);
+  const [showCoach, setShowCoach] = React.useState(() => localStorage.getItem('coachDismissed') !== 'true');
+  const [showQuickActions, setShowQuickActions] = React.useState(false);
+  const [pinnedRoutes, setPinnedRoutes] = React.useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('pinnedRoutes') || '[]');
+    } catch {
+      return [];
+    }
+  });
+  const paletteInputRef = React.useRef(null);
+  const triggerHaptic = (pattern = 12) => {
+    if (navigator?.vibrate) {
+      navigator.vibrate(pattern);
+    }
+  };
+
+  React.useEffect(() => {
+    const handleScroll = () => {
+      setShowScrollTop(window.scrollY > 400);
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    localStorage.setItem('focusMode', String(focusMode));
+  }, [focusMode]);
+
+  React.useEffect(() => {
+    localStorage.setItem('pinnedRoutes', JSON.stringify(pinnedRoutes));
+  }, [pinnedRoutes]);
+
+  React.useEffect(() => {
+    if (!showCoach) {
+      localStorage.setItem('coachDismissed', 'true');
+    }
+  }, [showCoach]);
+
+  React.useEffect(() => {
+    if (location.pathname) {
+      localStorage.setItem('lastVisited', location.pathname);
+    }
+  }, [location.pathname]);
+
+  React.useEffect(() => {
+    const handleKeydown = (event) => {
+      const isTyping = ['INPUT', 'TEXTAREA'].includes(event.target.tagName);
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        setShowPalette(true);
+      }
+      if (!isTyping && event.key === '/') {
+        event.preventDefault();
+        setShowPalette(true);
+      }
+      if (!isTyping && event.key === '?') {
+        event.preventDefault();
+        setShowShortcuts(true);
+        setShowPalette(true);
+      }
+      if (event.key === 'Escape') {
+        setShowPalette(false);
+        setShowShortcuts(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  }, []);
+
+  React.useEffect(() => {
+    if (showPalette) {
+      setTimeout(() => {
+        paletteInputRef.current?.focus();
+      }, 0);
+    } else {
+      setPaletteQuery('');
+      setShowShortcuts(false);
+    }
+  }, [showPalette]);
 
   // Navigation principale - V1 officielle (7 entrées)
   const navItems = [
@@ -21,6 +112,42 @@ export default function Layout() {
     { path: '/faq', label: 'FAQ', icon: '❓' },
     { path: '/contact', label: 'Contact', icon: '✉️' },
   ];
+  const quickLinks = [
+    ...navItems,
+    { path: '/scan-ean', label: 'Scanner EAN', icon: '📷' },
+  ];
+  const filteredLinks = quickLinks.filter((item) =>
+    item.label.toLowerCase().includes(paletteQuery.toLowerCase())
+  );
+  const pinnedItems = pinnedRoutes
+    .map((path) => quickLinks.find((item) => item.path === path))
+    .filter(Boolean);
+  const currentItem = quickLinks.find((item) => item.path === location.pathname);
+  const isPinned = currentItem ? pinnedRoutes.includes(currentItem.path) : false;
+  const nextSuggestion = (() => {
+    const suggestionMap = [
+      { match: '/', target: '/comparateur', label: 'Comparer les prix' },
+      { match: '/comparateur', target: '/scan-ean', label: 'Scanner un produit' },
+      { match: '/scan-ean', target: '/observatoire', label: 'Explorer l’observatoire' },
+      { match: '/observatoire', target: '/methodologie', label: 'Lire la méthodologie' },
+    ];
+    const match = suggestionMap.find((entry) => location.pathname.startsWith(entry.match));
+    return match && quickLinks.find((item) => item.path === match.target)
+      ? { path: match.target, label: match.label }
+      : null;
+  })();
+  const moduleHint = (() => {
+    if (location.pathname.startsWith('/comparateur')) {
+      return 'Astuce : comparez sur plusieurs enseignes pour révéler les écarts réels.';
+    }
+    if (location.pathname.startsWith('/scan-ean')) {
+      return 'Astuce : scannez d’abord, puis confirmez en saisie manuelle si besoin.';
+    }
+    if (location.pathname.startsWith('/observatoire')) {
+      return 'Astuce : utilisez les filtres pour isoler votre territoire.';
+    }
+    return null;
+  })();
 
   return (
     <div className="flex flex-col min-h-screen bg-slate-950 text-slate-100">
@@ -107,15 +234,256 @@ export default function Layout() {
       <OfflineIndicator />
 
       {/* CONTENU */}
-      <main id="main-content" className="flex-1 pt-20 pb-12 px-4 md:px-8" role="main">
+      <main
+        id="main-content"
+        className={`flex-1 pt-20 pb-24 px-4 md:px-8 ${focusMode ? 'max-w-4xl mx-auto' : ''}`}
+        style={{ fontSize: 'clamp(0.95rem, 0.2vw + 0.9rem, 1.05rem)' }}
+        role="main"
+      >
+        {showCoach && (
+          <div className="mb-6 rounded-2xl border border-white/10 bg-white/[0.04] p-4 text-sm text-white/80">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <div className="text-base font-semibold text-white">Coach rapide</div>
+                <p className="mt-1 text-xs text-white/60">
+                  Suivez ces étapes pour gagner du temps sur le comparateur et le scan.
+                </p>
+                <ol className="mt-2 list-decimal space-y-1 pl-4 text-xs">
+                  <li>Accédez à Comparateur pour comparer les prix.</li>
+                  <li>Scannez ou saisissez un EAN pour un produit précis.</li>
+                  <li>Activez une alerte pour suivre l’évolution des prix.</li>
+                </ol>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  triggerHaptic();
+                  setShowCoach(false);
+                }}
+                className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70 hover:text-white"
+              >
+                Masquer
+              </button>
+            </div>
+          </div>
+        )}
+        {pinnedItems.length > 0 && (
+          <div className="mb-6 rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+            <div className="text-xs font-semibold text-white/70">Accès rapides</div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {pinnedItems.map((item) => (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  className="rounded-full border border-white/15 px-3 py-1 text-xs text-white/80 hover:border-white/30 hover:bg-white/10"
+                >
+                  {item.icon} {item.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+        {nextSuggestion && (
+          <div className="mb-6 rounded-2xl border border-blue-500/30 bg-blue-500/10 p-4 text-xs text-blue-100">
+            👉 Étape suivante recommandée :{' '}
+            <Link to={nextSuggestion.path} className="font-semibold text-white underline">
+              {nextSuggestion.label}
+            </Link>
+          </div>
+        )}
+        {moduleHint && (
+          <div className="mb-6 rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-xs text-white/70">
+            {moduleHint}
+          </div>
+        )}
         <Outlet />
       </main>
 
       {/* Floating actions (chat + panier) - managed by single container */}
       <FloatingActions />
 
+      {/* Barre d'actions mobile (optimisée Android) */}
+      <div className="lg:hidden fixed bottom-0 left-0 right-0 z-40 border-t border-slate-800 bg-slate-900/95 backdrop-blur">
+        <div className="mx-auto flex max-w-7xl items-center justify-around px-4 py-2 text-xs text-slate-200">
+          {['/', '/comparateur', '/scan-ean', '/contact'].map((path) => {
+            const item = quickLinks.find((link) => link.path === path);
+            return item ? (
+              <Link
+                key={item.path}
+                to={item.path}
+                onClick={() => triggerHaptic(8)}
+                className={`flex flex-col items-center gap-1 rounded-lg px-2 py-1 ${
+                  location.pathname === item.path ? 'text-blue-300' : 'text-slate-200'
+                }`}
+              >
+                <span className="text-base">{item.icon}</span>
+                <span className="text-[10px]">{item.label}</span>
+              </Link>
+            ) : null;
+          })}
+          <button
+            type="button"
+            onClick={() => {
+              triggerHaptic(8);
+              setShowQuickActions(true);
+            }}
+            className="flex flex-col items-center gap-1 rounded-lg px-2 py-1 text-slate-200"
+            aria-label="Ouvrir les actions rapides"
+          >
+            <span className="text-base">⚡</span>
+            <span className="text-[10px]">Actions</span>
+          </button>
+        </div>
+      </div>
+
+      {showScrollTop && (
+        <button
+          type="button"
+          onClick={() => {
+            triggerHaptic();
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+          }}
+          className="fixed bottom-24 right-6 z-40 rounded-full border border-white/10 bg-slate-900/90 px-4 py-2 text-xs font-semibold text-white shadow-lg transition hover:bg-slate-800"
+          aria-label="Remonter en haut de la page"
+        >
+          ⬆️ Retour en haut
+        </button>
+      )}
+
       {/* Panneau de paramètres d'accessibilité */}
       <A11ySettingsPanel />
+
+      {showPalette && (
+        <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm">
+          <div className="mx-auto mt-24 w-[92%] max-w-xl rounded-2xl border border-white/10 bg-slate-900 p-4 shadow-2xl">
+            <div className="flex items-center justify-between">
+              <div className="text-sm font-semibold text-white">Recherche rapide</div>
+              <div className="text-xs text-white/60">Ctrl/Cmd + K • /</div>
+            </div>
+            <input
+              ref={paletteInputRef}
+              value={paletteQuery}
+              onChange={(event) => setPaletteQuery(event.target.value)}
+              placeholder="Rechercher une page, un module..."
+              className="mt-3 w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {pinnedItems.length > 0 && (
+              <div className="mt-4">
+                <div className="text-xs font-semibold text-white/70">Épinglés</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {pinnedItems.map((item) => (
+                    <Link
+                      key={item.path}
+                      to={item.path}
+                      onClick={() => setShowPalette(false)}
+                      className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/80 hover:bg-white/10"
+                    >
+                      {item.icon} {item.label}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+            <div className="mt-4 space-y-2">
+              {filteredLinks.map((item) => (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  onClick={() => {
+                    triggerHaptic(8);
+                    setShowPalette(false);
+                  }}
+                  className="flex items-center justify-between rounded-lg border border-white/10 px-3 py-2 text-sm text-white/80 hover:bg-white/10"
+                >
+                  <span>
+                    {item.icon} {item.label}
+                  </span>
+                  <span className="text-xs text-white/40">{item.path}</span>
+                </Link>
+              ))}
+              {filteredLinks.length === 0 && (
+                <div className="text-xs text-white/50">Aucun résultat. Essayez un autre terme.</div>
+              )}
+            </div>
+            <div className="mt-4 flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => setFocusMode(!focusMode)}
+                className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70 hover:text-white"
+              >
+                {focusMode ? 'Désactiver mode focus' : 'Activer mode focus'}
+              </button>
+              {currentItem && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    triggerHaptic(8);
+                    if (isPinned) {
+                      setPinnedRoutes(pinnedRoutes.filter((path) => path !== currentItem.path));
+                    } else {
+                      setPinnedRoutes([...new Set([...pinnedRoutes, currentItem.path])]);
+                    }
+                  }}
+                  className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70 hover:text-white"
+                >
+                  {isPinned ? 'Retirer des favoris' : 'Épingler cette page'}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => setShowPalette(false)}
+                className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70 hover:text-white"
+              >
+                Fermer
+              </button>
+            </div>
+            {showShortcuts && (
+              <div className="mt-4 rounded-lg border border-white/10 bg-white/5 p-3 text-xs text-white/70">
+                <div className="font-semibold text-white/80">Raccourcis clavier</div>
+                <ul className="mt-2 space-y-1">
+                  <li>Ctrl/Cmd + K : ouvrir la recherche rapide</li>
+                  <li>/ : ouvrir la recherche rapide</li>
+                  <li>? : afficher l’aide des raccourcis</li>
+                  <li>Échap : fermer</li>
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {showQuickActions && (
+        <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm">
+          <div className="fixed bottom-0 left-0 right-0 rounded-t-2xl border-t border-white/10 bg-slate-900 p-4 shadow-2xl">
+            <div className="flex items-center justify-between">
+              <div className="text-sm font-semibold text-white">Actions rapides</div>
+              <button
+                type="button"
+                onClick={() => setShowQuickActions(false)}
+                className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70"
+              >
+                Fermer
+              </button>
+            </div>
+            <div className="mt-4 grid grid-cols-2 gap-2 text-xs text-white/80">
+              {quickLinks.map((item) => (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  onClick={() => {
+                    triggerHaptic(8);
+                    setShowQuickActions(false);
+                  }}
+                  className="rounded-lg border border-white/10 px-3 py-3 text-center hover:bg-white/10"
+                >
+                  <div className="text-base">{item.icon}</div>
+                  <div className="mt-1">{item.label}</div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* FOOTER */}
       <footer id="footer" className="border-t border-slate-800 bg-slate-900/90 text-center py-6 text-sm text-slate-400" role="contentinfo">

--- a/frontend/src/pages/ScanEAN.tsx
+++ b/frontend/src/pages/ScanEAN.tsx
@@ -24,6 +24,9 @@ export default function ScanEAN() {
   
   const [manualEAN, setManualEAN] = useState('')
   const [manualError, setManualError] = useState<string | null>(null)
+  const [isPastingEAN, setIsPastingEAN] = useState(false)
+  const [offlineQueue, setOfflineQueue] = useState<Array<{ ean: string; queuedAt: string }>>([])
+  const [offlineQueueMessage, setOfflineQueueMessage] = useState<string | null>(null)
   const [showHistory, setShowHistory] = useState(false)
   const [imageUploadStatus, setImageUploadStatus] = useState<string | null>(null)
   const [isProcessingImage, setIsProcessingImage] = useState(false)
@@ -82,9 +85,23 @@ export default function ScanEAN() {
     }
   }, [resolver, addToHistory, isUnifiedFlow, isPhotoMode, scanFlow])
 
+  useEffect(() => {
+    try {
+      const storedQueue = JSON.parse(localStorage.getItem('offlineEANQueue') || '[]')
+      setOfflineQueue(Array.isArray(storedQueue) ? storedQueue : [])
+    } catch (error) {
+      console.error('Failed to read offline EAN queue:', error)
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('offlineEANQueue', JSON.stringify(offlineQueue))
+  }, [offlineQueue])
+
   // Handle manual EAN search
   const handleManualSearch = async () => {
     setManualError(null)
+    setOfflineQueueMessage(null)
 
     if (!manualEAN.trim()) {
       setManualError('Veuillez saisir un code EAN')
@@ -97,8 +114,58 @@ export default function ScanEAN() {
       return
     }
 
+    if (!navigator.onLine) {
+      const queuedItem = { ean: manualEAN.trim(), queuedAt: new Date().toISOString() }
+      setOfflineQueue((prev) => [...prev, queuedItem])
+      setOfflineQueueMessage('📥 Vous êtes hors ligne. Recherche ajoutée à la file d’attente.')
+      return
+    }
+
     await handleEAN(manualEAN.trim())
   }
+
+  const handleProcessOfflineQueue = async () => {
+    if (!navigator.onLine || offlineQueue.length === 0) return
+    setOfflineQueueMessage('🔄 Traitement des recherches en attente...')
+    for (const item of offlineQueue) {
+      await handleEAN(item.ean)
+    }
+    setOfflineQueue([])
+    setOfflineQueueMessage('✅ Recherches en attente traitées.')
+    setTimeout(() => setOfflineQueueMessage(null), 3000)
+  }
+
+  const handlePasteFromClipboard = async () => {
+    setManualError(null)
+    setIsPastingEAN(true)
+
+    try {
+      const clipboardText = await navigator.clipboard.readText()
+      const digits = clipboardText.replace(/\D/g, '').slice(0, 13)
+
+      if (!digits) {
+        setManualError('Aucun code EAN trouvé dans le presse-papiers')
+        return
+      }
+
+      setManualEAN(digits)
+    } catch (error) {
+      console.error('Clipboard read error:', error)
+      setManualError('Accès au presse-papiers refusé ou indisponible')
+    } finally {
+      setIsPastingEAN(false)
+    }
+  }
+
+  const manualEANLength = manualEAN.trim().length
+  const isManualEANLengthValid = manualEANLength === 8 || manualEANLength === 13
+  const isManualEANValid = isManualEANLengthValid && validateEAN(manualEAN.trim())
+  const canSubmitManual = manualEAN.trim().length > 0 && isManualEANValid && !resolver.loading
+  const recentHistory = history.slice(0, 2)
+  const lastHistoryEntry = history[0]
+  const matchedCatalogProduct = manualEAN.trim()
+    ? productCatalog.find((product) => product.ean === manualEAN.trim())
+    : null
 
   // Handle camera detection
   const handleCameraDetection = async (ean: string) => {
@@ -278,6 +345,14 @@ export default function ScanEAN() {
             onStartScan={scanner.startScanning}
             onStopScan={scanner.stopScanning}
           />
+          <div className="mt-4 rounded-lg border border-white/10 bg-white/[0.03] p-3 text-xs text-white/70">
+            <div className="font-semibold text-white/80">Mode scan assisté</div>
+            <ol className="mt-2 list-decimal space-y-1 pl-4">
+              <li>Placez le code-barres dans le cadre et stabilisez.</li>
+              <li>Évitez les reflets, approchez progressivement.</li>
+              <li>Si l’auto-scan échoue, passez en saisie manuelle.</li>
+            </ol>
+          </div>
         </GlassCard>
 
         {/* Import image */}
@@ -337,6 +412,11 @@ export default function ScanEAN() {
                   setManualEAN(e.target.value.replace(/\D/g, ''))
                   setManualError(null)
                 }}
+                onBlur={() => {
+                  if (manualEAN.trim() && !isManualEANValid) {
+                    setManualError('Code EAN invalide (vérifiez la longueur et le checksum)')
+                  }
+                }}
                 onKeyPress={(e) => {
                   if (e.key === 'Enter') {
                     handleManualSearch()
@@ -347,6 +427,28 @@ export default function ScanEAN() {
                 aria-label="Saisir le code EAN manuellement"
                 aria-describedby={manualError ? 'manual-error' : undefined}
               />
+              <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-white/60">
+                <span className="rounded-full border border-white/20 px-2 py-1">
+                  {manualEANLength}/13 chiffres
+                </span>
+                {manualEANLength > 0 && (
+                  <span
+                    className={`rounded-full px-2 py-1 ${
+                      isManualEANValid
+                        ? 'bg-green-500/20 text-green-300 border border-green-500/40'
+                        : isManualEANLengthValid
+                        ? 'bg-yellow-500/20 text-yellow-300 border border-yellow-500/40'
+                        : 'bg-white/10 text-white/60 border border-white/20'
+                    }`}
+                  >
+                    {isManualEANValid
+                      ? 'EAN valide'
+                      : isManualEANLengthValid
+                      ? 'Vérifiez le checksum'
+                      : 'Saisissez 8 ou 13 chiffres'}
+                  </span>
+                )}
+              </div>
               {manualError && (
                 <p id="manual-error" className="mt-2 text-sm text-red-400">
                   {manualError}
@@ -354,14 +456,113 @@ export default function ScanEAN() {
               )}
             </div>
 
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={handlePasteFromClipboard}
+                disabled={isPastingEAN}
+                className="w-full px-4 py-2 text-sm bg-white/[0.08] hover:bg-white/[0.12] disabled:bg-white/[0.06] disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+                aria-label="Coller le code EAN depuis le presse-papiers"
+              >
+                {isPastingEAN ? '📋 Lecture...' : '📋 Coller depuis le presse-papiers'}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setManualEAN('')
+                  setManualError(null)
+                }}
+                disabled={!manualEAN}
+                className="w-full px-4 py-2 text-sm bg-white/[0.08] hover:bg-white/[0.12] disabled:bg-white/[0.06] disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+                aria-label="Effacer la saisie manuelle"
+              >
+                ✨ Effacer la saisie
+              </button>
+            </div>
+            {lastHistoryEntry && (
+              <button
+                type="button"
+                onClick={() => {
+                  setManualEAN(lastHistoryEntry.ean)
+                  setManualError(null)
+                }}
+                className="w-full px-4 py-2 text-xs bg-white/[0.08] hover:bg-white/[0.12] text-white/90 rounded-lg transition-colors"
+                aria-label="Pré-remplir avec le dernier EAN scanné"
+              >
+                🕘 Pré-remplir avec le dernier EAN ({lastHistoryEntry.ean})
+              </button>
+            )}
+            {recentHistory.length > 0 && (
+              <div className="rounded-lg border border-white/10 bg-white/[0.03] p-3">
+                <div className="text-xs font-semibold text-white/70">Derniers scans</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {recentHistory.map((entry) => (
+                    <button
+                      key={entry.ean}
+                      type="button"
+                      onClick={() => {
+                        setManualEAN(entry.ean)
+                        setManualError(null)
+                      }}
+                      className="rounded-full border border-white/15 px-3 py-1 text-xs text-white/80 hover:border-white/30 hover:bg-white/10 transition-colors"
+                      aria-label={`Réutiliser le code ${entry.ean}`}
+                    >
+                      {entry.productName ? `${entry.productName} • ${entry.ean}` : entry.ean}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+            {manualEAN.trim() && (
+              <div className="rounded-lg border border-white/10 bg-white/[0.03] p-3 text-xs text-white/70">
+                {matchedCatalogProduct ? (
+                  <div>
+                    ✅ Produit reconnu : <span className="text-white">{matchedCatalogProduct.label}</span>
+                  </div>
+                ) : (
+                  <div>🔎 Aucun produit connu trouvé pour cet EAN (vous pouvez tenter la recherche).</div>
+                )}
+              </div>
+            )}
+            {offlineQueue.length > 0 && (
+              <div className="rounded-lg border border-white/10 bg-white/[0.03] p-3 text-xs text-white/70">
+                <div>📦 {offlineQueue.length} recherche(s) en attente hors ligne.</div>
+                {navigator.onLine && (
+                  <button
+                    type="button"
+                    onClick={handleProcessOfflineQueue}
+                    className="mt-2 rounded-full border border-white/10 px-3 py-1 text-xs text-white/80 hover:bg-white/10"
+                  >
+                    Lancer les recherches en attente
+                  </button>
+                )}
+              </div>
+            )}
+            {offlineQueueMessage && (
+              <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs text-emerald-200">
+                {offlineQueueMessage}
+              </div>
+            )}
+
             <button
               onClick={handleManualSearch}
-              disabled={resolver.loading}
+              disabled={!canSubmitManual}
               className="w-full px-4 py-3 bg-blue-600 hover:bg-blue-500 disabled:bg-blue-600/50 disabled:cursor-not-allowed text-white rounded-lg font-medium transition-colors"
               aria-label="Rechercher le produit"
             >
               {resolver.loading ? '🔍 Recherche...' : '🔍 Rechercher'}
             </button>
+            <div className="text-xs text-white/60">
+              💡 Astuce : vous pouvez coller un code EAN depuis votre presse-papiers pour gagner du temps.
+            </div>
+            <div className="text-xs text-white/50">
+              Le bouton de recherche s'active dès que le code est valide.
+            </div>
+            {isManualEANValid && !resolver.loading && (
+              <div className="text-xs text-green-300">
+                ✅ EAN valide, prêt à lancer la recherche.
+              </div>
+            )}
           </div>
         </GlassCard>
       </div>

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, NavLink, Outlet } from 'react-router-dom';
+import { Link, NavLink, Outlet, useLocation } from 'react-router-dom';
 import '../styles/layout.css';
 import { Menu, X } from 'lucide-react';
 import TiPanierButton from './TiPanierButton';
@@ -7,7 +7,98 @@ import FloatingActions from './ui/FloatingActions';
 import { OfflineIndicator } from './OfflineIndicator';
 
 export default function Layout() {
+  const location = useLocation();
   const [open, setOpen] = React.useState(false);
+  const [showScrollTop, setShowScrollTop] = React.useState(false);
+  const [focusMode, setFocusMode] = React.useState(() => localStorage.getItem('focusMode') === 'true');
+  const [showPalette, setShowPalette] = React.useState(false);
+  const [paletteQuery, setPaletteQuery] = React.useState('');
+  const [showShortcuts, setShowShortcuts] = React.useState(false);
+  const [showCoach, setShowCoach] = React.useState(() => localStorage.getItem('coachDismissed') !== 'true');
+  const [showQuickActions, setShowQuickActions] = React.useState(false);
+  const [pinnedRoutes, setPinnedRoutes] = React.useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('pinnedRoutes') || '[]');
+    } catch {
+      return [];
+    }
+  });
+  const paletteInputRef = React.useRef(null);
+  const triggerHaptic = (pattern = 12) => {
+    if (navigator?.vibrate) {
+      navigator.vibrate(pattern);
+    }
+  };
+
+  React.useEffect(() => {
+    const handleScroll = () => {
+      setShowScrollTop(window.scrollY > 400);
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll();
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    localStorage.setItem('focusMode', String(focusMode));
+  }, [focusMode]);
+
+  React.useEffect(() => {
+    localStorage.setItem('pinnedRoutes', JSON.stringify(pinnedRoutes));
+  }, [pinnedRoutes]);
+
+  React.useEffect(() => {
+    if (!showCoach) {
+      localStorage.setItem('coachDismissed', 'true');
+    }
+  }, [showCoach]);
+
+  React.useEffect(() => {
+    if (location.pathname) {
+      localStorage.setItem('lastVisited', location.pathname);
+    }
+  }, [location.pathname]);
+
+  React.useEffect(() => {
+    const handleKeydown = (event) => {
+      const isTyping = ['INPUT', 'TEXTAREA'].includes(event.target.tagName);
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        setShowPalette(true);
+      }
+      if (!isTyping && event.key === '/') {
+        event.preventDefault();
+        setShowPalette(true);
+      }
+      if (!isTyping && event.key === '?') {
+        event.preventDefault();
+        setShowShortcuts(true);
+        setShowPalette(true);
+      }
+      if (event.key === 'Escape') {
+        setShowPalette(false);
+        setShowShortcuts(false);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  }, []);
+
+  React.useEffect(() => {
+    if (showPalette) {
+      setTimeout(() => {
+        paletteInputRef.current?.focus();
+      }, 0);
+    } else {
+      setPaletteQuery('');
+      setShowShortcuts(false);
+    }
+  }, [showPalette]);
 
   // Navigation principale - V1 officielle (6 entrées)
   const navItems = [
@@ -18,6 +109,42 @@ export default function Layout() {
     { path: '/faq', label: 'FAQ', icon: '❓' },
     { path: '/contact', label: 'Contact', icon: '✉️' },
   ];
+  const quickLinks = [
+    ...navItems,
+    { path: '/scan-ean', label: 'Scanner EAN', icon: '📷' },
+  ];
+  const filteredLinks = quickLinks.filter((item) =>
+    item.label.toLowerCase().includes(paletteQuery.toLowerCase())
+  );
+  const pinnedItems = pinnedRoutes
+    .map((path) => quickLinks.find((item) => item.path === path))
+    .filter(Boolean);
+  const currentItem = quickLinks.find((item) => item.path === location.pathname);
+  const isPinned = currentItem ? pinnedRoutes.includes(currentItem.path) : false;
+  const nextSuggestion = (() => {
+    const suggestionMap = [
+      { match: '/', target: '/comparateur', label: 'Comparer les prix' },
+      { match: '/comparateur', target: '/scan-ean', label: 'Scanner un produit' },
+      { match: '/scan-ean', target: '/observatoire', label: 'Explorer l’observatoire' },
+      { match: '/observatoire', target: '/methodologie', label: 'Lire la méthodologie' },
+    ];
+    const match = suggestionMap.find((entry) => location.pathname.startsWith(entry.match));
+    return match && quickLinks.find((item) => item.path === match.target)
+      ? { path: match.target, label: match.label }
+      : null;
+  })();
+  const moduleHint = (() => {
+    if (location.pathname.startsWith('/comparateur')) {
+      return 'Astuce : comparez sur plusieurs enseignes pour révéler les écarts réels.';
+    }
+    if (location.pathname.startsWith('/scan-ean')) {
+      return 'Astuce : scannez d’abord, puis confirmez en saisie manuelle si besoin.';
+    }
+    if (location.pathname.startsWith('/observatoire')) {
+      return 'Astuce : utilisez les filtres pour isoler votre territoire.';
+    }
+    return null;
+  })();
 
   return (
     <div className="flex flex-col min-h-screen bg-slate-950 text-slate-100">
@@ -99,12 +226,119 @@ export default function Layout() {
       <OfflineIndicator />
 
       {/* CONTENU */}
-      <main className="flex-1 pt-20 pb-12 px-4 md:px-8">
+      <main
+        className={`flex-1 pt-20 pb-24 px-4 md:px-8 ${focusMode ? 'max-w-4xl mx-auto' : ''}`}
+        style={{ fontSize: 'clamp(0.95rem, 0.2vw + 0.9rem, 1.05rem)' }}
+      >
+        {showCoach && (
+          <div className="mb-6 rounded-2xl border border-white/10 bg-white/[0.04] p-4 text-sm text-white/80">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <div className="text-base font-semibold text-white">Coach rapide</div>
+                <p className="mt-1 text-xs text-white/60">
+                  Suivez ces étapes pour gagner du temps sur le comparateur et le scan.
+                </p>
+                <ol className="mt-2 list-decimal space-y-1 pl-4 text-xs">
+                  <li>Accédez à Comparateur pour comparer les prix.</li>
+                  <li>Scannez ou saisissez un EAN pour un produit précis.</li>
+                  <li>Activez une alerte pour suivre l’évolution des prix.</li>
+                </ol>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  triggerHaptic();
+                  setShowCoach(false);
+                }}
+                className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70 hover:text-white"
+              >
+                Masquer
+              </button>
+            </div>
+          </div>
+        )}
+        {pinnedItems.length > 0 && (
+          <div className="mb-6 rounded-2xl border border-white/10 bg-white/[0.04] p-4">
+            <div className="text-xs font-semibold text-white/70">Accès rapides</div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {pinnedItems.map((item) => (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  className="rounded-full border border-white/15 px-3 py-1 text-xs text-white/80 hover:border-white/30 hover:bg-white/10"
+                >
+                  {item.icon} {item.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+        {nextSuggestion && (
+          <div className="mb-6 rounded-2xl border border-blue-500/30 bg-blue-500/10 p-4 text-xs text-blue-100">
+            👉 Étape suivante recommandée :{' '}
+            <Link to={nextSuggestion.path} className="font-semibold text-white underline">
+              {nextSuggestion.label}
+            </Link>
+          </div>
+        )}
+        {moduleHint && (
+          <div className="mb-6 rounded-2xl border border-white/10 bg-white/[0.03] p-4 text-xs text-white/70">
+            {moduleHint}
+          </div>
+        )}
         <Outlet />
       </main>
 
       {/* Floating actions (chat + panier) - managed by single container */}
       <FloatingActions />
+
+      {/* Barre d'actions mobile (optimisée Android) */}
+      <div className="lg:hidden fixed bottom-0 left-0 right-0 z-40 border-t border-slate-800 bg-slate-900/95 backdrop-blur">
+        <div className="mx-auto flex max-w-7xl items-center justify-around px-4 py-2 text-xs text-slate-200">
+          {['/', '/comparateur', '/scan-ean', '/contact'].map((path) => {
+            const item = quickLinks.find((link) => link.path === path);
+            return item ? (
+              <Link
+                key={item.path}
+                to={item.path}
+                onClick={() => triggerHaptic(8)}
+                className={`flex flex-col items-center gap-1 rounded-lg px-2 py-1 ${
+                  location.pathname === item.path ? 'text-blue-300' : 'text-slate-200'
+                }`}
+              >
+                <span className="text-base">{item.icon}</span>
+                <span className="text-[10px]">{item.label}</span>
+              </Link>
+            ) : null;
+          })}
+          <button
+            type="button"
+            onClick={() => {
+              triggerHaptic(8);
+              setShowQuickActions(true);
+            }}
+            className="flex flex-col items-center gap-1 rounded-lg px-2 py-1 text-slate-200"
+            aria-label="Ouvrir les actions rapides"
+          >
+            <span className="text-base">⚡</span>
+            <span className="text-[10px]">Actions</span>
+          </button>
+        </div>
+      </div>
+
+      {showScrollTop && (
+        <button
+          type="button"
+          onClick={() => {
+            triggerHaptic();
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+          }}
+          className="fixed bottom-24 right-6 z-40 rounded-full border border-white/10 bg-slate-900/90 px-4 py-2 text-xs font-semibold text-white shadow-lg transition hover:bg-slate-800"
+          aria-label="Remonter en haut de la page"
+        >
+          ⬆️ Retour en haut
+        </button>
+      )}
 
       {/* FOOTER */}
       <footer className="border-t border-slate-800 bg-slate-900/90 text-center py-6 text-sm text-slate-400">
@@ -114,6 +348,138 @@ export default function Layout() {
           Mentions légales
         </Link>
       </footer>
+
+      {showPalette && (
+        <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm">
+          <div className="mx-auto mt-24 w-[92%] max-w-xl rounded-2xl border border-white/10 bg-slate-900 p-4 shadow-2xl">
+            <div className="flex items-center justify-between">
+              <div className="text-sm font-semibold text-white">Recherche rapide</div>
+              <div className="text-xs text-white/60">Ctrl/Cmd + K • /</div>
+            </div>
+            <input
+              ref={paletteInputRef}
+              value={paletteQuery}
+              onChange={(event) => setPaletteQuery(event.target.value)}
+              placeholder="Rechercher une page, un module..."
+              className="mt-3 w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {pinnedItems.length > 0 && (
+              <div className="mt-4">
+                <div className="text-xs font-semibold text-white/70">Épinglés</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {pinnedItems.map((item) => (
+                    <Link
+                      key={item.path}
+                      to={item.path}
+                      onClick={() => setShowPalette(false)}
+                      className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/80 hover:bg-white/10"
+                    >
+                      {item.icon} {item.label}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+            )}
+            <div className="mt-4 space-y-2">
+              {filteredLinks.map((item) => (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  onClick={() => {
+                    triggerHaptic(8);
+                    setShowPalette(false);
+                  }}
+                  className="flex items-center justify-between rounded-lg border border-white/10 px-3 py-2 text-sm text-white/80 hover:bg-white/10"
+                >
+                  <span>
+                    {item.icon} {item.label}
+                  </span>
+                  <span className="text-xs text-white/40">{item.path}</span>
+                </Link>
+              ))}
+              {filteredLinks.length === 0 && (
+                <div className="text-xs text-white/50">Aucun résultat. Essayez un autre terme.</div>
+              )}
+            </div>
+            <div className="mt-4 flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => setFocusMode(!focusMode)}
+                className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70 hover:text-white"
+              >
+                {focusMode ? 'Désactiver mode focus' : 'Activer mode focus'}
+              </button>
+              {currentItem && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    triggerHaptic(8);
+                    if (isPinned) {
+                      setPinnedRoutes(pinnedRoutes.filter((path) => path !== currentItem.path));
+                    } else {
+                      setPinnedRoutes([...new Set([...pinnedRoutes, currentItem.path])]);
+                    }
+                  }}
+                  className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70 hover:text-white"
+                >
+                  {isPinned ? 'Retirer des favoris' : 'Épingler cette page'}
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => setShowPalette(false)}
+                className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70 hover:text-white"
+              >
+                Fermer
+              </button>
+            </div>
+            {showShortcuts && (
+              <div className="mt-4 rounded-lg border border-white/10 bg-white/5 p-3 text-xs text-white/70">
+                <div className="font-semibold text-white/80">Raccourcis clavier</div>
+                <ul className="mt-2 space-y-1">
+                  <li>Ctrl/Cmd + K : ouvrir la recherche rapide</li>
+                  <li>/ : ouvrir la recherche rapide</li>
+                  <li>? : afficher l’aide des raccourcis</li>
+                  <li>Échap : fermer</li>
+                </ul>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {showQuickActions && (
+        <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm">
+          <div className="fixed bottom-0 left-0 right-0 rounded-t-2xl border-t border-white/10 bg-slate-900 p-4 shadow-2xl">
+            <div className="flex items-center justify-between">
+              <div className="text-sm font-semibold text-white">Actions rapides</div>
+              <button
+                type="button"
+                onClick={() => setShowQuickActions(false)}
+                className="rounded-full border border-white/10 px-3 py-1 text-xs text-white/70"
+              >
+                Fermer
+              </button>
+            </div>
+            <div className="mt-4 grid grid-cols-2 gap-2 text-xs text-white/80">
+              {quickLinks.map((item) => (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  onClick={() => {
+                    triggerHaptic(8);
+                    setShowQuickActions(false);
+                  }}
+                  className="rounded-lg border border-white/10 px-3 py-3 text-center hover:bg-white/10"
+                >
+                  <div className="text-base">{item.icon}</div>
+                  <div className="mt-1">{item.label}</div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/ScanEAN.tsx
+++ b/src/pages/ScanEAN.tsx
@@ -24,6 +24,9 @@ export default function ScanEAN() {
   
   const [manualEAN, setManualEAN] = useState('')
   const [manualError, setManualError] = useState<string | null>(null)
+  const [isPastingEAN, setIsPastingEAN] = useState(false)
+  const [offlineQueue, setOfflineQueue] = useState<Array<{ ean: string; queuedAt: string }>>([])
+  const [offlineQueueMessage, setOfflineQueueMessage] = useState<string | null>(null)
   const [showHistory, setShowHistory] = useState(false)
   const [imageUploadStatus, setImageUploadStatus] = useState<string | null>(null)
   const [isProcessingImage, setIsProcessingImage] = useState(false)
@@ -82,9 +85,23 @@ export default function ScanEAN() {
     }
   }, [resolver, addToHistory, isUnifiedFlow, isPhotoMode, scanFlow])
 
+  useEffect(() => {
+    try {
+      const storedQueue = JSON.parse(localStorage.getItem('offlineEANQueue') || '[]')
+      setOfflineQueue(Array.isArray(storedQueue) ? storedQueue : [])
+    } catch (error) {
+      console.error('Failed to read offline EAN queue:', error)
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('offlineEANQueue', JSON.stringify(offlineQueue))
+  }, [offlineQueue])
+
   // Handle manual EAN search
   const handleManualSearch = async () => {
     setManualError(null)
+    setOfflineQueueMessage(null)
 
     if (!manualEAN.trim()) {
       setManualError('Veuillez saisir un code EAN')
@@ -97,8 +114,58 @@ export default function ScanEAN() {
       return
     }
 
+    if (!navigator.onLine) {
+      const queuedItem = { ean: manualEAN.trim(), queuedAt: new Date().toISOString() }
+      setOfflineQueue((prev) => [...prev, queuedItem])
+      setOfflineQueueMessage('📥 Vous êtes hors ligne. Recherche ajoutée à la file d’attente.')
+      return
+    }
+
     await handleEAN(manualEAN.trim())
   }
+
+  const handleProcessOfflineQueue = async () => {
+    if (!navigator.onLine || offlineQueue.length === 0) return
+    setOfflineQueueMessage('🔄 Traitement des recherches en attente...')
+    for (const item of offlineQueue) {
+      await handleEAN(item.ean)
+    }
+    setOfflineQueue([])
+    setOfflineQueueMessage('✅ Recherches en attente traitées.')
+    setTimeout(() => setOfflineQueueMessage(null), 3000)
+  }
+
+  const handlePasteFromClipboard = async () => {
+    setManualError(null)
+    setIsPastingEAN(true)
+
+    try {
+      const clipboardText = await navigator.clipboard.readText()
+      const digits = clipboardText.replace(/\D/g, '').slice(0, 13)
+
+      if (!digits) {
+        setManualError('Aucun code EAN trouvé dans le presse-papiers')
+        return
+      }
+
+      setManualEAN(digits)
+    } catch (error) {
+      console.error('Clipboard read error:', error)
+      setManualError('Accès au presse-papiers refusé ou indisponible')
+    } finally {
+      setIsPastingEAN(false)
+    }
+  }
+
+  const manualEANLength = manualEAN.trim().length
+  const isManualEANLengthValid = manualEANLength === 8 || manualEANLength === 13
+  const isManualEANValid = isManualEANLengthValid && validateEAN(manualEAN.trim())
+  const canSubmitManual = manualEAN.trim().length > 0 && isManualEANValid && !resolver.loading
+  const recentHistory = history.slice(0, 2)
+  const lastHistoryEntry = history[0]
+  const matchedCatalogProduct = manualEAN.trim()
+    ? productCatalog.find((product) => product.ean === manualEAN.trim())
+    : null
 
   // Handle camera detection
   const handleCameraDetection = async (ean: string) => {
@@ -278,6 +345,14 @@ export default function ScanEAN() {
             onStartScan={scanner.startScanning}
             onStopScan={scanner.stopScanning}
           />
+          <div className="mt-4 rounded-lg border border-white/10 bg-white/[0.03] p-3 text-xs text-white/70">
+            <div className="font-semibold text-white/80">Mode scan assisté</div>
+            <ol className="mt-2 list-decimal space-y-1 pl-4">
+              <li>Placez le code-barres dans le cadre et stabilisez.</li>
+              <li>Évitez les reflets, approchez progressivement.</li>
+              <li>Si l’auto-scan échoue, passez en saisie manuelle.</li>
+            </ol>
+          </div>
         </GlassCard>
 
         {/* Import image */}
@@ -337,6 +412,11 @@ export default function ScanEAN() {
                   setManualEAN(e.target.value.replace(/\D/g, ''))
                   setManualError(null)
                 }}
+                onBlur={() => {
+                  if (manualEAN.trim() && !isManualEANValid) {
+                    setManualError('Code EAN invalide (vérifiez la longueur et le checksum)')
+                  }
+                }}
                 onKeyPress={(e) => {
                   if (e.key === 'Enter') {
                     handleManualSearch()
@@ -347,6 +427,28 @@ export default function ScanEAN() {
                 aria-label="Saisir le code EAN manuellement"
                 aria-describedby={manualError ? 'manual-error' : undefined}
               />
+              <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-white/60">
+                <span className="rounded-full border border-white/20 px-2 py-1">
+                  {manualEANLength}/13 chiffres
+                </span>
+                {manualEANLength > 0 && (
+                  <span
+                    className={`rounded-full px-2 py-1 ${
+                      isManualEANValid
+                        ? 'bg-green-500/20 text-green-300 border border-green-500/40'
+                        : isManualEANLengthValid
+                        ? 'bg-yellow-500/20 text-yellow-300 border border-yellow-500/40'
+                        : 'bg-white/10 text-white/60 border border-white/20'
+                    }`}
+                  >
+                    {isManualEANValid
+                      ? 'EAN valide'
+                      : isManualEANLengthValid
+                      ? 'Vérifiez le checksum'
+                      : 'Saisissez 8 ou 13 chiffres'}
+                  </span>
+                )}
+              </div>
               {manualError && (
                 <p id="manual-error" className="mt-2 text-sm text-red-400">
                   {manualError}
@@ -354,14 +456,113 @@ export default function ScanEAN() {
               )}
             </div>
 
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={handlePasteFromClipboard}
+                disabled={isPastingEAN}
+                className="w-full px-4 py-2 text-sm bg-white/[0.08] hover:bg-white/[0.12] disabled:bg-white/[0.06] disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+                aria-label="Coller le code EAN depuis le presse-papiers"
+              >
+                {isPastingEAN ? '📋 Lecture...' : '📋 Coller depuis le presse-papiers'}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setManualEAN('')
+                  setManualError(null)
+                }}
+                disabled={!manualEAN}
+                className="w-full px-4 py-2 text-sm bg-white/[0.08] hover:bg-white/[0.12] disabled:bg-white/[0.06] disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+                aria-label="Effacer la saisie manuelle"
+              >
+                ✨ Effacer la saisie
+              </button>
+            </div>
+            {lastHistoryEntry && (
+              <button
+                type="button"
+                onClick={() => {
+                  setManualEAN(lastHistoryEntry.ean)
+                  setManualError(null)
+                }}
+                className="w-full px-4 py-2 text-xs bg-white/[0.08] hover:bg-white/[0.12] text-white/90 rounded-lg transition-colors"
+                aria-label="Pré-remplir avec le dernier EAN scanné"
+              >
+                🕘 Pré-remplir avec le dernier EAN ({lastHistoryEntry.ean})
+              </button>
+            )}
+            {recentHistory.length > 0 && (
+              <div className="rounded-lg border border-white/10 bg-white/[0.03] p-3">
+                <div className="text-xs font-semibold text-white/70">Derniers scans</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {recentHistory.map((entry) => (
+                    <button
+                      key={entry.ean}
+                      type="button"
+                      onClick={() => {
+                        setManualEAN(entry.ean)
+                        setManualError(null)
+                      }}
+                      className="rounded-full border border-white/15 px-3 py-1 text-xs text-white/80 hover:border-white/30 hover:bg-white/10 transition-colors"
+                      aria-label={`Réutiliser le code ${entry.ean}`}
+                    >
+                      {entry.productName ? `${entry.productName} • ${entry.ean}` : entry.ean}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+            {manualEAN.trim() && (
+              <div className="rounded-lg border border-white/10 bg-white/[0.03] p-3 text-xs text-white/70">
+                {matchedCatalogProduct ? (
+                  <div>
+                    ✅ Produit reconnu : <span className="text-white">{matchedCatalogProduct.label}</span>
+                  </div>
+                ) : (
+                  <div>🔎 Aucun produit connu trouvé pour cet EAN (vous pouvez tenter la recherche).</div>
+                )}
+              </div>
+            )}
+            {offlineQueue.length > 0 && (
+              <div className="rounded-lg border border-white/10 bg-white/[0.03] p-3 text-xs text-white/70">
+                <div>📦 {offlineQueue.length} recherche(s) en attente hors ligne.</div>
+                {navigator.onLine && (
+                  <button
+                    type="button"
+                    onClick={handleProcessOfflineQueue}
+                    className="mt-2 rounded-full border border-white/10 px-3 py-1 text-xs text-white/80 hover:bg-white/10"
+                  >
+                    Lancer les recherches en attente
+                  </button>
+                )}
+              </div>
+            )}
+            {offlineQueueMessage && (
+              <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs text-emerald-200">
+                {offlineQueueMessage}
+              </div>
+            )}
+
             <button
               onClick={handleManualSearch}
-              disabled={resolver.loading}
+              disabled={!canSubmitManual}
               className="w-full px-4 py-3 bg-blue-600 hover:bg-blue-500 disabled:bg-blue-600/50 disabled:cursor-not-allowed text-white rounded-lg font-medium transition-colors"
               aria-label="Rechercher le produit"
             >
               {resolver.loading ? '🔍 Recherche...' : '🔍 Rechercher'}
             </button>
+            <div className="text-xs text-white/60">
+              💡 Astuce : vous pouvez coller un code EAN depuis votre presse-papiers pour gagner du temps.
+            </div>
+            <div className="text-xs text-white/50">
+              Le bouton de recherche s'active dès que le code est valide.
+            </div>
+            {isManualEANValid && !resolver.loading && (
+              <div className="text-xs text-green-300">
+                ✅ EAN valide, prêt à lancer la recherche.
+              </div>
+            )}
           </div>
         </GlassCard>
       </div>


### PR DESCRIPTION
### Motivation
- Améliorer l’ergonomie mobile et la résilience du parcours de scan en apportant des raccourcis, un feedback haptique et une prise en charge hors‑ligne pour les recherches EAN.
- Rendre la page et le layout plus utiles en contexte via des indices modulaires et une typographie adaptative pour une meilleure lisibilité sur petits écrans.

### Description
- Ajout d’un panneau « Actions rapides » mobile (bottom sheet) et d’un bouton dédié dans le footer mobile, avec feedback haptique via `triggerHaptic`, accessible depuis `frontend/src/components/Layout.jsx` et `src/components/Layout.jsx`.
- Ajout d’indices contextuels (`moduleHint`), d’un mode focus, d’une recherche rapide (palette) enrichie et d’une typographie adaptative (`fontSize: clamp(...)`) dans le layout pour améliorer l’UX générale.
- Renforcement de la page de scan `ScanEAN` (`frontend/src/pages/ScanEAN.tsx` et `src/pages/ScanEAN.tsx`) avec file d’attente hors‑ligne (`offlineQueue`), messages de statut (`offlineQueueMessage`), traitement manuel différé quand l’app est hors‑ligne, bouton de relance des recherches en attente et affichage d’indicateurs de validité EAN et d’aide (coller depuis le presse‑papiers, historique récent, préremplissage).
- Harmonisation des mêmes améliorations entre les variantes `frontend/src` et `src/` pour garder la parité des builds et UX.

### Testing
- Démarrage du serveur de dev avec `cd frontend && npm run dev -- --host 0.0.0.0` : Vite a démarré et a indiqué « ready », avec un avertissement non bloquant `Error: spawn xdg-open ENOENT` (serveur fonctionnel). — succès.
- Exécution d’un script Playwright pour ouvrir la page et ouvrir la feuille « Actions rapides » : un essai initial a expiré mais un second run a réussi et a produit la capture `artifacts/layout-quick-actions-sheet.png` — screenshot généré avec succès.
- Aucun test unitaire automatisé supplémentaire n’a été modifié ou exécuté dans cette PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69896d3010548321a08816ac65ded3e0)

## Summary by Sourcery

Introduce mobile-friendly quick actions and contextual guidance in the main layout, and enhance the ScanEAN page with offline-safe manual EAN search and assistive hints.

New Features:
- Add a mobile bottom action bar and quick actions sheet with haptic feedback for primary navigation routes.
- Add a command palette with keyboard shortcuts, pinned pages, next-step suggestions, and contextual hints in the layout to speed up navigation.
- Persist last visited route, focus mode, and pinned routes in local storage to personalize the browsing experience.
- Extend the ScanEAN page with an offline queue for manual EAN searches, including status messaging and a retry action when connectivity is restored.
- Add clipboard-based EAN paste, recent-history shortcuts, catalog matching, and inline validation hints to assist manual EAN entry.

Enhancements:
- Apply adaptive typography and an optional focus mode to improve readability on smaller screens.
- Display an onboarding-style coach panel and quick-access chips to guide new users through core flows.
- Mirror all layout and ScanEAN improvements across both frontend and src builds to maintain UX parity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search palette with keyboard shortcuts (Ctrl/Cmd+K or /) for quick navigation
  * Focus mode to minimize distractions
  * Scroll-to-top button with haptic feedback
  * Quick actions panel for rapid access to core features
  * Mobile bottom action bar for improved navigation
  * Offline queue for EAN searches when disconnected
  * Clipboard paste support for EAN entry with validation
  * Assisted scanning mode with step-by-step guidance
  * Recent scans history with quick-reuse buttons
  * Real-time EAN validation with checksum feedback
  * Coach introduction panel with smart dismissal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->