### PR TITLE
hotfix: fix prod crash (undefined .add)

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import L from 'leaflet';
+import { HelmetProvider } from 'react-helmet-async';
 
 import './styles/glass.css';
 import './styles/mobile-fixes.css';
@@ -80,9 +81,11 @@ if (!rootElement) {
 
   ReactDOM.createRoot(rootElement).render(
     <React.StrictMode>
-      <ErrorBoundary>
-        <App />
-      </ErrorBoundary>
+      <HelmetProvider>
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
+      </HelmetProvider>
     </React.StrictMode>
   );
 


### PR DESCRIPTION
### Motivation
- Corriger le crash de production visible sur https://akiprisaye-web.pages.dev/ (`Cannot read properties of undefined (reading 'add')`) causé par l’absence d’initialisation du contexte utilisé par `react-helmet-async` lorsque des composants utilisent `<Helmet />`.

### Description
- Import de `HelmetProvider` depuis `react-helmet-async` et enrobage du rendu root dans `frontend/src/main.jsx` avec `<HelmetProvider>` (modification minimale et sans changement métier / UI / routes), `react-helmet-async` étant déjà présent dans `frontend/package.json`.

### Testing
- Vérifications locales exécutées dans `frontend/`: `npm ci` ✅, `npm run build` ✅, `npm run lint` ✅ (warnings historiques, 0 erreur), `npm run test:ci` ✅ (suite de tests projet: placeholder non bloquant); commit réalisé avec le message exact `hotfix: fix prod crash (undefined .add)` et PR créée avec le titre exact `hotfix: fix prod crash (undefined .add)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e181fec148321a65e170f853bbcdf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized core application component structure and hierarchy to improve stability and enhance support for document head management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->