### PR TITLE
Fix runtime crash (reading 'add') via sourcemaps + init guard

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "lint": "eslint src --ext .ts,.tsx,.js,.jsx",
     "lint:fix": "eslint src --ext .ts,.tsx,.js,.jsx --fix",
-    "test": "echo '⚠️ Tests unitaires non configurés pour le moment' && exit 0"
+    "test": "echo '⚠️ Tests unitaires non configurés pour le moment' && exit 0",
+    "smoke:preview": "npm run build && node scripts/smoke-preview.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/frontend/scripts/smoke-preview.mjs
+++ b/frontend/scripts/smoke-preview.mjs
@@ -1,0 +1,96 @@
+import { spawn } from 'node:child_process';
+
+const PREVIEW_URL = 'http://127.0.0.1:4173/';
+const READY_TOKEN = 'Local:';
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitForPreviewReady(proc, timeoutMs = 20000) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Vite preview did not become ready within ${timeoutMs}ms.`));
+    }, timeoutMs);
+
+    const onData = (chunk) => {
+      const text = chunk.toString();
+      if (text.includes(READY_TOKEN)) {
+        cleanup();
+        resolve();
+      }
+    };
+
+    const onExit = (code) => {
+      cleanup();
+      reject(new Error(`Vite preview exited before readiness (code=${code ?? 'null'}).`));
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      proc.stdout?.off('data', onData);
+      proc.stderr?.off('data', onData);
+      proc.off('exit', onExit);
+    };
+
+    proc.stdout?.on('data', onData);
+    proc.stderr?.on('data', onData);
+    proc.on('exit', onExit);
+  });
+}
+
+async function runSmoke() {
+  const preview = spawn(
+    process.platform === 'win32' ? 'npm.cmd' : 'npm',
+    ['run', 'preview', '--', '--host', '127.0.0.1', '--port', '4173', '--strictPort'],
+    { stdio: ['ignore', 'pipe', 'pipe'], env: process.env, detached: process.platform !== 'win32' }
+  );
+
+  preview.stdout.on('data', (chunk) => process.stdout.write(chunk));
+  preview.stderr.on('data', (chunk) => process.stderr.write(chunk));
+
+  try {
+    await waitForPreviewReady(preview);
+
+    const homeResponse = await fetch(PREVIEW_URL);
+    if (!homeResponse.ok) {
+      throw new Error(`Home route request failed with HTTP ${homeResponse.status}.`);
+    }
+
+    const html = await homeResponse.text();
+    if (!html.includes('id="root"')) {
+      throw new Error('Smoke check failed: #root container missing from preview HTML response.');
+    }
+
+    const bundleMatch = html.match(/<script[^>]+src="([^"]*assets\/index-[^"]+\.js)"/i);
+    if (!bundleMatch?.[1]) {
+      throw new Error('Smoke check failed: unable to identify main index bundle in HTML.');
+    }
+
+    const bundleUrl = new URL(bundleMatch[1], PREVIEW_URL).toString();
+    const bundleResponse = await fetch(bundleUrl);
+    if (!bundleResponse.ok) {
+      throw new Error(`Main bundle request failed with HTTP ${bundleResponse.status} for ${bundleUrl}.`);
+    }
+
+    console.log(`[smoke-preview] OK: #root found and bundle is reachable (${bundleUrl}).`);
+  } finally {
+    if (process.platform !== 'win32') {
+      process.kill(-preview.pid, 'SIGTERM');
+    } else {
+      preview.kill('SIGTERM');
+    }
+    await wait(500);
+    if (!preview.killed) {
+      if (process.platform !== 'win32') {
+        process.kill(-preview.pid, 'SIGKILL');
+      } else {
+        preview.kill('SIGKILL');
+      }
+    }
+  }
+}
+
+runSmoke().catch((error) => {
+  console.error('[smoke-preview] FAILED:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/frontend/src/services/boatComparisonService.ts
+++ b/frontend/src/services/boatComparisonService.ts
@@ -24,6 +24,7 @@ import type {
   RegularPassengerAnalysis,
   TerritoryBoatStatistics,
 } from '../types/boatComparison';
+import { logRuntimeIssueOnce } from '../utils/runtimeDiagnostics';
 
 /**
  * Configuration constants
@@ -323,17 +324,40 @@ export function analyzeRegularPassengers(
  */
 export function generateBoatMetadata(prices: BoatPricePoint[]): BoatComparisonMetadata {
   const operators = new Set(prices.map((p) => p.operator));
-  const sources = prices.reduce((acc, price) => {
-    const sourceType = price.source.type;
-    if (!acc[sourceType]) {
-      acc[sourceType] = { count: 0, operators: new Set<string>() };
-    }
-    acc[sourceType].count++;
-    acc[sourceType].operators.add(price.operator);
-    return acc;
-  }, {} as Record<string, { count: number; operators: Set<string> }>);
+  const sources = new Map<string, { count: number; operators: Set<string> }>();
+  prices.forEach((price) => {
+    const sourceType =
+      typeof price?.source?.type === 'string' && price.source.type.trim().length > 0
+        ? price.source.type
+        : 'unknown';
 
-  const sourceSummaries: BoatSourceSummary[] = Object.entries(sources).map(([source, data]) => ({
+    if (sourceType === 'unknown') {
+      logRuntimeIssueOnce(
+        'boat-metadata-invalid-source',
+        'Unexpected boat source type while generating metadata. Falling back to "unknown" source bucket.',
+        { price }
+      );
+    }
+
+    if (!sources.has(sourceType)) {
+      sources.set(sourceType, { count: 0, operators: new Set<string>() });
+    }
+
+    const sourceBucket = sources.get(sourceType);
+    if (!sourceBucket) {
+      logRuntimeIssueOnce(
+        'boat-metadata-source-bucket-missing',
+        'Unable to access boat source bucket after initialization. Metadata aggregation skipped for this item.',
+        { sourceType, price }
+      );
+      return;
+    }
+
+    sourceBucket.count++;
+    sourceBucket.operators.add(price.operator);
+  });
+
+  const sourceSummaries: BoatSourceSummary[] = Array.from(sources.entries()).map(([source, data]) => ({
     source: source as any,
     observationCount: data.count,
     operatorCount: data.operators.size,

--- a/frontend/src/services/flightComparisonService.ts
+++ b/frontend/src/services/flightComparisonService.ts
@@ -24,6 +24,7 @@ import type {
   SeasonalPriceAnalysis,
   TerritoryFlightStatistics,
 } from '../types/flightComparison';
+import { logRuntimeIssueOnce } from '../utils/runtimeDiagnostics';
 
 /**
  * Configuration constants
@@ -359,17 +360,40 @@ export function analyzeSeasonalPrices(
  */
 export function generateFlightMetadata(prices: FlightPricePoint[]): FlightComparisonMetadata {
   const airlines = new Set(prices.map((p) => p.airline));
-  const sources = prices.reduce((acc, price) => {
-    const sourceType = price.source.type;
-    if (!acc[sourceType]) {
-      acc[sourceType] = { count: 0, airlines: new Set<string>() };
-    }
-    acc[sourceType].count++;
-    acc[sourceType].airlines.add(price.airline);
-    return acc;
-  }, {} as Record<string, { count: number; airlines: Set<string> }>);
+  const sources = new Map<string, { count: number; airlines: Set<string> }>();
+  prices.forEach((price) => {
+    const sourceType =
+      typeof price?.source?.type === 'string' && price.source.type.trim().length > 0
+        ? price.source.type
+        : 'unknown';
 
-  const sourceSummaries: FlightSourceSummary[] = Object.entries(sources).map(([source, data]) => ({
+    if (sourceType === 'unknown') {
+      logRuntimeIssueOnce(
+        'flight-metadata-invalid-source',
+        'Unexpected flight source type while generating metadata. Falling back to "unknown" source bucket.',
+        { price }
+      );
+    }
+
+    if (!sources.has(sourceType)) {
+      sources.set(sourceType, { count: 0, airlines: new Set<string>() });
+    }
+
+    const sourceBucket = sources.get(sourceType);
+    if (!sourceBucket) {
+      logRuntimeIssueOnce(
+        'flight-metadata-source-bucket-missing',
+        'Unable to access flight source bucket after initialization. Metadata aggregation skipped for this item.',
+        { sourceType, price }
+      );
+      return;
+    }
+
+    sourceBucket.count++;
+    sourceBucket.airlines.add(price.airline);
+  });
+
+  const sourceSummaries: FlightSourceSummary[] = Array.from(sources.entries()).map(([source, data]) => ({
     source: source as any,
     observationCount: data.count,
     airlineCount: data.airlines.size,

--- a/frontend/src/utils/runtimeDiagnostics.ts
+++ b/frontend/src/utils/runtimeDiagnostics.ts
@@ -1,0 +1,13 @@
+const emittedDiagnostics = new Set<string>();
+
+/**
+ * Emit a runtime diagnostic once per unique key to avoid console spam.
+ */
+export function logRuntimeIssueOnce(key: string, message: string, details?: unknown): void {
+  if (emittedDiagnostics.has(key)) {
+    return;
+  }
+
+  emittedDiagnostics.add(key);
+  console.error(`[RuntimeDiagnostic:${key}] ${message}`, details);
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -48,7 +48,7 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
-    sourcemap: false,
+    sourcemap: true,
     minify: 'terser',
     terserOptions: {
       compress: {


### PR DESCRIPTION
### Motivation
- Corriger le crash production « Cannot read properties of undefined (reading 'add') » en identifiant précisément la ligne source via sourcemaps et en appliquant une correction robuste au point d'agrégation fautif plutôt que de masquer l'erreur.
- Prévenir la régression en ajoutant une télémétrie minimale et non spammy pour repérer rapidement le module responsable si le problème survient de nouveau.
- Maintenir la compatibilité Cloudflare Pages et conserver l'architecture/style existants.

### Description
- Activation des sourcemaps de build Vite (`build.sourcemap = true` dans `frontend/vite.config.ts`) pour permettre le mappage des stacks minifiées vers les fichiers `src`.
- Ajout d'un utilitaire `logRuntimeIssueOnce` (`frontend/src/utils/runtimeDiagnostics.ts`) qui émet un `console.error` unique par clé pour éviter le spam lors d'incidents récurrents.
- Durcissement de l'agrégation des sources dans `generateFlightMetadata` et `generateBoatMetadata` (`frontend/src/services/flightComparisonService.ts` et `frontend/src/services/boatComparisonService.ts`) en remplaçant l'indexation d'objet fragile par des `Map`, en normalisant les clés `source.type` (fallback `"unknown"`) et en vérifiant l'existence du bucket avant d'appeler `.add(...)`, avec log one-shot en cas de données malformées.
- Ajout d'un script de contrôle léger `scripts/smoke-preview.mjs` et d'un script npm `smoke:preview` qui builde, lance `vite preview`, vérifie que la page racine contient `#root` et que le bundle principal `assets/index-*.js` est servi en 200.

### Testing
- Exécuté `npm ci` puis `npm run build` dans `frontend` (succès) et vérifié que le bundle principal `assets/index-DUQNAcmo.js` est bien généré (succès).
- Lancement de `npm run preview -- --host 0.0.0.0 --port 4173` et navigation automatisée par Playwright sur `/`, `/login`, `/home`, `/comparateur`, `/observatoire` sans `pageerror` ni `console error` (succès).
- Exécution du smoke check via `npm run smoke:preview` qui build + preview + vérifie `#root` et le statut 200 du bundle (succès).
- Lint (`npm run lint`) a été exécuté et a échoué en raison de nombreuses erreurs/warnings préexistantes hors périmètre de ce correctif (échec attendu et non bloquant pour ce fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c8957bf5c832188c97352a0c9919b)

## Summary by Sourcery

Harden runtime metadata aggregation for flight and boat comparisons and add minimal diagnostics and smoke testing to prevent and detect crashes in production.

Bug Fixes:
- Prevent runtime crashes in flight metadata generation when source information is missing or malformed.
- Prevent runtime crashes in boat metadata generation when source information is missing or malformed.

Enhancements:
- Normalize and safely bucket unknown or invalid source types when aggregating flight metadata while logging one-shot diagnostics.
- Normalize and safely bucket unknown or invalid source types when aggregating boat metadata while logging one-shot diagnostics.
- Add a utility for single-emission runtime diagnostics to avoid console log spam.
- Enable Vite build sourcemaps to facilitate debugging of minified production errors.

Build:
- Enable sourcemap generation in the Vite build configuration.
- Add a smoke:preview npm script to build the app and run a basic preview health check.

Tests:
- Add a smoke-preview script that spins up Vite preview, verifies the root container is present, and checks that the main bundle is served with a successful HTTP response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated preview server validation testing to the build pipeline.
  * Introduced runtime diagnostics for enhanced error tracking and troubleshooting.

* **Bug Fixes**
  * Enhanced error handling in comparison services with graceful fallbacks for invalid data sources.
  * Enabled source maps for improved debugging support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->