### PR TITLE
fix(ci): make ci-strict.yml 100% YAML-safe and structurally robust

### DIFF
--- a/.github/workflows/ci-strict.yml
+++ b/.github/workflows/ci-strict.yml
@@ -171,27 +171,27 @@ jobs:
             const reportUrl = '${{ steps.lhci-url.outputs.report_url }}';
 
             const body = `
-### 🧪 CI Strict – Quality Report (non bloquant)
+            ### 🧪 CI Strict – Quality Report (non bloquant)
 
-**Checks exécutés :**
-- TypeScript strict
-- ESLint (max-warnings=0)
-- Build
-- Tests
-- Audit sécurité (npm)
-- Accessibilité (WCAG 2.1 AA)
-- Lighthouse (Performance, A11y, Best Practices, SEO)
+            **Checks exécutés :**
+            - TypeScript strict
+            - ESLint (max-warnings=0)
+            - Build
+            - Tests
+            - Audit sécurité (npm)
+            - Accessibilité (WCAG 2.1 AA)
+            - Lighthouse (Performance, A11y, Best Practices, SEO)
 
-**Standards cibles (post-V1) :**
-- Performance ≥ 85
-- Accessibilité ≥ 95
-- Best Practices ≥ 95
-- SEO ≥ 90
+            **Standards cibles (post-V1) :**
+            - Performance ≥ 85
+            - Accessibilité ≥ 95
+            - Best Practices ≥ 95
+            - SEO ≥ 90
 
-${reportUrl !== 'Not available' ? `🔍 Voir le rapport Lighthouse : ${reportUrl}` : 'Rapport Lighthouse indisponible'}
+            ${reportUrl !== 'Not available' ? `🔍 Voir le rapport Lighthouse : ${reportUrl}` : 'Rapport Lighthouse indisponible'}
 
-ℹ️ *Quality gate non bloquant – hardening progressif.*
-`;
+            ℹ️ *Quality gate non bloquant – hardening progressif.*
+            `;
             await github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,


### PR DESCRIPTION
### Motivation
- The `actions/github-script` multi-line `script: |` block in `.github/workflows/ci-strict.yml` contained mis-indented content that caused YAML parsing errors and needed strict 2-space indentation to be GitHub Actions-safe.
- The change must preserve the full CI logic, quality gates, permissions and PR-only comment behavior while eliminating YAML fragility.

### Description
- Reindented the entire `script: |` block content for the `actions/github-script@v7` step so the embedded template string and Markdown are properly nested under the `|` indicator in `.github/workflows/ci-strict.yml`.
- Kept all steps and logic unchanged (checkout, setup node, install, typecheck, lint, build, tests, audits, lighthouse, artifact uploads, and the PR-only comment), and preserved explicit `permissions` and `if: github.event_name == 'pull_request'` checks.
- Committed the change with message `fix(ci): make ci-strict.yml 100% YAML-safe and structurally robust` and prepared a PR containing that change.

### Testing
- Ran the Ruby YAML parser with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci-strict.yml'); puts 'YAML OK'"` which returned `YAML OK` confirming valid YAML.
- Checked for tab characters with a small Python script (`python - <<'PY' ...`) which reported no tabs, confirming consistent 2-space indentation.
- Verified the file diff shows only the reindentation of the `script` block and no functional changes to CI steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dc7ff70d4832192a5de09b8a4e726)