### PR TITLE
feat: add clean live price provider (no tech debt)

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -10,6 +10,8 @@ Cette couche introduit une architecture provider minimale et sûre dans `fronten
   - Normalisation centralisée des `PriceObservation` (prix, unité, texte).
 - `frontend/src/providers/seedProvider.ts`
   - Fallback obligatoire vers `seedProducts` (EAN ou recherche nom), filtrage territoire.
+- `frontend/src/providers/openPricesProvider.ts`
+  - Provider live Open Prices (feature-flag, timeout, parsing défensif, fallback propre).
 - `frontend/src/providers/index.ts`
   - Orchestration des providers live/stub + fallback automatique seed si aucun prix live.
 
@@ -17,6 +19,7 @@ Cette couche introduit une architecture provider minimale et sûre dans `fronten
 
 - `VITE_PRICE_PROVIDER_OPEN_FOOD_FACTS` (défaut: `true`)
 - `VITE_PRICE_PROVIDER_OPEN_PRICES` (défaut: `false`)
+- `VITE_PRICE_PROVIDER_OPEN_PRICES_ENDPOINT` (défaut: vide => provider `UNAVAILABLE`)
 - `VITE_PRICE_PROVIDER_DATA_GOUV` (défaut: `false`)
 
 Valeurs truthy acceptées: `1`, `true`, `on`, `yes`.
@@ -30,13 +33,23 @@ Valeurs truthy acceptées: `1`, `true`, `on`, `yes`.
 ## État actuel
 
 - `open_food_facts`: enrichissement métadonnées produit (non bloquant).
-- `open_prices`: stub contrôlé par flag.
+- `open_prices`:
+  - mode live activable par flag,
+  - `timeout`/`abort` à 5s,
+  - parsing strict et défensif,
+  - si endpoint non configuré ou erreur HTTP/réseau/parsing: `UNAVAILABLE` + warning explicite.
 - `data_gouv`: stub contrôlé par flag.
 - `seedProducts`: fallback de sécurité (obligatoire).
 
+## Limites connues (open_prices live)
+
+- Aucun endpoint public stable n'est supposé par défaut.
+- Sans `VITE_PRICE_PROVIDER_OPEN_PRICES_ENDPOINT`, le provider reste volontairement `UNAVAILABLE`.
+- Le filtrage territoire est appliqué côté client; les observations hors territoire sont ignorées.
+
 ## Brancher une future API
 
-1. Ajouter un provider conforme à `PriceProvider` dans `frontend/src/providers/`.
-2. Normaliser les observations via `normalizePriceObservation`.
-3. L’enregistrer dans `index.ts` et le protéger par un feature flag `import.meta.env`.
+1. Conserver `openPricesProvider.ts` et brancher l’endpoint réel via `VITE_PRICE_PROVIDER_OPEN_PRICES_ENDPOINT`.
+2. Continuer à normaliser les observations via `normalizePriceObservation`.
+3. Conserver la gestion de timeout/abort et le parser défensif.
 4. Conserver le fallback seed en dernier filet de sécurité.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,58 @@
+# Local Telemetry (no backend)
+
+Cette télémétrie est **strictement locale** :
+- aucun envoi réseau,
+- aucune analytics tierce,
+- aucun backend,
+- export manuel uniquement.
+
+## Activation
+
+Par défaut, la télémétrie est **désactivée**.
+
+Activer via la variable d'environnement build/runtime frontend :
+- `VITE_TELEMETRY_DEBUG=1`
+
+## Données capturées
+
+Événements (schéma strict):
+- `search_start`
+- `search_result`
+- `cache_hit`
+- `cache_miss`
+- `cache_stale_used`
+- `provider_run`
+- `error`
+
+Champs stockés:
+- `ts`, `kind`, `territory`, `mode`
+- `queryLen`, `eanLen`
+- `durationMs`, `status`
+- `sourcesUsed`, `warningsCount`
+- `meta` (optionnel, max 5 clés)
+
+## Vie privée
+
+- Pas de PII.
+- Pas de query brute.
+- Pas d'EAN complet.
+- Corrélation éventuelle via hash court non réversible (FNV-1a 32-bit).
+
+## Stockage
+
+- Priorité: IndexedDB
+- Fallback: localStorage
+- Capacité: 300 événements max (FIFO)
+
+## UI Diagnostics
+
+En mode debug uniquement (`/diagnostics`):
+- 50 derniers événements,
+- export JSON,
+- vider l'historique,
+- synthèse (cache hit rate, médiane durée, statuts).
+
+## Limites
+
+- Données locales au navigateur courant (non synchronisées entre appareils).
+- Effaçables par l'utilisateur (clear storage).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import OnboardingTour from './components/OnboardingTour';
 import OnboardingAutoStart from './components/OnboardingAutoStart';
 import HelpButton from './components/HelpButton';
 import AnalyticsTracker from './components/analytics/AnalyticsTracker';
+import { isTelemetryEnabled } from './telemetry';
 
 // Lazy-loaded pages - Main routes
 const Home = React.lazy(() => import('./pages/Home'));
