### PR TITLE
Fix Cloudflare Pages SPA fallback configuration

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && cp dist/index.html dist/404.html",
     "preview": "vite preview",
     "lint": "eslint src --ext .ts,.tsx,.js,.jsx",
     "lint:fix": "eslint src --ext .ts,.tsx,.js,.jsx --fix",

--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -1,2 +1,1 @@
 /api/*  /api/:splat  200
-/*      /index.html  200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,3 +1,1 @@
 /api/* /api/:splat 200
-/index.html /index.html 200
-/* /index.html 200


### PR DESCRIPTION
### Motivation
- Cloudflare Pages was rejecting the catch-all redirect `/* -> /index.html` due to an infinite-loop detection, which breaks SPA deep-link routing on some paths. 
- The goal is to provide a stable SPA fallback compatible with Pages while keeping Functions `/api/*` routing intact.

### Description
- Removed the catch-all SPA redirect lines from `frontend/public/_redirects` and `public/_redirects`, leaving only the `/api/* -> /api/:splat 200` mapping.
- Updated the frontend build script in `frontend/package.json` to run `vite build && cp dist/index.html dist/404.html` so the SPA is served via a generated `404.html` fallback instead of a redirect rule.
- Changes affect `frontend/package.json`, `frontend/public/_redirects`, and `public/_redirects`.

### Testing
- Ran the repository build with `npm run build` (root) which installs frontend dependencies and runs the new build step, and the build completed successfully (Vite built client and `dist/404.html` was created).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fb5be70248321a43bc08676347260)