### PR TITLE
Improve camera access fallback for barcode scanner

### DIFF
--- a/src/components/BarcodeScanner.tsx
+++ b/src/components/BarcodeScanner.tsx
@@ -120,15 +120,40 @@ export default function BarcodeScanner({ onScan, onClose, options = {} }: Barcod
         if (enableDebugLogging) {
           console.log('[SCAN] 📷 Requesting camera access...');
         }
-        
-        // Request camera permission with proper constraints
-        const stream = await navigator.mediaDevices.getUserMedia({
-          video: { 
-            facingMode: { ideal: 'environment' },
-            width: { ideal: 1280 },
-            height: { ideal: 720 }
-          },
-        });
+
+        const requestCameraStream = async () => {
+          const constraintSets: MediaStreamConstraints[] = [
+            {
+              video: {
+                facingMode: { ideal: 'environment' },
+                width: { ideal: 1280 },
+                height: { ideal: 720 },
+              },
+            },
+            { video: { facingMode: { ideal: 'environment' } } },
+            { video: true },
+          ];
+
+          let lastError: unknown = null;
+
+          for (const constraints of constraintSets) {
+            try {
+              if (enableDebugLogging) {
+                console.log('[SCAN] 📷 Trying constraints:', constraints);
+              }
+              return await navigator.mediaDevices.getUserMedia(constraints);
+            } catch (constraintError) {
+              lastError = constraintError;
+              if (enableDebugLogging) {
+                console.log('[SCAN] ⚠️ Constraint failed, trying fallback:', constraintError);
+              }
+            }
+          }
+
+          throw lastError ?? new Error('Aucune contrainte caméra compatible');
+        };
+
+        const stream = await requestCameraStream();
         
         if (enableDebugLogging) {
           console.log('[SCAN] ✅ Camera access granted');
@@ -138,6 +163,8 @@ export default function BarcodeScanner({ onScan, onClose, options = {} }: Barcod
         
         if (videoRef.current) {
           videoRef.current.srcObject = stream;
+          videoRef.current.setAttribute('playsinline', 'true');
+          videoRef.current.muted = true;
           
           // Wait for video to be ready
           await new Promise<void>((resolve, reject) => {
@@ -165,16 +192,20 @@ export default function BarcodeScanner({ onScan, onClose, options = {} }: Barcod
 
         // Check if torch is supported
         const track = stream.getVideoTracks()[0];
-        const capabilities = track.getCapabilities() as any;
-        if (enableDebugLogging) {
-          console.log('[SCAN] 📱 Camera capabilities:', capabilities);
-        }
-        
-        if ('torch' in capabilities) {
-          setTorchSupported(true);
+        if (track) {
+          const capabilities = track.getCapabilities() as any;
           if (enableDebugLogging) {
-            console.log('[SCAN] 🔦 Torch supported');
+            console.log('[SCAN] 📱 Camera capabilities:', capabilities);
           }
+
+          if ('torch' in capabilities) {
+            setTorchSupported(true);
+            if (enableDebugLogging) {
+              console.log('[SCAN] 🔦 Torch supported');
+            }
+          }
+        } else if (enableDebugLogging) {
+          console.log('[SCAN] ⚠️ No video track available to check torch support');
         }
 
         // Start decoding with timeout


### PR DESCRIPTION
### Motivation
- Improve reliability of camera-based barcode scanning across devices and browsers by making camera requests more tolerant and avoiding runtime errors when capabilities are missing.

### Description
- Add a progressive fallback that attempts multiple `getUserMedia` constraint sets (preferred 1280x720 with `facingMode`, then simplified constraints, then `video: true`) to increase success rate on mobile and older browsers.
- Ensure video elements are configured for inline playback by setting the `playsinline` attribute and muting the element to avoid autoplay/inline restrictions on mobile browsers.
- Guard torch capability checks by verifying a video track exists before calling `getCapabilities()` and add debug logging when no track is available.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69897988613083218980cee91cbc293d)

## Summary by Sourcery

Improve robustness of camera access and capability handling in the barcode scanner component.

New Features:
- Introduce a progressive fallback strategy for getUserMedia constraints to increase camera access success across devices and browsers.

Bug Fixes:
- Prevent runtime errors when checking torch capabilities by validating the presence of a video track before accessing its capabilities.
- Ensure inline video playback and avoid mobile autoplay restrictions by setting playsinline and muting the scanner video element.

Enhancements:
- Add debug logging around camera constraint attempts and missing video track scenarios to aid troubleshooting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera access reliability across browsers with enhanced fallback mechanisms.
  * Enhanced flashlight/torch capability detection and support.
  * Better error handling for camera permission requests.
  * Improved video playback stability and readiness handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->