@@ -86,6 +87,7 @@ const SyncDashboard = React.lazy(() => import('./pages/admin/sync/SyncDashboard'
 
 // i18n Test page (for development/testing)
 const I18nTest = React.lazy(() => import('./pages/I18nTest'));
+const Diagnostics = React.lazy(() => import('./pages/Diagnostics'));
 
 function LoadingFallback() {
   const [showTimeout, setShowTimeout] = useState(false);
@@ -132,6 +134,7 @@ function LoadingFallback() {
 
 export default function App() {
   const [providerError, setProviderError] = useState<Error | null>(null);
+  const debugTelemetryEnabled = isTelemetryEnabled();
 
   useEffect(() => {
     console.log('🚀 App: Starting initialization');
@@ -254,6 +257,7 @@ export default function App() {
                       
                       {/* i18n Test (development/testing) */}
                       <Route path="test-i18n" element={<I18nTest />} />
+                      {debugTelemetryEnabled && <Route path="diagnostics" element={<Diagnostics />} />}
                       
                       {/* Catch-all route - redirect to home */}
                       <Route path="*" element={<Navigate to="/" replace />} />

--- a/frontend/src/pages/Diagnostics.tsx
+++ b/frontend/src/pages/Diagnostics.tsx
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { clear, exportJson, getEvents, isTelemetryEnabled, stats, type TelemetryEvent } from '../telemetry';
+
+export default function Diagnostics() {
+  const [events, setEvents] = useState<TelemetryEvent[]>([]);
+  const [summary, setSummary] = useState<Awaited<ReturnType<typeof stats>> | null>(null);
+
+  const enabled = isTelemetryEnabled();
+
+  const refresh = useCallback(async () => {
+    if (!enabled) return;
+    const [latest, telemetryStats] = await Promise.all([getEvents(50), stats(50)]);
+    setEvents(latest.reverse());
+    setSummary(telemetryStats);
+  }, [enabled]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const totalShown = useMemo(() => events.length, [events]);
+
+  if (!enabled) {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+          <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Diagnostics</h1>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+            La télémétrie locale est désactivée. Activez-la via <code>VITE_TELEMETRY_DEBUG=1</code>.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8 space-y-4">
+      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+        <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Diagnostics locaux</h1>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+          Données strictement locales (IndexedDB/localStorage), export manuel uniquement.
+        </p>
+
+        <div className="mt-4 grid sm:grid-cols-4 gap-3 text-sm">
+          <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-3">Total: <strong>{summary?.total ?? 0}</strong></div>
+          <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-3">Cache hit rate: <strong>{summary?.cacheHitRate ?? 0}%</strong></div>
+          <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-3">Médiane durée: <strong>{summary?.medianDurationMs ?? '-'} ms</strong></div>
+          <div className="rounded-lg border border-slate-200 dark:border-slate-700 p-3">
+            Status: <strong>OK {summary?.statusBreakdown.OK ?? 0}</strong> / <strong>PARTIAL {summary?.statusBreakdown.PARTIAL ?? 0}</strong> / <strong>NO_DATA {summary?.statusBreakdown.NO_DATA ?? 0}</strong> / <strong>UNAVAILABLE {summary?.statusBreakdown.UNAVAILABLE ?? 0}</strong>
+          </div>
+        </div>
+
+        <div className="mt-4 flex gap-2">
+          <button
+            type="button"
+            onClick={async () => {
+              const content = await exportJson();
+              const blob = new Blob([content], { type: 'application/json;charset=utf-8' });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = `telemetry-local-${new Date().toISOString()}.json`;
+              a.click();
+              URL.revokeObjectURL(url);
+            }}
+            className="px-3 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-sm"
+          >
+            Exporter JSON
+          </button>
+          <button
+            type="button"
+            onClick={async () => {
+              await clear();
+              await refresh();
+            }}
+            className="px-3 py-2 rounded-lg bg-slate-200 dark:bg-slate-700 hover:bg-slate-300 dark:hover:bg-slate-600 text-sm"
+          >
+            Vider
+          </button>
+        </div>
+      </div>
+
+      <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-xl p-6">
+        <h2 className="font-semibold text-slate-900 dark:text-slate-100">Derniers événements ({totalShown}/50)</h2>
+        <div className="mt-3 space-y-2 max-h-[60vh] overflow-auto">
+          {events.map((event, index) => (
+            <div key={`${event.ts}-${index}`} className="text-xs font-mono p-2 border border-slate-200 dark:border-slate-700 rounded-lg text-slate-700 dark:text-slate-300">
+              <div><strong>{event.kind}</strong> • {event.ts}</div>
+              <div>status={event.status ?? 'null'} territory={event.territory} mode={event.mode} queryLen={event.queryLen} eanLen={event.eanLen} durationMs={event.durationMs ?? 'null'}</div>
+              <div>sources=[{event.sourcesUsed.join(', ')}] warnings={event.warningsCount}</div>
+            </div>
+          ))}
+          {events.length === 0 && <p className="text-sm text-slate-500">Aucun événement.</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/providers/index.ts
+++ b/frontend/src/providers/index.ts
@@ -1,7 +1,9 @@
 import type { PriceSearchInput } from '../services/priceSearch/price.types';
 import { normalizeText } from './normalize';
+import { openPricesProvider } from './openPricesProvider';
 import { seedProvider } from './seedProvider';
 import type { PriceProvider, ProviderResult } from './types';
+import { track } from '../telemetry';
 
 const OPEN_FOOD_FACTS_ENDPOINT = 'https://world.openfoodfacts.org';
 
@@ -11,11 +13,21 @@ const parseFlag = (value: string | boolean | undefined, fallback: boolean): bool
   return ['1', 'true', 'on', 'yes'].includes(value.toLowerCase());
 };
 
-const env = import.meta.env;
+const env = (import.meta as ImportMeta & { env?: Record<string, string | boolean | undefined> }).env ?? {};
+
+function readEnv(name: string): string | boolean | undefined {
+  const fromVite = env[name];
+  if (fromVite !== undefined) return fromVite;
+  const runtime = globalThis as typeof globalThis & { process?: { env?: Record<string, string | undefined> } };
+  if (runtime.process?.env) {
+    return runtime.process.env[name];
+  }
+  return undefined;
+}
 
 const openFoodFactsProvider: PriceProvider = {
   source: 'open_food_facts',
-  isEnabled: () => parseFlag(env.VITE_PRICE_PROVIDER_OPEN_FOOD_FACTS, true),
+  isEnabled: () => parseFlag(readEnv('VITE_PRICE_PROVIDER_OPEN_FOOD_FACTS'), true),
   async search(input, signal) {
     if (!input.barcode && !input.query) {
       return {
@@ -68,7 +80,7 @@ const openFoodFactsProvider: PriceProvider = {
 
 const dataGouvStubProvider: PriceProvider = {
   source: 'data_gouv',
-  isEnabled: () => parseFlag(env.VITE_PRICE_PROVIDER_DATA_GOUV, false),
+  isEnabled: () => parseFlag(readEnv('VITE_PRICE_PROVIDER_DATA_GOUV'), false),
   async search() {
     return {
       source: 'data_gouv',
@@ -79,42 +91,105 @@ const dataGouvStubProvider: PriceProvider = {
   },
 };
 
-const openPricesStubProvider: PriceProvider = {
-  source: 'open_prices',
-  isEnabled: () => parseFlag(env.VITE_PRICE_PROVIDER_OPEN_PRICES, false),
-  async search() {
-    return {
-      source: 'open_prices',
-      status: 'UNAVAILABLE',
-      observations: [],
-      warnings: ['open_prices indisponible (stub provider).'],
-    };
-  },
+const PROVIDERS: PriceProvider[] = [openFoodFactsProvider, openPricesProvider, dataGouvStubProvider];
+
+type ProviderRun = {
+  result: ProviderResult;
+  durationMs: number;
+  errorType?: string;
 };
 
-const PROVIDERS: PriceProvider[] = [openFoodFactsProvider, openPricesStubProvider, dataGouvStubProvider];
+async function runProvider(provider: PriceProvider, input: PriceSearchInput, signal: AbortSignal): Promise<ProviderRun> {
+  const startedAt = performance.now();
+  try {
+    const result = await provider.search(input, signal);
+    return {
+      result,
+      durationMs: Math.round(performance.now() - startedAt),
+    };
+  } catch {
+    return {
+      result: {
+        source: provider.source,
+        status: 'UNAVAILABLE',
+        observations: [],
+        warnings: [`${provider.source} indisponible (exception provider).`],
+      },
+      durationMs: Math.round(performance.now() - startedAt),
+      errorType: 'provider_rejected',
+    };
+  }
+}
+
+function trackProviderRun(
+  input: PriceSearchInput,
+  run: { source: string; status: ProviderResult['status']; warningsCount: number; observationsCount: number; durationMs: number; errorType?: string }
+): void {
+  const mode = input.barcode && input.query ? 'mixed' : input.barcode ? 'ean' : 'query';
+  const territory = input.territory ?? 'fr';
+  const queryLen = input.query?.trim().length ?? 0;
+  const eanLen = input.barcode?.trim().length ?? 0;
+
+  track({
+    kind: 'provider_run',
+    territory,
+    mode,
+    queryLen,
+    eanLen,
+    durationMs: run.durationMs,
+    status: run.status,
+    sourcesUsed: [run.source],
+    warningsCount: run.warningsCount,
+    meta: {
+      provider: run.source,
+      observations: run.observationsCount,
+      ...(run.errorType ? { errorType: run.errorType } : {}),
+    },
+  });
+}
 
 export async function queryProviders(input: PriceSearchInput, signal: AbortSignal): Promise<ProviderResult[]> {
   const enabledProviders = PROVIDERS.filter((provider) => provider.isEnabled());
 
   if (enabledProviders.length === 0) {
-    return [await seedProvider.search(input, signal)];
+    const seedRun = await runProvider(seedProvider, input, signal);
+    trackProviderRun(input, {
+      source: seedRun.result.source,
+      status: seedRun.result.status,
+      warningsCount: seedRun.result.warnings.length,
+      observationsCount: seedRun.result.observations.length,
+      durationMs: seedRun.durationMs,
+      errorType: seedRun.errorType,
+    });
+    return [seedRun.result];
   }
 
-  const settled = await Promise.allSettled(enabledProviders.map((provider) => provider.search(input, signal)));
-  const liveResults = settled.flatMap((result, index) => {
-    const provider = enabledProviders[index];
-    if (result.status === 'fulfilled') {
-      return [result.value];
-    }
-    return [{ source: provider.source, status: 'UNAVAILABLE', observations: [], warnings: [] } as ProviderResult];
-  });
+  const liveRuns = await Promise.all(enabledProviders.map((provider) => runProvider(provider, input, signal)));
+  for (const run of liveRuns) {
+    trackProviderRun(input, {
+      source: run.result.source,
+      status: run.result.status,
+      warningsCount: run.result.warnings.length,
+      observationsCount: run.result.observations.length,
+      durationMs: run.durationMs,
+      errorType: run.errorType,
+    });
+  }
 
+  const liveResults = liveRuns.map((run) => run.result);
   const hasPriceObservations = liveResults.some((result) => result.observations.length > 0);
   if (hasPriceObservations) {
     return liveResults;
   }
 
-  const seedResult = await seedProvider.search(input, signal);
-  return [...liveResults, seedResult];
+  const seedRun = await runProvider(seedProvider, input, signal);
+  trackProviderRun(input, {
+    source: seedRun.result.source,
+    status: seedRun.result.status,
+    warningsCount: seedRun.result.warnings.length,
+    observationsCount: seedRun.result.observations.length,
+    durationMs: seedRun.durationMs,
+    errorType: seedRun.errorType,
+  });
+  return [...liveResults, seedRun.result];
 }

--- a/frontend/src/providers/openPricesProvider.ts
+++ b/frontend/src/providers/openPricesProvider.ts
@@ -1,0 +1,210 @@
+import { normalizeTerritoryCode } from '../services/priceSearch/normalizeTerritoryCode';
+import type {
+  PriceObservation,
+  PriceSearchInput,
+  PriceSourceId,
+  TerritoryCode,
+} from '../services/priceSearch/price.types';
+import { normalizePriceObservation } from './normalize';
+import type { PriceProvider, ProviderResult } from './types';
+
+const REQUEST_TIMEOUT_MS = 5000;
+const OPEN_PRICES_SOURCE: PriceSourceId = 'open_prices';
+
+const parseFlag = (value: string | boolean | undefined, fallback: boolean): boolean => {
+  if (typeof value === 'boolean') return value;
+  if (typeof value !== 'string') return fallback;
+  return ['1', 'true', 'on', 'yes'].includes(value.toLowerCase());
+};
+
+const env = (import.meta as ImportMeta & { env?: Record<string, string | boolean | undefined> }).env ?? {};
+
+function readEnv(name: string): string | boolean | undefined {
+  const fromVite = env[name];
+  if (fromVite !== undefined) return fromVite;
+  const runtime = globalThis as typeof globalThis & { process?: { env?: Record<string, string | undefined> } };
+  if (runtime.process?.env) {
+    return runtime.process.env[name];
+  }
+  return undefined;
+}
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value.replace(',', '.').trim());
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function toStringOrUndefined(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function parseUnit(value: unknown): PriceObservation['unit'] {
+  if (value === 'kg' || value === 'l' || value === 'unit') return value;
+  return 'unit';
+}
+
+function parseObservation(raw: unknown, input: PriceSearchInput): PriceObservation | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const item = raw as Record<string, unknown>;
+
+  const priceCandidate = toNumber(item.price ?? item.amount ?? item.value);
+  if (priceCandidate === null || priceCandidate <= 0) return null;
+
+  const territory = toStringOrUndefined(item.territory ?? item.territoryCode);
+  const normalizedTerritory = territory ? normalizeTerritoryCode(territory) : input.territory;
+
+  return normalizePriceObservation({
+    source: OPEN_PRICES_SOURCE,
+    productName: toStringOrUndefined(item.productName ?? item.product_name ?? item.name),
+    brand: toStringOrUndefined(item.brand),
+    barcode: toStringOrUndefined(item.barcode ?? item.ean),
+    price: priceCandidate,
+    currency: 'EUR',
+    unit: parseUnit(item.unit),
+    observedAt: toStringOrUndefined(item.observedAt ?? item.observed_at ?? item.timestamp),
+    territory: normalizedTerritory,
+    metadata: {
+      endpoint: 'open_prices_live',
+      store: toStringOrUndefined(item.storeName ?? item.store ?? item.seller) ?? 'unknown',
+    },
+  });
+}
+
+function pickItems(payload: unknown): unknown[] {
+  if (Array.isArray(payload)) return payload;
+  if (!payload || typeof payload !== 'object') return [];
+
+  const data = payload as Record<string, unknown>;
+  const candidates = [data.items, data.results, data.data, data.prices];
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) return candidate;
+  }
+  return [];
+}
+
+function buildUrl(input: PriceSearchInput, endpoint: string): string {
+  const url = new URL(endpoint);
+  if (input.barcode) {
+    url.searchParams.set('ean', input.barcode.trim());
+  }
+  if (input.query) {
+    url.searchParams.set('q', input.query.trim());
+  }
+  if (input.territory) {
+    url.searchParams.set('territory', input.territory);
+  }
+  return url.toString();
+}
+
+function filterByTerritory(observations: PriceObservation[], territory: TerritoryCode): PriceObservation[] {
+  return observations.filter((obs) => {
+    if (!obs.territory) return true;
+    return normalizeTerritoryCode(obs.territory) === territory;
+  });
+}
+
+async function withTimeoutFetch(url: string, signal: AbortSignal) {
+  const controller = new globalThis.AbortController();
+  const timeoutId = globalThis.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  const relayAbort = () => controller.abort();
+  signal.addEventListener('abort', relayAbort);
+
+  try {
+    return await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+  } finally {
+    signal.removeEventListener('abort', relayAbort);
+    globalThis.clearTimeout(timeoutId);
+  }
+}
+
+export const openPricesProvider: PriceProvider = {
+  source: OPEN_PRICES_SOURCE,
+  isEnabled: () => parseFlag(readEnv('VITE_PRICE_PROVIDER_OPEN_PRICES'), false),
+  async search(input, signal): Promise<ProviderResult> {
+    const endpoint = typeof readEnv('VITE_PRICE_PROVIDER_OPEN_PRICES_ENDPOINT') === 'string'
+      ? String(readEnv('VITE_PRICE_PROVIDER_OPEN_PRICES_ENDPOINT')).trim()
+      : '';
+
+    if (!endpoint) {
+      return {
+        source: OPEN_PRICES_SOURCE,
+        status: 'UNAVAILABLE',
+        observations: [],
+        warnings: ['open_prices live non configuré: définir VITE_PRICE_PROVIDER_OPEN_PRICES_ENDPOINT.'],
+      };
+    }
+
+    const territory = normalizeTerritoryCode(input.territory ?? 'fr');
+
+    try {
+      const response = await withTimeoutFetch(buildUrl(input, endpoint), signal);
+      if (!response.ok) {
+        return {
+          source: OPEN_PRICES_SOURCE,
+          status: 'UNAVAILABLE',
+          observations: [],
+          warnings: [`open_prices live HTTP ${response.status}.`],
+        };
+      }
+
+      const body = (await response.json()) as unknown;
+      const items = pickItems(body);
+      const parsed = items
+        .map((item) => parseObservation(item, input))
+        .filter((item): item is PriceObservation => item !== null);
+
+      if (parsed.length === 0) {
+        return {
+          source: OPEN_PRICES_SOURCE,
+          status: 'NO_DATA',
+          observations: [],
+          warnings: ['open_prices live: aucune observation exploitable dans la réponse.'],
+        };
+      }
+
+      const territoryScoped = filterByTerritory(parsed, territory);
+      if (territoryScoped.length === 0) {
+        return {
+          source: OPEN_PRICES_SOURCE,
+          status: 'PARTIAL',
+          observations: [],
+          warnings: ['open_prices live: données reçues hors territoire demandé.'],
+        };
+      }
+
+      return {
+        source: OPEN_PRICES_SOURCE,
+        status: 'OK',
+        observations: territoryScoped,
+        warnings: territoryScoped.length < parsed.length
+          ? ['open_prices live: observations hors territoire ignorées.']
+          : [],
+      };
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        return {
+          source: OPEN_PRICES_SOURCE,
+          status: 'UNAVAILABLE',
+          observations: [],
+          warnings: ['open_prices live timeout/abort (>5s).'],
+        };
+      }
+      return {
+        source: OPEN_PRICES_SOURCE,
+        status: 'UNAVAILABLE',
+        observations: [],
+        warnings: ['open_prices live indisponible (erreur réseau ou parsing).'],
+      };
+    }
+  },
+};

--- a/frontend/src/providers/types.ts
+++ b/frontend/src/providers/types.ts
@@ -1,6 +1,6 @@
 import type { PriceObservation, PriceSearchInput, PriceSourceId } from '../services/priceSearch/price.types';
 
-export type ProviderStatus = 'OK' | 'NO_DATA' | 'UNAVAILABLE';
+export type ProviderStatus = 'OK' | 'NO_DATA' | 'UNAVAILABLE' | 'PARTIAL';
 
 export interface ProviderResult {
   source: PriceSourceId;

--- a/frontend/src/services/priceSearch/priceSearch.service.ts
+++ b/frontend/src/services/priceSearch/priceSearch.service.ts
@@ -5,6 +5,7 @@ import { computePriceConfidence } from './priceConfidence';
 import { normalizeTerritoryCode } from './normalizeTerritoryCode';
 import { queryProviders } from '../../providers';
 import { buildCacheKey, getCache, purgeExpiredCache, setCache } from '../../providers/cache';
+import { track } from '../../telemetry';
 import type {
   PriceInterval,
   PriceSearchInput,
@@ -15,6 +16,35 @@ import type {
 
 const DEFAULT_TERRITORY: TerritoryCode = 'fr';
 const PROVIDER_TIMEOUT_MS = 5000;
+
+function getMode(input: PriceSearchInput): 'ean' | 'query' | 'mixed' {
+  if (input.barcode && input.query) return 'mixed';
+  if (input.barcode) return 'ean';
+  return 'query';
+}
+
+function trackSearchEvent(
+  kind: 'search_start' | 'cache_hit' | 'cache_miss' | 'cache_stale_used' | 'search_result' | 'error',
+  input: PriceSearchInput,
+  territory: TerritoryCode,
+  payload: Partial<PriceSearchResult> & {
+    durationMs?: number | null;
+    meta?: Record<string, string | number>;
+  } = {}
+): void {
+  track({
+    kind,
+    territory,
+    mode: getMode(input),
+    queryLen: input.query?.trim().length ?? 0,
+    eanLen: input.barcode?.trim().length ?? 0,
+    durationMs: payload.durationMs ?? null,
+    status: payload.status ?? null,
+    sourcesUsed: payload.sourcesUsed ?? [],
+    warningsCount: payload.warnings?.length ?? 0,
+    meta: payload.meta,
+  });
+}
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, signal: AbortSignal): Promise<T> {
   return new Promise((resolve, reject) => {
@@ -141,11 +171,21 @@ export async function searchProductPrices(input: PriceSearchInput): Promise<Pric
   const queryUsed = input.barcode || input.query || 'recherche libre';
   const cacheKey = buildSearchCacheKey(normalizedInput, territory);
   const hasSearchTerm = Boolean((normalizedInput.barcode ?? '').trim() || (normalizedInput.query ?? '').trim());
+  const startedAt = performance.now();
+
+  trackSearchEvent('search_start', normalizedInput, territory);
 
   purgeExpiredCache();
   const cached = getCache<PriceSearchResult>(cacheKey);
 
   if (cached?.isFresh) {
+    trackSearchEvent('cache_hit', normalizedInput, territory, {
+      status: cached.value.status,
+      sourcesUsed: cached.value.sourcesUsed,
+      warnings: cached.value.warnings,
+      durationMs: Math.round(performance.now() - startedAt),
+    });
+
     if (hasSearchTerm) {
       void fetchLiveResult(normalizedInput, territory, queryUsed)
         .then((liveResult) => {
@@ -158,10 +198,33 @@ export async function searchProductPrices(input: PriceSearchInput): Promise<Pric
         });
     }
 
+    trackSearchEvent('search_result', normalizedInput, territory, {
+      status: cached.value.status,
+      sourcesUsed: cached.value.sourcesUsed,
+      warnings: cached.value.warnings,
+      durationMs: Math.round(performance.now() - startedAt),
+      meta: { cache: 1 },
+    });
+
     return cached.value;
   }
 
+  trackSearchEvent('cache_miss', normalizedInput, territory);
+
   if (cached && !hasSearchTerm) {
+    trackSearchEvent('cache_stale_used', normalizedInput, territory, {
+      status: cached.value.status,
+      sourcesUsed: cached.value.sourcesUsed,
+      warnings: cached.value.warnings,
+      durationMs: Math.round(performance.now() - startedAt),
+    });
+    trackSearchEvent('search_result', normalizedInput, territory, {
+      status: cached.value.status,
+      sourcesUsed: cached.value.sourcesUsed,
+      warnings: cached.value.warnings,
+      durationMs: Math.round(performance.now() - startedAt),
+      meta: { stale: 1 },
+    });
     return cached.value;
   }
 
@@ -170,13 +233,41 @@ export async function searchProductPrices(input: PriceSearchInput): Promise<Pric
     if (shouldCacheResult(liveResult)) {
       setCache(cacheKey, liveResult);
     }
+
+    trackSearchEvent('search_result', normalizedInput, territory, {
+      status: liveResult.status,
+      sourcesUsed: liveResult.sourcesUsed,
+      warnings: liveResult.warnings,
+      durationMs: Math.round(performance.now() - startedAt),
+      meta: { cache: 0 },
+    });
+
     return liveResult;
   } catch {
     if (cached) {
+      trackSearchEvent('cache_stale_used', normalizedInput, territory, {
+        status: cached.value.status,
+        sourcesUsed: cached.value.sourcesUsed,
+        warnings: cached.value.warnings,
+        durationMs: Math.round(performance.now() - startedAt),
+        meta: { reason: 'provider_failure' },
+      });
+      trackSearchEvent('search_result', normalizedInput, territory, {
+        status: cached.value.status,
+        sourcesUsed: cached.value.sourcesUsed,
+        warnings: cached.value.warnings,
+        durationMs: Math.round(performance.now() - startedAt),
+        meta: { stale: 1 },
+      });
+      trackSearchEvent('error', normalizedInput, territory, {
+        status: 'UNAVAILABLE',
+        durationMs: Math.round(performance.now() - startedAt),
+        meta: { message: 'provider_failure_with_stale' },
+      });
       return cached.value;
     }
 
-    return {
+    const unavailable: PriceSearchResult = {
       status: 'UNAVAILABLE',
       intervals: [],
       confidence: 0,
@@ -190,5 +281,20 @@ export async function searchProductPrices(input: PriceSearchInput): Promise<Pric
         territoryMessage: territoryMessage(territory),
       },
     };
+
+    trackSearchEvent('error', normalizedInput, territory, {
+      status: 'UNAVAILABLE',
+      durationMs: Math.round(performance.now() - startedAt),
+      meta: { message: 'provider_failure_no_stale' },
+    });
+    trackSearchEvent('search_result', normalizedInput, territory, {
+      status: unavailable.status,
+      sourcesUsed: unavailable.sourcesUsed,
+      warnings: unavailable.warnings,
+      durationMs: Math.round(performance.now() - startedAt),
+      meta: { cache: 0 },
+    });
+
+    return unavailable;
   }
 }

--- a/frontend/src/telemetry/client.ts
+++ b/frontend/src/telemetry/client.ts
@@ -1,0 +1,108 @@
+import { appendTelemetryEvent, clearTelemetryEvents, readTelemetryEvents } from './store';
+import type {
+  TelemetryEvent,
+  TelemetryKind,
+  TelemetryMeta,
+  TelemetryMode,
+  TelemetryStats,
+  TelemetryStatus,
+} from './types';
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined';
+}
+
+export function isTelemetryEnabled(): boolean {
+  if (!isBrowser()) return false;
+  return import.meta.env.VITE_TELEMETRY_DEBUG === '1';
+}
+
+function sanitizeMeta(meta?: TelemetryMeta): TelemetryMeta | undefined {
+  if (!meta) return undefined;
+  const entries = Object.entries(meta).slice(0, 5).filter(([, value]) => {
+    return typeof value === 'string' || typeof value === 'number';
+  });
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+type TrackInput = Partial<Omit<TelemetryEvent, 'ts' | 'kind'>> & Pick<TelemetryEvent, 'kind'>;
+
+export function track(event: TrackInput): void {
+  if (!isTelemetryEnabled()) return;
+
+  const safeEvent: TelemetryEvent = {
+    ts: new Date().toISOString(),
+    kind: event.kind,
+    territory: event.territory ?? 'fr',
+    mode: event.mode ?? 'query',
+    queryLen: Number.isFinite(event.queryLen) ? Number(event.queryLen) : 0,
+    eanLen: Number.isFinite(event.eanLen) ? Number(event.eanLen) : 0,
+    durationMs: event.durationMs ?? null,
+    status: event.status ?? null,
+    sourcesUsed: Array.isArray(event.sourcesUsed) ? event.sourcesUsed.slice(0, 10) : [],
+    warningsCount: Number.isFinite(event.warningsCount) ? Number(event.warningsCount) : 0,
+    meta: sanitizeMeta(event.meta),
+  };
+
+  void appendTelemetryEvent(safeEvent);
+}
+
+export async function getEvents(limit?: number): Promise<TelemetryEvent[]> {
+  if (!isTelemetryEnabled()) return [];
+  const events = await readTelemetryEvents();
+  if (!limit || limit <= 0) return events;
+  return events.slice(-limit);
+}
+
+export async function clear(): Promise<void> {
+  if (!isTelemetryEnabled()) return;
+  await clearTelemetryEvents();
+}
+
+export async function exportJson(): Promise<string> {
+  const events = await getEvents();
+  return JSON.stringify(events, null, 2);
+}
+
+export async function stats(sampleSize = 50): Promise<TelemetryStats> {
+  const all = await getEvents();
+  const recent = all.slice(-Math.max(1, sampleSize));
+
+  const cacheEvents = recent.filter((event) => event.kind === 'cache_hit' || event.kind === 'cache_miss');
+  const cacheHits = cacheEvents.filter((event) => event.kind === 'cache_hit').length;
+
+  const durations = recent
+    .filter((event) => typeof event.durationMs === 'number')
+    .map((event) => Number(event.durationMs))
+    .sort((a, b) => a - b);
+
+  const medianDurationMs =
+    durations.length === 0
+      ? null
+      : durations.length % 2 === 1
+        ? durations[Math.floor(durations.length / 2)]
+        : Math.round((durations[durations.length / 2 - 1] + durations[durations.length / 2]) / 2);
+
+  const statusBreakdown: TelemetryStats['statusBreakdown'] = {
+    OK: 0,
+    PARTIAL: 0,
+    NO_DATA: 0,
+    UNAVAILABLE: 0,
+  };
+
+  for (const event of recent) {
+    if (event.status && event.status in statusBreakdown) {
+      statusBreakdown[event.status] += 1;
+    }
+  }
+
+  return {
+    total: all.length,
+    recentCount: recent.length,
+    cacheHitRate: cacheEvents.length === 0 ? 0 : Number(((cacheHits / cacheEvents.length) * 100).toFixed(1)),
+    medianDurationMs,
+    statusBreakdown,
+  };
+}
+
+export type { TelemetryEvent, TelemetryKind, TelemetryMeta, TelemetryMode, TelemetryStatus };

--- a/frontend/src/telemetry/hash.ts
+++ b/frontend/src/telemetry/hash.ts
@@ -1,0 +1,8 @@
+export function fnv1a32(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}

--- a/frontend/src/telemetry/index.ts
+++ b/frontend/src/telemetry/index.ts
@@ -1,0 +1,9 @@
+export { isTelemetryEnabled, track, getEvents, clear, exportJson, stats } from './client';
+export { fnv1a32 } from './hash';
+export type {
+  TelemetryEvent,
+  TelemetryKind,
+  TelemetryMeta,
+  TelemetryMode,
+  TelemetryStatus,
+} from './client';

--- a/frontend/src/telemetry/store.ts
+++ b/frontend/src/telemetry/store.ts
@@ -1,0 +1,138 @@
+import type { TelemetryEvent } from './types';
+
+const STORAGE_KEY = 'akp:telemetry:v1';
+const MAX_EVENTS = 300;
+const DB_NAME = 'akp-local-telemetry';
+const DB_VERSION = 1;
+const STORE_NAME = 'events';
+const RECORD_KEY = 'buffer';
+
+type TelemetryRecord = {
+  events: TelemetryEvent[];
+};
+
+function isBrowser(): boolean {
+  return typeof window !== 'undefined';
+}
+
+function clampEvents(events: TelemetryEvent[]): TelemetryEvent[] {
+  return events.slice(-MAX_EVENTS);
+}
+
+async function openDb(): Promise<IDBDatabase | null> {
+  if (!isBrowser() || !('indexedDB' in window)) return null;
+
+  return new Promise((resolve) => {
+    try {
+      const req = window.indexedDB.open(DB_NAME, DB_VERSION);
+
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME);
+        }
+      };
+
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => resolve(null);
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+async function readFromIdb(): Promise<TelemetryEvent[] | null> {
+  const db = await openDb();
+  if (!db) return null;
+
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(STORE_NAME, 'readonly');
+      const store = tx.objectStore(STORE_NAME);
+      const req = store.get(RECORD_KEY);
+      req.onsuccess = () => {
+        const result = req.result as TelemetryRecord | undefined;
+        resolve(Array.isArray(result?.events) ? result.events : []);
+      };
+      req.onerror = () => resolve([]);
+      tx.oncomplete = () => db.close();
+      tx.onerror = () => db.close();
+    } catch {
+      db.close();
+      resolve([]);
+    }
+  });
+}
+
+async function writeToIdb(events: TelemetryEvent[]): Promise<boolean> {
+  const db = await openDb();
+  if (!db) return false;
+
+  return new Promise((resolve) => {
+    try {
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      store.put({ events: clampEvents(events) } satisfies TelemetryRecord, RECORD_KEY);
+      tx.oncomplete = () => {
+        db.close();
+        resolve(true);
+      };
+      tx.onerror = () => {
+        db.close();
+        resolve(false);
+      };
+    } catch {
+      db.close();
+      resolve(false);
+    }
+  });
+}
+
+function readFromLocalStorage(): TelemetryEvent[] {
+  if (!isBrowser()) return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeToLocalStorage(events: TelemetryEvent[]): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(clampEvents(events)));
+  } catch {
+    // silent fallback
+  }
+}
+
+export async function readTelemetryEvents(): Promise<TelemetryEvent[]> {
+  const idbEvents = await readFromIdb();
+  if (idbEvents !== null) return clampEvents(idbEvents);
+  return clampEvents(readFromLocalStorage());
+}
+
+export async function appendTelemetryEvent(event: TelemetryEvent): Promise<void> {
+  const current = await readTelemetryEvents();
+  const next = clampEvents([...current, event]);
+  const idbOk = await writeToIdb(next);
+  if (!idbOk) {
+    writeToLocalStorage(next);
+  }
+}
+
+export async function clearTelemetryEvents(): Promise<void> {
+  const idbOk = await writeToIdb([]);
+  if (!idbOk && isBrowser()) {
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // noop
+    }
+  }
+}
+
+export { MAX_EVENTS };

--- a/frontend/src/telemetry/types.ts
+++ b/frontend/src/telemetry/types.ts
@@ -1,0 +1,38 @@
+export type TelemetryKind =
+  | 'search_start'
+  | 'search_result'
+  | 'cache_hit'
+  | 'cache_miss'
+  | 'cache_stale_used'
+  | 'provider_run'
+  | 'error';
+
+export type TelemetryMode = 'ean' | 'query' | 'mixed';
+
+export type TelemetryStatus = 'OK' | 'PARTIAL' | 'NO_DATA' | 'UNAVAILABLE' | null;
+
+export type TelemetryMetaValue = string | number;
+
+export type TelemetryMeta = Record<string, TelemetryMetaValue>;
+
+export interface TelemetryEvent {
+  ts: string;
+  kind: TelemetryKind;
+  territory: string;
+  mode: TelemetryMode;
+  queryLen: number;
+  eanLen: number;
+  durationMs: number | null;
+  status: TelemetryStatus;
+  sourcesUsed: string[];
+  warningsCount: number;
+  meta?: TelemetryMeta;
+}
+
+export interface TelemetryStats {
+  total: number;
+  recentCount: number;
+  cacheHitRate: number;
+  medianDurationMs: number | null;
+  statusBreakdown: Record<'OK' | 'PARTIAL' | 'NO_DATA' | 'UNAVAILABLE', number>;
+}


### PR DESCRIPTION
### Motivation
- Provide a production-grade live `open_prices` provider to fetch price observations live while keeping the existing public API and fallback behavior unchanged.
- Ensure the provider is safe for production by adding defensive parsing, territory handling, timeout/abort support, and explicit UNAVAILABLE behavior when no endpoint is configured.
- Integrate lightweight local telemetry and diagnostics to observe provider behavior during debug sessions without any network telemetry.

### Description
- Add `frontend/src/providers/openPricesProvider.ts` which implements `PriceProvider` for `open_prices` with feature-flag activation (`VITE_PRICE_PROVIDER_OPEN_PRICES`), endpoint configuration via `VITE_PRICE_PROVIDER_OPEN_PRICES_ENDPOINT`, a 5s timeout + `AbortController` relay, strict defensive JSON parsing/sanitization, territory filtering, and clear `ProviderResult` statuses (`OK | PARTIAL | NO_DATA | UNAVAILABLE`).
- Integrate the provider into the orchestrator ordering in `frontend/src/providers/index.ts` (priority: `open_food_facts` → `open_prices` → `data_gouv`) and keep the `seedProvider` as guaranteed fallback, while preserving the public `queryProviders`/`searchProductPrices` behavior and keeping cache ownership in the service layer.
- Add precise provider run tracking in the orchestrator using existing local telemetry `track` calls (include `provider` id, `status`, `durationMs`, `errorType`, `territory`, and `mode`), and extend `ProviderStatus` with `PARTIAL` in `frontend/src/providers/types.ts` for out-of-territory cases.
- Add local telemetry implementation and diagnostics UI: `frontend/src/telemetry/{client,store,types,hash,index}.ts`, `frontend/src/pages/Diagnostics.tsx`, and conditional route registration in `frontend/src/App.tsx` gated by `isTelemetryEnabled()`; update `docs/providers.md` to document flags and behavior; no external dependencies added.

### Testing
- Built the frontend with `cd frontend && npm run build`, which completed successfully and produced `dist/` output. ✅
- Ran lint with `cd frontend && npm run lint`, which completed successfully with legacy repository warnings only (no errors), and therefore passed CI-style validation (warnings remain). ⚠️
- Performed a manual provider check by mocking `fetch` in a quick script to activate `open_prices` with `VITE_PRICE_PROVIDER_OPEN_PRICES=1` and a mock `VITE_PRICE_PROVIDER_OPEN_PRICES_ENDPOINT`, then invoked `queryProviders` for an EAN; result showed `open_prices_status= OK` and `open_prices_observations= 1`, demonstrating the provider is called and parses observations as expected. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e7f3881dc8321ac4b2828e7afb0aa)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Open Prices as a live price data provider with timeout protection (feature-flag controlled).
  * Introduced local-only telemetry and diagnostics page (/diagnostics) with cache analytics, event history, and JSON export.
  * Expanded provider status to include partial results.

* **Documentation**
  * Added provider endpoint configuration and telemetry documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->