### PR TITLE
Fix startup duplicate declarations and prevent map `.add` runtime crash

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -18,11 +18,6 @@ const consoleInfo = globalThis?.console?.info?.bind(globalThis.console);
 consoleInfo?.(`[build] A KI PRI SA YÉ boot sha=${BUILD_SHA}`);
 installRuntimeCrashProbe();
 
-const BUILD_SHA = import.meta.env.VITE_BUILD_SHA || 'unknown';
-window.__BUILD_SHA__ = BUILD_SHA;
-const consoleInfo = globalThis?.console?.info?.bind(globalThis.console);
-consoleInfo?.(`[build] A KI PRI SA YÉ boot sha=${BUILD_SHA}`);
-
 // Fix Leaflet marker icons for Vite/Cloudflare build
 // Point to our bundled markers in /public/leaflet/
 delete L.Icon.Default.prototype._getIconUrl;

--- a/frontend/src/pages/Carte.jsx
+++ b/frontend/src/pages/Carte.jsx
@@ -33,33 +33,41 @@ function MapUpdater({ map, position }) {
 
 function MarkerClusterGroup({ map, leaflet, stores, currentTerritory, formatDistance, markerRefs, territory }) {
   useEffect(() => {
-    if (!map || !leaflet) return;
+    if (!map || !leaflet || typeof map.addLayer !== 'function') return;
 
-    const markerClusterGroup = leaflet.markerClusterGroup({
-      chunkedLoading: true,
-      spiderfyOnMaxZoom: true,
-      showCoverageOnHover: true,
-      zoomToBoundsOnClick: true,
-      maxClusterRadius: 60,
-      disableClusteringAtZoom: 15,
-      iconCreateFunction: function(cluster) {
-        const count = cluster.getChildCount();
-        let className = 'marker-cluster-';
-        if (count < 10) {
-          className += 'small';
-        } else if (count < 20) {
-          className += 'medium';
-        } else {
-          className += 'large';
-        }
+    const canUseMarkerCluster = typeof leaflet.markerClusterGroup === 'function';
+    const markerLayerGroup = canUseMarkerCluster
+      ? leaflet.markerClusterGroup({
+        chunkedLoading: true,
+        spiderfyOnMaxZoom: true,
+        showCoverageOnHover: true,
+        zoomToBoundsOnClick: true,
+        maxClusterRadius: 60,
+        disableClusteringAtZoom: 15,
+        iconCreateFunction: function(cluster) {
+          const count = cluster.getChildCount();
+          let className = 'marker-cluster-';
+          if (count < 10) {
+            className += 'small';
+          } else if (count < 20) {
+            className += 'medium';
+          } else {
+            className += 'large';
+          }
 
-        return leaflet.divIcon({
-          html: `<div><span>${count}</span></div>`,
-          className: `marker-cluster ${className}`,
-          iconSize: leaflet.point(40, 40),
-        });
-      },
-    });
+          return leaflet.divIcon({
+            html: `<div><span>${count}</span></div>`,
+            className: `marker-cluster ${className}`,
+            iconSize: leaflet.point(40, 40),
+          });
+        },
+      })
+      : leaflet.layerGroup();
+
+    if (!markerLayerGroup || typeof markerLayerGroup.addLayer !== 'function') {
+      console.warn('[Carte] Unable to initialize marker layer group; skipping map markers');
+      return;
+    }
 
     stores.forEach((store) => {
       // Get store hours and status
@@ -198,13 +206,15 @@ function MarkerClusterGroup({ map, leaflet, stores, currentTerritory, formatDist
         className: 'custom-popup',
       });
 
-      markerClusterGroup.addLayer(leafletMarker);
+      markerLayerGroup.addLayer(leafletMarker);
     });
 
-    map.addLayer(markerClusterGroup);
+    map.addLayer(markerLayerGroup);
 
     return () => {
-      map.removeLayer(markerClusterGroup);
+      if (typeof map.removeLayer === 'function') {
+        map.removeLayer(markerLayerGroup);
+      }
     };
   }, [map, leaflet, stores, currentTerritory, formatDistance, markerRefs, territory]);
 


### PR DESCRIPTION
### Motivation
- Build failed due to duplicate declarations of `BUILD_SHA` and `consoleInfo` in `frontend/src/main.jsx`, causing redeclaration errors during the Vite build step.
- The map page could crash at runtime when calling `.add`/`.addLayer` if the Leaflet map or the marker-cluster plugin was not ready, so the marker initialization needed to be hardened.

### Description
- Removed the duplicated `BUILD_SHA` / `consoleInfo` block in `frontend/src/main.jsx` so those constants are declared only once during app boot.
- In `frontend/src/pages/Carte.jsx` added guards to return early if `map` or `map.addLayer` are not available, and detect whether `leaflet.markerClusterGroup` exists before using it.
- Implemented a safe fallback to `leaflet.layerGroup()` when the marker-cluster plugin is unavailable and check that the created layer supports `addLayer` before adding markers.
- Guarded the cleanup logic to call `map.removeLayer` only when that function exists and added a `console.warn` when the marker layer cannot be initialized.

### Testing
- Ran `cd frontend && npm run build`, which now completes successfully (previous redeclaration error resolved).
- Ran `cd frontend && node scripts/smoke-preview.mjs`, which runs the preview and reports runtime checks OK (Playwright skipped when unavailable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ca6a206c083218fc283ccf57829ce)

## Summary by Sourcery

Resolve frontend build-time redeclaration errors and harden map marker initialization to avoid runtime crashes when Leaflet or its clustering plugin are not fully available.

Bug Fixes:
- Remove duplicate BUILD_SHA and consoleInfo declarations in the frontend entrypoint to fix Vite build failures.
- Add defensive checks around Leaflet map and marker cluster initialization to prevent `.addLayer`/`.add` runtime crashes when the map or clustering plugin is unavailable.

Enhancements:
- Fallback to a standard Leaflet layer group when the marker-cluster plugin is missing, with guarded cleanup and a warning when marker layers cannot be initialized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up duplicate initialization declarations in the main application entry point.

* **Bug Fixes**
  * Enhanced map stability with defensive checks for leaflet availability and marker clustering support, including graceful fallback to standard layer grouping when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->