### PR TITLE
fix(store-selector): harden risk points before merge

### DIFF
--- a/frontend/docs/store-selector-mvp.md
+++ b/frontend/docs/store-selector-mvp.md
@@ -1,0 +1,26 @@
+# StoreSelector MVP
+
+## Objectif
+Rendre l’application **magasin-aware** avec un choix persistant : magasin + mode de service.
+
+## Périmètre livré
+- `StoreChip` dans le header pour afficher la sélection courante.
+- `StoreSelectorModal` mobile-friendly avec:
+  - recherche texte (ville/code postal),
+  - géolocalisation optionnelle,
+  - tri par distance si position disponible,
+  - sélection du mode (`magasin`, `drive`, `livraison`) avec options indisponibles désactivées.
+- Persistance locale via `akps_store_selection_v1`.
+- Contexte global React pour éviter les relectures répétées de `localStorage`.
+- Injection de `territory`, `storeId`, `serviceMode` dans les paramètres de recherche prix.
+
+## Données
+- Source actuelle: `src/modules/store/stores.mock.ts` (MVP GP).
+- Extension future: brancher un provider API/KV/Firestore derrière une interface store-provider.
+
+## Robustesse UX
+- Si géolocalisation refusée: pas de crash, message court + fallback recherche texte.
+- Si aucun magasin sélectionné: bannière de rappel dans le comparateur pour améliorer la précision.
+
+## Verification
+La revue de risque avant merge confirme que les services n'importent pas `StoreSelectionContext`, que les accès `window/localStorage` sont protégés pour SSR/build, que les query params sont normalisés via `URLSearchParams` (avec validation du mode), que `/api/observations` parse les entrées en mode sûr sans casser l'existant, et que l'UX reste non bloquante sans sélection magasin.

--- a/frontend/functions/_lib/observations.ts
+++ b/frontend/functions/_lib/observations.ts
@@ -1,0 +1,42 @@
+export type Observation = {
+  id: string;
+  barcode: string;
+  productName: string;
+  territory: string;
+  storeId?: string;
+  storeName: string;
+  price: number;
+  currency: 'EUR';
+  observedAt: string;
+  source: string;
+  reliability: 'high' | 'medium' | 'low';
+};
+
+const mockDataset: Observation[] = [
+  { id: 'obs-1', barcode: '3274080005003', productName: 'Lait demi-écrémé 1L', territory: 'gp', storeId: 'leclerc-bas-du-fort', storeName: 'E.Leclerc Bas du Fort', price: 1.48, currency: 'EUR', observedAt: '2026-02-12T10:00:00.000Z', source: 'ticket citoyen', reliability: 'high' },
+  { id: 'obs-2', barcode: '3274080005003', productName: 'Lait demi-écrémé 1L', territory: 'gp', storeId: 'u-baie-mahault', storeName: 'U Baie-Mahault', price: 1.55, currency: 'EUR', observedAt: '2026-02-11T10:00:00.000Z', source: 'ticket citoyen', reliability: 'medium' },
+  { id: 'obs-3', barcode: '3017620422003', productName: 'Pâte à tartiner 750g', territory: 'mq', storeId: 'carrefour-dillon', storeName: 'Carrefour Dillon', price: 5.9, currency: 'EUR', observedAt: '2026-02-12T08:00:00.000Z', source: 'relevé partenaire', reliability: 'high' },
+];
+
+let memoryStore = [...mockDataset];
+
+export const observationDriver = {
+  mode: 'mock',
+  list(query: { territory?: string; barcode?: string; q?: string }) {
+    return memoryStore
+      .filter((obs) => !query.territory || obs.territory === query.territory)
+      .filter((obs) => !query.barcode || obs.barcode === query.barcode)
+      .filter((obs) => !query.q || obs.productName.toLowerCase().includes(query.q.toLowerCase()))
+      .sort((a, b) => +new Date(b.observedAt) - +new Date(a.observedAt));
+  },
+  add(input: Observation) {
+    memoryStore = [input, ...memoryStore];
+    return input;
+  },
+};
+
+export const computeStatus = (count: number) => {
+  if (count === 0) return 'NO_DATA';
+  if (count < 2) return 'PARTIAL';
+  return 'OK';
+};

--- a/frontend/functions/api/observations.ts
+++ b/frontend/functions/api/observations.ts
@@ -1,0 +1,77 @@
+import { errorResponse, getRequestId, handleOptions, jsonResponse, methodGuard, parseJson, parseQuery } from '../_lib/http';
+import { computeStatus, observationDriver, type Observation } from '../_lib/observations';
+
+const ALLOWED_MODES = new Set(['inStore', 'drive', 'delivery']);
+
+export const onRequestOptions: PagesFunction = async ({ request }) => handleOptions(request, ['GET', 'POST']) ?? new Response(null, { status: 204 });
+
+export const onRequestGet: PagesFunction = async ({ request }) => {
+  const query = parseQuery(request);
+  const territory = (query.get('territory') ?? '').trim().toLowerCase() || undefined;
+  const barcode = (query.get('barcode') ?? '').trim() || undefined;
+  const q = (query.get('q') ?? '').trim() || undefined;
+  const storeId = (query.get('storeId') ?? '').trim() || undefined;
+  const modeRaw = (query.get('mode') ?? query.get('serviceMode') ?? '').trim();
+  const mode = ALLOWED_MODES.has(modeRaw) ? modeRaw : undefined;
+
+  const observations = observationDriver.list({
+    territory,
+    barcode,
+    q,
+  });
+
+  const metadata: Record<string, unknown> = {
+    status: computeStatus(observations.length),
+    total: observations.length,
+    driver: observationDriver.mode,
+    lastUpdatedAt: observations[0]?.observedAt ?? null,
+  };
+  if (territory) metadata.territory = territory;
+  if (storeId) metadata.storeId = storeId;
+  if (mode) metadata.mode = mode;
+
+  return jsonResponse({
+    observations,
+    metadata,
+  }, { request });
+};
+
+export const onRequestPost: PagesFunction = async ({ request, env }) => {
+  const requestId = getRequestId(request);
+  const blocked = methodGuard(request, ['POST']);
+  if (blocked) return blocked;
+
+  const envObj = env as Record<string, string | undefined>;
+  if (envObj.OBSERVATIONS_WRITE_ENABLED !== 'true') {
+    return errorResponse('FORBIDDEN', 'Write endpoint disabled', { status: 403, request, requestId });
+  }
+
+  const adminKey = envObj.OBSERVATIONS_ADMIN_KEY;
+  if (adminKey && request.headers.get('x-admin-key') !== adminKey) {
+    return errorResponse('UNAUTHORIZED', 'Missing or invalid admin key', { status: 401, request, requestId });
+  }
+
+  const payload = await parseJson<Partial<Observation>>(request);
+  if (!payload || typeof payload !== 'object') {
+    return errorResponse('INVALID_INPUT', 'Invalid JSON body', { status: 400, request, requestId });
+  }
+  if (!payload?.barcode || !payload?.territory || typeof payload.price !== 'number' || !payload.observedAt) {
+    return errorResponse('INVALID_INPUT', 'Missing required fields', { status: 400, request, requestId });
+  }
+
+  const observation: Observation = {
+    id: payload.id ?? `${payload.barcode}-${payload.territory}-${Date.now()}`,
+    barcode: payload.barcode,
+    productName: payload.productName ?? 'Produit non précisé',
+    territory: payload.territory,
+    storeId: payload.storeId,
+    storeName: payload.storeName ?? 'Magasin non précisé',
+    price: Number(payload.price),
+    currency: 'EUR',
+    observedAt: new Date(payload.observedAt).toISOString(),
+    source: payload.source ?? 'contribution admin',
+    reliability: payload.reliability ?? 'medium',
+  };
+
+  return jsonResponse({ ok: true, observation: observationDriver.add(observation), driver: observationDriver.mode }, { request, status: 201 });
+};

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import OnboardingTour from './components/OnboardingTour';
 import OnboardingAutoStart from './components/OnboardingAutoStart';
 import HelpButton from './components/HelpButton';
 import AnalyticsTracker from './components/analytics/AnalyticsTracker';
+import { StoreSelectionProvider } from './context/StoreSelectionContext';
 
 // Lazy-loaded pages - Main routes
 const Home = React.lazy(() => import('./pages/Home'));
@@ -60,6 +61,7 @@ const Settings = React.lazy(() => import('./pages/Settings'));
 const HistoriquePrix = React.lazy(() => import('./pages/HistoriquePrix'));
 const RecherchePrix = React.lazy(() => import('./pages/RecherchePrix'));
 const Alertes = React.lazy(() => import('./pages/Alertes'));
+const Promos = React.lazy(() => import('./pages/Promos'));
 const MesListes = React.lazy(() => import('./pages/MesListes'));
 
 // Savings Dashboard
@@ -167,6 +169,7 @@ export default function App() {
         <ThemeProvider>
           <AuthProvider>
             <OnboardingProvider>
+              <StoreSelectionProvider>
               <BrowserRouter>
                 <Suspense fallback={<LoadingFallback />}>
                   <Routes>
@@ -226,6 +229,7 @@ export default function App() {
                       <Route path="historique" element={<HistoriquePrix />} />
                       <Route path="recherche-prix" element={<RecherchePrix />} />
                       <Route path="alertes" element={<Alertes />} />
+                      <Route path="promos" element={<Promos />} />
                       <Route path="mes-listes" element={<MesListes />} />
                       
                       {/* Savings Dashboard */}
@@ -268,6 +272,7 @@ export default function App() {
                   <HelpButton />
                 </Suspense>
               </BrowserRouter>
+              </StoreSelectionProvider>
             </OnboardingProvider>
           </AuthProvider>
         </ThemeProvider>

--- a/frontend/src/components/AlertBanner.tsx
+++ b/frontend/src/components/AlertBanner.tsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom';
+import { getTopActiveAlert } from '../services/alertsService';
+import { getPreferredTerritory } from '../utils/userPreferences';
+
+export default function AlertBanner() {
+  const alert = getTopActiveAlert(getPreferredTerritory());
+
+  if (!alert) return null;
+
+  const tone = alert.severity === 'critical' ? 'border-red-700 bg-red-950/60' : alert.severity === 'warning' ? 'border-amber-700 bg-amber-950/40' : 'border-blue-700 bg-blue-950/40';
+
+  return (
+    <div className={`border-b ${tone}`}>
+      <div className="max-w-7xl mx-auto px-4 py-2 text-sm flex items-center justify-between gap-3">
+        <p className="text-slate-100 truncate"><strong>{alert.title}</strong> — {alert.message}</p>
+        <Link className="text-blue-300 shrink-0 underline" to="/alertes">Voir détails</Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -9,6 +9,8 @@ import SkipLinks from './a11y/SkipLinks';
 import A11ySettingsPanel from './a11y/A11ySettingsPanel';
 import SeoDefaults from './SeoDefaults';
 import { LanguageSelector } from './i18n/LanguageSelector';
+import AlertBanner from './AlertBanner';
+import StoreChip from './store/StoreChip';
 
 export default function Layout() {
   const location = useLocation();
@@ -126,6 +128,7 @@ export default function Layout() {
   const navItems = [
     { path: '/', label: 'Accueil', icon: '🏠' },
     { path: '/comparateur', label: 'Comparateur', icon: '📊' },
+    { path: '/promos', label: 'Promos', icon: '📰' },
     { path: '/observatoire', label: 'Observatoire', icon: '📈' },
     { path: '/mes-economies', label: 'Mes Économies', icon: '💰' },
     { path: '/mes-listes', label: 'Mes listes', icon: '⭐' },
@@ -199,6 +202,7 @@ export default function Layout() {
 
           {/* Ti‑panier (desktop placement) */}
           <div className="hidden md:flex items-center gap-3">
+            <StoreChip />
             <LanguageSelector variant="compact" />
             <TiPanierButton float={false} />
           </div>
@@ -240,6 +244,9 @@ export default function Layout() {
         {open && (
           <div id="mobile-menu" className="lg:hidden bg-slate-900/95 backdrop-blur-xl border-t border-slate-700 relative z-50" role="navigation" aria-label="Menu mobile">
             <div className="py-2">
+              <div className="px-6 py-2">
+                <StoreChip />
+              </div>
               {navItems.map((item) => (
                 <NavLink
                   key={item.path}
@@ -262,6 +269,8 @@ export default function Layout() {
           </div>
         )}
       </header>
+
+      <AlertBanner />
 
       {/* Offline/Network Indicator */}
       <OfflineIndicator />

--- a/frontend/src/components/store/StoreChip.tsx
+++ b/frontend/src/components/store/StoreChip.tsx
@@ -1,0 +1,42 @@
+import { useMemo, useState } from 'react';
+import StoreSelectorModal from './StoreSelectorModal';
+import { useStoreSelection } from '../../context/StoreSelectionContext';
+import type { ServiceMode } from '../../modules/store/types';
+
+const MODE_LABEL: Record<ServiceMode, string> = {
+  inStore: 'Magasin',
+  drive: 'Drive',
+  delivery: 'Livraison',
+};
+
+export default function StoreChip() {
+  const [open, setOpen] = useState(false);
+  const { selection, selectedStore, updateSelection } = useStoreSelection();
+
+  const label = useMemo(() => {
+    if (!selectedStore || !selection) return 'Choisir un magasin';
+    return `${selectedStore.city ?? selectedStore.name} • ${MODE_LABEL[selection.serviceMode]}`;
+  }, [selectedStore, selection]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center rounded-full border border-slate-700 bg-slate-800 px-3 py-1.5 text-xs text-slate-100 hover:bg-slate-700"
+        aria-label="Choisir un magasin"
+      >
+        📍 {label}
+      </button>
+      <StoreSelectorModal
+        open={open}
+        territory={selection?.territory ?? 'gp'}
+        onClose={() => setOpen(false)}
+        onSelect={(store, mode) => {
+          updateSelection(store, mode);
+          setOpen(false);
+        }}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/store/StoreSelectorModal.tsx
+++ b/frontend/src/components/store/StoreSelectorModal.tsx
@@ -1,0 +1,149 @@
+import { useMemo, useState } from 'react';
+import { storesMock } from '../../modules/store/stores.mock';
+import type { ServiceMode, Store } from '../../modules/store/types';
+
+interface Props {
+  open: boolean;
+  territory: string;
+  onClose: () => void;
+  onSelect: (store: Store, serviceMode: ServiceMode) => void;
+}
+
+const SERVICE_LABELS: Record<ServiceMode, string> = {
+  inStore: 'Magasin',
+  drive: 'Drive',
+  delivery: 'Livraison',
+};
+
+function toRad(value: number) {
+  return (value * Math.PI) / 180;
+}
+
+function distanceKm(from: { lat: number; lon: number }, to: { lat?: number; lon?: number }) {
+  if (typeof to.lat !== 'number' || typeof to.lon !== 'number') return null;
+  const earth = 6371;
+  const dLat = toRad(to.lat - from.lat);
+  const dLon = toRad(to.lon - from.lon);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(from.lat)) * Math.cos(toRad(to.lat)) * Math.sin(dLon / 2) ** 2;
+  return earth * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export default function StoreSelectorModal({ open, territory, onClose, onSelect }: Props) {
+  const [query, setQuery] = useState('');
+  const [serviceMode, setServiceMode] = useState<ServiceMode>('inStore');
+  const [userCoords, setUserCoords] = useState<{ lat: number; lon: number } | null>(null);
+  const [geoError, setGeoError] = useState<string | null>(null);
+
+  const stores = useMemo(() => {
+    const queryLower = query.trim().toLowerCase();
+    return storesMock
+      .filter((store) => store.territory === territory)
+      .filter((store) => {
+        if (!queryLower) return true;
+        return [store.name, store.city, store.postalCode].filter(Boolean).join(' ').toLowerCase().includes(queryLower);
+      })
+      .map((store) => ({
+        store,
+        distance: userCoords ? distanceKm(userCoords, store) : null,
+      }))
+      .sort((a, b) => {
+        if (a.distance === null && b.distance === null) return 0;
+        if (a.distance === null) return 1;
+        if (b.distance === null) return -1;
+        return a.distance - b.distance;
+      });
+  }, [query, territory, userCoords]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/60 flex items-end md:items-center justify-center" onClick={onClose}>
+      <div className="w-full md:max-w-2xl bg-slate-900 border border-slate-700 rounded-t-2xl md:rounded-2xl p-4 max-h-[85vh] overflow-auto" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-white">Choisir un magasin</h2>
+          <button className="text-sm text-slate-300" onClick={onClose}>Fermer</button>
+        </div>
+
+        <div className="space-y-3 mb-4">
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Ville ou code postal"
+            className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-white"
+          />
+          <button
+            type="button"
+            className="rounded-lg border border-slate-700 px-3 py-2 text-sm text-slate-100 bg-slate-800"
+            onClick={() => {
+              setGeoError(null);
+              if (!navigator.geolocation) {
+                setGeoError('Géolocalisation non disponible sur cet appareil.');
+                return;
+              }
+              navigator.geolocation.getCurrentPosition(
+                (position) => {
+                  setUserCoords({ lat: position.coords.latitude, lon: position.coords.longitude });
+                },
+                () => {
+                  setGeoError('Accès à la géolocalisation refusé.');
+                },
+                { enableHighAccuracy: false, timeout: 6000 },
+              );
+            }}
+          >
+            Utiliser ma position
+          </button>
+          {geoError && <p className="text-xs text-amber-300">{geoError}</p>}
+        </div>
+
+        <div className="space-y-3">
+          {stores.map(({ store, distance }) => {
+            const isModeAvailable = store.services[serviceMode];
+            return (
+              <article key={store.id} className="border border-slate-700 rounded-xl p-3 bg-slate-800">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-sm font-semibold text-white">{store.name}</h3>
+                    <p className="text-xs text-slate-400">{store.city} {store.postalCode ? `• ${store.postalCode}` : ''}</p>
+                    {distance !== null && <p className="text-xs text-slate-400">{distance.toFixed(1)} km</p>}
+                    <div className="mt-2 flex gap-2 flex-wrap text-xs">
+                      {(['inStore', 'drive', 'delivery'] as ServiceMode[]).map((mode) => (
+                        <span key={mode} className={`px-2 py-0.5 rounded border ${store.services[mode] ? 'border-slate-500 text-slate-200' : 'border-slate-700 text-slate-500'}`}>
+                          {SERVICE_LABELS[mode]}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="min-w-[150px] space-y-2">
+                    <select
+                      value={serviceMode}
+                      onChange={(e) => setServiceMode(e.target.value as ServiceMode)}
+                      className="w-full rounded border border-slate-700 bg-slate-800 px-2 py-1 text-xs text-white"
+                    >
+                      {(['inStore', 'drive', 'delivery'] as ServiceMode[]).map((mode) => (
+                        <option key={mode} value={mode} disabled={!store.services[mode]}>
+                          {SERVICE_LABELS[mode]}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      disabled={!isModeAvailable}
+                      onClick={() => onSelect(store, serviceMode)}
+                      className="w-full rounded bg-blue-600 hover:bg-blue-500 disabled:bg-slate-700 disabled:text-slate-400 px-3 py-1.5 text-xs"
+                    >
+                      Choisir
+                    </button>
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+          {stores.length === 0 && <p className="text-sm text-slate-400">Aucun magasin trouvé.</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/context/StoreSelectionContext.tsx
+++ b/frontend/src/context/StoreSelectionContext.tsx
@@ -1,0 +1,55 @@
+import React, { createContext, useContext, useMemo, useState } from 'react';
+import { storesMock } from '../modules/store/stores.mock';
+import { clearSelection, getSelection, setSelection } from '../modules/store/storeSelection';
+import type { ServiceMode, Store, StoreSelection } from '../modules/store/types';
+
+interface StoreSelectionContextValue {
+  selection: StoreSelection | null;
+  selectedStore: Store | null;
+  updateSelection: (store: Store, mode: ServiceMode) => void;
+  resetSelection: () => void;
+}
+
+const StoreSelectionContext = createContext<StoreSelectionContextValue | undefined>(undefined);
+
+export function StoreSelectionProvider({ children }: { children: React.ReactNode }) {
+  const [selection, setState] = useState<StoreSelection | null>(() => getSelection());
+
+  const selectedStore = useMemo(() => {
+    if (!selection) return null;
+    return storesMock.find((store) => store.id === selection.storeId) ?? null;
+  }, [selection]);
+
+  const value = useMemo<StoreSelectionContextValue>(() => ({
+    selection,
+    selectedStore,
+    updateSelection: (store, mode) => {
+      const next: StoreSelection = {
+        storeId: store.id,
+        territory: store.territory,
+        serviceMode: mode,
+        updatedAt: new Date().toISOString(),
+      };
+      setSelection(next);
+      setState(next);
+    },
+    resetSelection: () => {
+      clearSelection();
+      setState(null);
+    },
+  }), [selection, selectedStore]);
+
+  return (
+    <StoreSelectionContext.Provider value={value}>
+      {children}
+    </StoreSelectionContext.Provider>
+  );
+}
+
+export function useStoreSelection() {
+  const context = useContext(StoreSelectionContext);
+  if (!context) {
+    throw new Error('useStoreSelection must be used within StoreSelectionProvider');
+  }
+  return context;
+}

--- a/frontend/src/data/alerts.ts
+++ b/frontend/src/data/alerts.ts
@@ -1,0 +1,35 @@
+import type { Alert } from '../types/market';
+
+export const alertsDataset: Alert[] = [
+  {
+    id: 'alert-gp-logistique-1',
+    severity: 'critical',
+    territory: 'gp',
+    title: 'Tension logistique sur les produits frais',
+    message: 'Retards d’acheminement signalés sur plusieurs références périssables.',
+    sourceName: 'Observatoire local',
+    sourceUrl: '/transparence',
+    startsAt: '2026-02-12T08:00:00.000Z',
+    endsAt: '2026-02-16T20:00:00.000Z',
+  },
+  {
+    id: 'alert-mq-info-1',
+    severity: 'info',
+    territory: 'mq',
+    title: 'Nouvelle collecte citoyenne ouverte',
+    message: 'Vous pouvez partager vos tickets pour améliorer la couverture locale.',
+    sourceName: 'A KI PRI SA YÉ',
+    sourceUrl: '/contribuer-prix',
+    startsAt: '2026-02-10T08:00:00.000Z',
+  },
+  {
+    id: 'alert-fr-warning-1',
+    severity: 'warning',
+    territory: 'fr',
+    title: 'Données partielles sur certaines enseignes',
+    message: 'Le module observation consolide encore des relevés sur 48h.',
+    sourceName: 'Pipeline data',
+    startsAt: '2026-02-11T08:00:00.000Z',
+    endsAt: '2026-02-20T18:00:00.000Z',
+  },
+];

--- a/frontend/src/data/observationsMock.ts
+++ b/frontend/src/data/observationsMock.ts
@@ -1,0 +1,7 @@
+import type { NormalizedPriceObservation } from '../types/market';
+
+export const observationsMock: NormalizedPriceObservation[] = [
+  { id: 'obs-1', barcode: '3274080005003', productName: 'Lait demi-écrémé 1L', territory: 'gp', storeId: 'leclerc-bas-du-fort', storeName: 'E.Leclerc Bas du Fort', price: 1.48, currency: 'EUR', observedAt: '2026-02-12T10:00:00.000Z', source: 'ticket citoyen', reliability: 'high' },
+  { id: 'obs-2', barcode: '3274080005003', productName: 'Lait demi-écrémé 1L', territory: 'gp', storeId: 'u-baie-mahault', storeName: 'U Baie-Mahault', price: 1.55, currency: 'EUR', observedAt: '2026-02-11T10:00:00.000Z', source: 'ticket citoyen', reliability: 'medium' },
+  { id: 'obs-3', barcode: '3017620422003', productName: 'Pâte à tartiner 750g', territory: 'mq', storeId: 'carrefour-dillon', storeName: 'Carrefour Dillon', price: 5.9, currency: 'EUR', observedAt: '2026-02-12T08:00:00.000Z', source: 'relevé partenaire', reliability: 'high' },
+];

--- a/frontend/src/data/promos.ts
+++ b/frontend/src/data/promos.ts
@@ -1,0 +1,21 @@
+import type { PromoSource } from '../types/market';
+
+export const promosDataset: PromoSource[] = [
+  {
+    id: 'promo-gp-leclerc-bas-du-fort-jan',
+    name: 'E.Leclerc Bas du Fort',
+    territory: 'gp',
+    storeId: 'leclerc-bas-du-fort',
+    title: 'Catalogue hebdomadaire — produits du quotidien',
+    periodStart: '2026-02-10',
+    periodEnd: '2026-02-23',
+    url: 'https://www.e.leclerc',
+    tags: ['alimentaire', 'mvp'],
+  },
+  { id: 'promo-gp-u-baie-mahault', name: 'U Baie-Mahault', territory: 'gp', storeId: 'u-baie-mahault', title: 'Prospectus semaine budget famille', periodStart: '2026-02-08', periodEnd: '2026-02-20', url: 'https://www.magasins-u.com/', tags: ['famille', 'budget'] },
+  { id: 'promo-mq-carrefour-dillon', name: 'Carrefour Dillon', territory: 'mq', storeId: 'carrefour-dillon', title: 'Catalogue maison & entretien', periodStart: '2026-02-12', periodEnd: '2026-02-24', url: 'https://www.carrefour.fr/', tags: ['entretien'] },
+  { id: 'promo-mq-hyper-u-robert', name: 'Hyper U Le Robert', territory: 'mq', storeId: 'hyperu-robert', title: 'Offres anti-gaspi', periodStart: '2026-02-09', periodEnd: '2026-02-18', url: 'https://www.magasins-u.com/', tags: ['anti-gaspi'] },
+  { id: 'promo-fr-carrefour-market', name: 'Carrefour Market', territory: 'fr', title: 'Sélection promos nationales', periodStart: '2026-02-05', periodEnd: '2026-02-28', url: 'https://www.carrefour.fr/' },
+  { id: 'promo-fr-auchan-drive', name: 'Auchan Drive', territory: 'fr', title: 'Prix barrés - drive', periodStart: '2026-02-03', periodEnd: '2026-02-21', url: 'https://www.auchan.fr/', tags: ['drive'] },
+  { id: 'promo-gp-super-u-sainte-anne', name: 'Super U Sainte-Anne', territory: 'gp', storeId: 'superu-sainte-anne', title: 'Cuisine locale et frais', periodStart: '2026-02-11', periodEnd: '2026-02-19', url: 'https://www.magasins-u.com/', tags: ['frais', 'local'] },
+];

--- a/frontend/src/modules/store/storeSelection.ts
+++ b/frontend/src/modules/store/storeSelection.ts
@@ -1,0 +1,61 @@
+import type { StoreSelection } from './types';
+
+export const STORE_SELECTION_KEY = 'akps_store_selection_v1';
+export const LEGACY_STORE_SELECTION_KEY = 'akps_store_selection';
+const SERVICE_MODES = new Set(['inStore', 'drive', 'delivery']);
+
+function hasBrowserStorage() {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function parseSelection(value: string | null): StoreSelection | null {
+  if (!value) return null;
+
+  try {
+    const parsed = JSON.parse(value) as StoreSelection;
+    if (!parsed?.storeId || !parsed?.territory || !parsed?.serviceMode || !parsed?.updatedAt) {
+      return null;
+    }
+    if (!SERVICE_MODES.has(parsed.serviceMode)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function getSelection(): StoreSelection | null {
+  if (!hasBrowserStorage()) return null;
+
+  const current = parseSelection(window.localStorage.getItem(STORE_SELECTION_KEY));
+  if (current) return current;
+
+  const legacy = parseSelection(window.localStorage.getItem(LEGACY_STORE_SELECTION_KEY));
+  if (legacy) {
+    window.localStorage.setItem(STORE_SELECTION_KEY, JSON.stringify(legacy));
+    window.localStorage.removeItem(LEGACY_STORE_SELECTION_KEY);
+    return legacy;
+  }
+
+  return null;
+}
+
+export function setSelection(sel: StoreSelection) {
+  if (!hasBrowserStorage()) return;
+  window.localStorage.setItem(STORE_SELECTION_KEY, JSON.stringify(sel));
+}
+
+export function clearSelection() {
+  if (!hasBrowserStorage()) return;
+  window.localStorage.removeItem(STORE_SELECTION_KEY);
+}
+
+export function getEffectiveSelection(defaultTerritory = 'gp') {
+  const selection = getSelection();
+  return {
+    territory: selection?.territory || defaultTerritory,
+    storeId: selection?.storeId,
+    serviceMode: selection?.serviceMode,
+  };
+}

--- a/frontend/src/modules/store/stores.mock.ts
+++ b/frontend/src/modules/store/stores.mock.ts
@@ -1,0 +1,53 @@
+import type { Store } from './types';
+
+export const storesMock: Store[] = [
+  {
+    id: 'gp-leclerc-bas-du-fort',
+    name: 'E.Leclerc Bas du Fort',
+    brand: 'E.Leclerc',
+    territory: 'gp',
+    address: 'Bas du Fort',
+    city: 'Le Gosier',
+    postalCode: '97190',
+    lat: 16.2148,
+    lon: -61.5111,
+    services: { inStore: true, drive: true, delivery: false },
+  },
+  {
+    id: 'gp-u-baie-mahault',
+    name: 'U Baie-Mahault',
+    brand: 'Système U',
+    territory: 'gp',
+    address: 'Zone de Jarry',
+    city: 'Baie-Mahault',
+    postalCode: '97122',
+    lat: 16.2425,
+    lon: -61.5881,
+    services: { inStore: true, drive: true, delivery: true },
+  },
+  {
+    id: 'gp-super-u-sainte-anne',
+    name: 'Super U Sainte-Anne',
+    brand: 'Système U',
+    territory: 'gp',
+    city: 'Sainte-Anne',
+    postalCode: '97180',
+    lat: 16.2256,
+    lon: -61.3862,
+    services: { inStore: true, drive: false, delivery: false },
+  },
+  {
+    id: 'gp-carrefour-destinrelles',
+    name: 'Carrefour Destrellan',
+    brand: 'Carrefour',
+    territory: 'gp',
+    city: 'Baie-Mahault',
+    postalCode: '97122',
+    lat: 16.2668,
+    lon: -61.5849,
+    services: { inStore: true, drive: true, delivery: true },
+  },
+];
+
+// TODO(api): remplacer la source mock par une source API/KV (Cloudflare Functions)
+// export interface StoreProvider { listStores(territory?: string): Promise<Store[]> }

--- a/frontend/src/modules/store/types.ts
+++ b/frontend/src/modules/store/types.ts
@@ -1,0 +1,25 @@
+export type ServiceMode = 'inStore' | 'drive' | 'delivery';
+
+export interface Store {
+  id: string;
+  name: string;
+  brand: string;
+  territory: string;
+  address?: string;
+  city?: string;
+  postalCode?: string;
+  lat?: number;
+  lon?: number;
+  services: {
+    inStore: boolean;
+    drive: boolean;
+    delivery: boolean;
+  };
+}
+
+export interface StoreSelection {
+  storeId: string;
+  territory: string;
+  serviceMode: ServiceMode;
+  updatedAt: string;
+}

--- a/frontend/src/pages/Alertes.jsx
+++ b/frontend/src/pages/Alertes.jsx
@@ -1,221 +1,40 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { filterActiveAlerts } from '../services/alertsService';
+import { getPreferredTerritory } from '../utils/userPreferences';
 
 export default function Alertes() {
-  const [selectedTerritory, setSelectedTerritory] = useState('GP');
+  const [territory, setTerritory] = useState(getPreferredTerritory());
+  const [severity, setSeverity] = useState('all');
 
-  // Placeholder: En attente de données réelles d'alertes
-  const alertsPlaceholder = [
-    {
-      id: 1,
-      type: 'prix_eleve',
-      territory: 'GP',
-      product: 'Lait UHT',
-      message: 'Prix anormalement élevé détecté',
-      date: '2025-01-15',
-      status: 'active',
-      severity: 'medium',
-    },
-    {
-      id: 2,
-      type: 'penurie',
-      territory: 'MQ',
-      product: 'Huile de tournesol',
-      message: 'Rupture de stock signalée dans plusieurs enseignes',
-      date: '2025-01-14',
-      status: 'active',
-      severity: 'high',
-    },
-    {
-      id: 3,
-      type: 'variation',
-      territory: 'RE',
-      product: 'Poulet',
-      message: 'Hausse brutale de +15% en 1 semaine',
-      date: '2025-01-13',
-      status: 'active',
-      severity: 'high',
-    },
-  ];
-
-  const getSeverityColor = (severity) => {
-    switch (severity) {
-      case 'high': return 'border-red-500 bg-red-500/10';
-      case 'medium': return 'border-orange-500 bg-orange-500/10';
-      case 'low': return 'border-yellow-500 bg-yellow-500/10';
-      default: return 'border-gray-500 bg-gray-500/10';
-    }
-  };
-
-  const getSeverityIcon = (type) => {
-    // Icons removed per design specification: NO EMOJIS
-    switch (type) {
-      case 'prix_eleve': return '⚠';
-      case 'penurie': return '!';
-      case 'variation': return '↑';
-      default: return '•';
-    }
-  };
+  const alerts = useMemo(() => filterActiveAlerts({ territory, severity: severity === 'all' ? undefined : severity }), [territory, severity]);
 
   return (
-    <div className="min-h-screen bg-[#121212] text-white">
-      {/* Header */}
-      <header className="bg-gradient-to-r from-[#0f62fe] to-[#0353e9] p-6 shadow-lg">
-        <div className="max-w-6xl mx-auto">
-          <div className="flex items-center justify-between mb-4">
-            <h1 className="text-3xl font-bold">Alertes Consommateurs</h1>
-            <a 
-              href="/" 
-              className="text-white hover:text-gray-200 transition-colors"
-            >
-              ← Accueil
-            </a>
-          </div>
-          <p className="text-gray-100">
-            Alertes sur les prix anormaux, pénuries et variations brutales
-          </p>
-        </div>
-      </header>
-
-      {/* Main Content */}
-      <main className="max-w-6xl mx-auto p-6">
-        
-        {/* Notice - Données en développement */}
-        <div className="mb-8 bg-yellow-900/20 border border-yellow-700 rounded-xl p-6">
-          <div className="flex items-start gap-3">
-            <span className="text-2xl">⚙️</span>
-            <div>
-              <h2 className="text-xl font-semibold mb-2 text-yellow-400">Module en développement</h2>
-              <p className="text-gray-300 mb-2">
-                Le système d'alertes automatiques est actuellement en cours de développement.
-                Les alertes affichées ci-dessous sont des exemples pour illustrer le futur fonctionnement.
-              </p>
-              <p className="text-gray-400 text-sm">
-                <strong>À venir :</strong> Alertes basées sur des données réelles collectées quotidiennement,
-                système de notification, abonnement par territoire et catégorie de produits.
-              </p>
-            </div>
-          </div>
-        </div>
-
-        {/* Territory Filter */}
-        <div className="mb-8">
-          <div className="bg-[#1e1e1e] rounded-xl border border-gray-700 p-6">
-            <h2 className="text-xl font-semibold mb-4">🌍 Filtrer par territoire</h2>
-            <div className="max-w-md">
-              <select 
-                value={selectedTerritory}
-                onChange={(e) => setSelectedTerritory(e.target.value)}
-                className="w-full p-2 rounded bg-gray-800 border border-gray-700"
-              >
-                <option value="ALL">Tous les territoires</option>
-                <option value="GP">Guadeloupe</option>
-                <option value="MQ">Martinique</option>
-                <option value="RE">Réunion</option>
-              </select>
-            </div>
-          </div>
-        </div>
-
-        {/* Alerts Types Legend */}
-        <div className="mb-8 bg-[#1e1e1e] rounded-xl border border-gray-700 p-6">
-          <h2 className="text-xl font-semibold mb-4">📋 Types d'alertes</h2>
-          <div className="grid gap-4 md:grid-cols-3">
-            <div className="flex items-start gap-3">
-              <span className="text-2xl">⚠️</span>
-              <div>
-                <h3 className="font-semibold text-orange-400">Prix anormalement élevés</h3>
-                <p className="text-sm text-gray-400">Prix supérieur de +20% à la moyenne régionale</p>
-              </div>
-            </div>
-            <div className="flex items-start gap-3">
-              <span className="text-2xl">📦</span>
-              <div>
-                <h3 className="font-semibold text-red-400">Pénuries</h3>
-                <p className="text-sm text-gray-400">Ruptures de stock signalées dans plusieurs magasins</p>
-              </div>
-            </div>
-            <div className="flex items-start gap-3">
-              <span className="text-2xl">📈</span>
-              <div>
-                <h3 className="font-semibold text-yellow-400">Variations brutales</h3>
-                <p className="text-sm text-gray-400">Hausse ou baisse supérieure à ±10% en moins d'une semaine</p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Alerts List */}
-        <div className="space-y-4">
-          <h2 className="text-2xl font-semibold mb-4">📢 Alertes actives</h2>
-          
-          {alertsPlaceholder
-            .filter(alert => selectedTerritory === 'ALL' || alert.territory === selectedTerritory)
-            .map(alert => (
-              <div 
-                key={alert.id}
-                className={`border-l-4 rounded-r-xl p-6 ${getSeverityColor(alert.severity)}`}
-              >
-                <div className="flex items-start justify-between gap-4">
-                  <div className="flex items-start gap-3 flex-1">
-                    <span className="text-2xl">{getSeverityIcon(alert.type)}</span>
-                    <div className="flex-1">
-                      <div className="flex items-center gap-3 mb-2">
-                        <h3 className="text-lg font-semibold">{alert.product}</h3>
-                        <span className="text-xs bg-gray-700 px-2 py-1 rounded">
-                          {alert.territory}
-                        </span>
-                      </div>
-                      <p className="text-gray-300 mb-2">{alert.message}</p>
-                      <p className="text-sm text-gray-400">
-                        Signalé le {new Date(alert.date).toLocaleDateString('fr-FR', {
-                          day: 'numeric',
-                          month: 'long',
-                          year: 'numeric',
-                        })}
-                      </p>
-                    </div>
-                  </div>
-                  <span className={`px-3 py-1 rounded text-xs font-semibold ${
-                    alert.severity === 'high' ? 'bg-red-600' :
-                      alert.severity === 'medium' ? 'bg-orange-600' :
-                        'bg-yellow-600'
-                  }`}>
-                    {alert.severity === 'high' ? 'Urgent' :
-                      alert.severity === 'medium' ? 'Important' :
-                        'À surveiller'}
-                  </span>
-                </div>
-              </div>
-            ))}
-
-          {alertsPlaceholder.filter(alert => selectedTerritory === 'ALL' || alert.territory === selectedTerritory).length === 0 && (
-            <div className="bg-[#1e1e1e] rounded-xl border border-gray-700 p-8 text-center">
-              <p className="text-gray-400">Aucune alerte active pour ce territoire</p>
-            </div>
-          )}
-        </div>
-
-        {/* How it works */}
-        <div className="mt-12 bg-[#1e1e1e] rounded-xl border border-gray-700 p-6">
-          <h2 className="text-xl font-semibold mb-4">Comment fonctionnent les alertes ?</h2>
-          <div className="text-gray-300 space-y-3">
-            <p>
-              Le système d'alertes A KI PRI SA YÉ analysera quotidiennement les prix collectés
-              pour détecter automatiquement :
-            </p>
-            <ul className="list-disc list-inside space-y-2 ml-4">
-              <li>Les prix anormalement élevés par rapport à la moyenne du territoire</li>
-              <li>Les ruptures de stock récurrentes sur des produits de première nécessité</li>
-              <li>Les variations de prix brutales (hausses ou baisses importantes)</li>
-            </ul>
-            <p className="text-sm text-gray-400 mt-4">
-              <strong>Source des données :</strong> Prix collectés quotidiennement dans les enseignes participantes,
-              données publiques INSEE, signalements citoyens vérifiés.
-            </p>
-          </div>
-        </div>
-
-      </main>
-    </div>
+    <main className="max-w-6xl mx-auto px-4 py-8 text-slate-100">
+      <h1 className="text-2xl font-bold mb-4">Alertes prix</h1>
+      <div className="grid md:grid-cols-2 gap-3 mb-6">
+        <select className="bg-slate-800 border border-slate-700 rounded-lg p-2" value={territory} onChange={(e) => setTerritory(e.target.value)}>
+          <option value="gp">Guadeloupe</option>
+          <option value="mq">Martinique</option>
+          <option value="fr">France hexagonale</option>
+        </select>
+        <select className="bg-slate-800 border border-slate-700 rounded-lg p-2" value={severity} onChange={(e) => setSeverity(e.target.value)}>
+          <option value="all">Toutes sévérités</option>
+          <option value="critical">Critique</option>
+          <option value="warning">Avertissement</option>
+          <option value="info">Information</option>
+        </select>
+      </div>
+      <div className="space-y-3">
+        {alerts.map((alert) => (
+          <article key={alert.id} className="rounded-xl border border-slate-700 bg-slate-900 p-4">
+            <p className="text-xs uppercase text-slate-400 mb-1">{alert.severity}</p>
+            <h2 className="font-semibold">{alert.title}</h2>
+            <p className="text-sm text-slate-300">{alert.message}</p>
+            <p className="text-xs text-slate-500 mt-2">Source: {alert.sourceName}</p>
+          </article>
+        ))}
+        {alerts.length === 0 && <p className="text-slate-400">Aucune alerte active pour ces filtres.</p>}
+      </div>
+    </main>
   );
 }

--- a/frontend/src/pages/Comparateur.jsx
+++ b/frontend/src/pages/Comparateur.jsx
@@ -7,6 +7,8 @@ import PriceSparkline from '../components/PriceSparkline';
 import { useEffect, useRef, useState } from 'react';
 import { findProductByEan, filterPricesByTerritory, searchProductsByName } from '../data/seedProducts';
 import { DEFAULT_TERRITORY, getTerritoryByCode } from '../constants/territories';
+import { useStoreSelection } from '../context/StoreSelectionContext';
+import { getEffectiveSelection } from '../modules/store/storeSelection';
 
 const MIN_QUERY_LENGTH = 3;
 
@@ -43,9 +45,14 @@ export default function Comparateur() {
   const [localPriceInsight, setLocalPriceInsight] = useState({ product: null, aggregate: null, timeseries: [] });
   const [webPriceInsight, setWebPriceInsight] = useState([]);
   const [debugApi, setDebugApi] = useState({ local: null, web: null });
+  const { selection } = useStoreSelection();
   const [loadingLocalPrice, setLoadingLocalPrice] = useState(false);
+  const [observationMeta, setObservationMeta] = useState({ status: 'NO_DATA', lastUpdatedAt: null, total: 0 });
+  const [observationHistory, setObservationHistory] = useState([]);
+  const [showHistory, setShowHistory] = useState(false);
   const requestIdRef = useRef(0);
   const abortRef = useRef(null);
+  const allowedModes = new Set(['inStore', 'drive', 'delivery']);
 
   const resetDisplayedResults = () => {
     setResults(EMPTY_RESULTS_STATE);
@@ -114,16 +121,26 @@ export default function Comparateur() {
     const controller = new AbortController();
     abortRef.current = controller;
 
+    const fallbackTerritory = 'gp';
+    const effectiveSelection = selection ?? getEffectiveSelection(fallbackTerritory);
+    const activeTerritory = effectiveSelection?.territory || territory || DEFAULT_TERRITORY || fallbackTerritory;
+
     setLoading(true);
     setLoadingLocalPrice(false);
     setLocalPriceInsight({ product: null, aggregate: null, timeseries: [] });
     setWebPriceInsight([]);
     setDebugApi({ local: null, web: null });
+    setObservationMeta({ status: 'NO_DATA', lastUpdatedAt: null, total: 0 });
+    setObservationHistory([]);
     resetDisplayedResults();
 
     try {
       // Try to fetch from API, fallback to mock data
-      const searchParams = new URLSearchParams({ territory });
+      const searchParams = new URLSearchParams({ territory: activeTerritory });
+      if (effectiveSelection?.storeId) searchParams.set('storeId', effectiveSelection.storeId);
+      if (effectiveSelection?.serviceMode && allowedModes.has(effectiveSelection.serviceMode)) {
+        searchParams.set('serviceMode', effectiveSelection.serviceMode);
+      }
       if (descriptor.mode === 'EAN') {
         searchParams.set('ean', barcode);
       } else {
@@ -131,6 +148,23 @@ export default function Comparateur() {
       }
 
       const response = await fetch(`/api/prices?${searchParams.toString()}`, { signal: controller.signal }).catch(() => null);
+
+      const observationParams = new URLSearchParams({
+        territory: activeTerritory || 'gp',
+        barcode: barcode || '',
+        q: descriptor.mode === 'QUERY' ? descriptor.key : '',
+      });
+      if (effectiveSelection?.storeId) observationParams.set('storeId', effectiveSelection.storeId);
+      if (effectiveSelection?.serviceMode && allowedModes.has(effectiveSelection.serviceMode)) {
+        observationParams.set('mode', effectiveSelection.serviceMode);
+      }
+
+      const observationResponse = await fetch(`/api/observations?${observationParams.toString()}`).catch(() => null);
+      if (observationResponse?.ok) {
+        const payload = await observationResponse.json();
+        setObservationMeta(payload.metadata ?? { status: 'NO_DATA', lastUpdatedAt: null, total: 0 });
+        setObservationHistory(Array.isArray(payload.observations) ? payload.observations : []);
+      }
 
       if (requestId !== requestIdRef.current) {
         return;
@@ -313,6 +347,7 @@ export default function Comparateur() {
                 <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
                   Service public de transparence des prix en Outre-mer
                 </p>
+                <a href="/promos" className="text-sm text-blue-600 dark:text-blue-400 underline">Voir promos</a>
               </div>
             </div>
             <a 
@@ -369,6 +404,11 @@ export default function Comparateur() {
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {!selection && (
+          <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 text-amber-900 px-4 py-3 text-sm">
+            Choisis ton magasin pour des résultats plus précis.
+          </div>
+        )}
         {/* Product Search Section */}
         <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-lg border border-slate-200 dark:border-slate-700 p-6 mb-6">
           <div className="flex items-start gap-3 mb-4">
@@ -396,6 +436,11 @@ export default function Comparateur() {
 
         {/* Search Form - Design moderne */}
         <div className="bg-white dark:bg-slate-900 rounded-2xl shadow-lg border border-slate-200 dark:border-slate-700 p-6 mb-6">
+          {observationMeta.status === 'NO_DATA' && (
+            <div className="mb-4 rounded-lg border border-blue-200 bg-blue-50 text-blue-900 px-4 py-3 text-sm">
+              Pas encore de données d'observation consolidées pour cette recherche. <a href="/transparence" className="underline font-medium">Pourquoi ?</a>
+            </div>
+          )}
           <form onSubmit={searchPrices} className="space-y-6">
             <div className="grid gap-6 md:grid-cols-2">
               {/* EAN Input */}
@@ -534,6 +579,7 @@ export default function Comparateur() {
                       Pour le produit : <span className="font-semibold">{results.productLabel}</span>
                     </p>
                   )}
+                  <p className="text-xs text-slate-500 mt-2">Dernière mise à jour: {observationMeta.lastUpdatedAt ? formatDate(observationMeta.lastUpdatedAt) : 'n/a'} · Source: observations déclaratives · Fiabilité: {observationMeta.status === 'OK' ? 'élevée' : observationMeta.status === 'PARTIAL' ? 'moyenne' : 'faible'}</p>
                 </div>
                 {bestPrice && (
                   <div className="bg-gradient-to-br from-green-50 to-emerald-50 dark:from-green-900/20 dark:to-emerald-900/20 border-2 border-green-500 dark:border-green-600 px-6 py-3 rounded-xl">
@@ -545,6 +591,7 @@ export default function Comparateur() {
                     </div>
                   </div>
                 )}
+                <button type="button" onClick={() => setShowHistory(true)} className="px-3 py-2 rounded-lg border border-slate-300 dark:border-slate-600 text-sm">Historique</button>
               </div>
             </div>
 
@@ -736,6 +783,17 @@ export default function Comparateur() {
           onScan={handleScanResult}
           onClose={() => setShowScanner(false)}
         />
+      )}
+
+      {showHistory && (
+        <div className="fixed inset-0 z-50 bg-black/50 flex items-end md:items-center justify-center" onClick={() => setShowHistory(false)}>
+          <div className="bg-white dark:bg-slate-900 w-full md:max-w-xl rounded-t-2xl md:rounded-2xl p-4 max-h-[70vh] overflow-auto" onClick={(e) => e.stopPropagation()}>
+            <div className="flex justify-between items-center mb-3"><h3 className="font-semibold">Historique des observations</h3><button onClick={() => setShowHistory(false)}>Fermer</button></div>
+            <ul className="space-y-2 text-sm">
+              {observationHistory.map((item) => <li key={item.id} className="border border-slate-200 dark:border-slate-700 rounded p-2">{item.storeName} · {item.price} € · {formatDate(item.observedAt)}</li>)}
+            </ul>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/Promos.tsx
+++ b/frontend/src/pages/Promos.tsx
@@ -1,0 +1,49 @@
+import { useMemo, useState } from 'react';
+import { promosDataset } from '../data/promos';
+import { getPreferredTerritory } from '../utils/userPreferences';
+
+export default function PromosPage() {
+  const [territory, setTerritory] = useState(getPreferredTerritory());
+  const [store, setStore] = useState('all');
+
+  const stores = useMemo(
+    () => Array.from(new Set(promosDataset.filter((p) => p.territory === territory).map((p) => p.name))),
+    [territory],
+  );
+
+  const filtered = promosDataset.filter((promo) => {
+    if (promo.territory !== territory) return false;
+    if (store !== 'all' && promo.name !== store) return false;
+    return true;
+  });
+
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-8 text-slate-100">
+      <h1 className="text-2xl font-bold mb-4">Promos & catalogues</h1>
+      <div className="grid md:grid-cols-2 gap-3 mb-6">
+        <select className="bg-slate-800 border border-slate-700 rounded-lg p-2" value={territory} onChange={(e) => setTerritory(e.target.value as typeof territory)}>
+          <option value="gp">Guadeloupe</option>
+          <option value="mq">Martinique</option>
+          <option value="fr">France hexagonale</option>
+        </select>
+        <select className="bg-slate-800 border border-slate-700 rounded-lg p-2" value={store} onChange={(e) => setStore(e.target.value)}>
+          <option value="all">Toutes les enseignes</option>
+          {stores.map((name) => <option key={name} value={name}>{name}</option>)}
+        </select>
+      </div>
+
+      <div className="grid gap-4">
+        {filtered.map((promo) => (
+          <article key={promo.id} className="rounded-xl border border-slate-700 bg-slate-900 p-4">
+            <h2 className="font-semibold">{promo.title}</h2>
+            <p className="text-sm text-slate-400 mb-2">{promo.name} · {promo.periodStart} → {promo.periodEnd}</p>
+            <div className="flex gap-2 flex-wrap mb-3">
+              {(promo.tags ?? []).map((tag) => <span key={tag} className="text-xs px-2 py-1 bg-slate-800 rounded">#{tag}</span>)}
+            </div>
+            <a className="inline-block px-3 py-2 rounded bg-blue-600 hover:bg-blue-500 text-sm" href={promo.url} target="_blank" rel="noreferrer">Ouvrir</a>
+          </article>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/pages/ScanEAN.tsx
+++ b/frontend/src/pages/ScanEAN.tsx
@@ -581,6 +581,9 @@ export default function ScanEAN() {
         <div className="mb-8">
           <h2 className="text-2xl font-bold text-white mb-4">Résultat</h2>
           <ScanErrorState message={resolver.error} />
+          <div className="mt-3 rounded-lg border border-blue-500/40 bg-blue-500/10 p-3 text-sm text-blue-200">
+            Données indisponibles pour ce code (statut NO_DATA). <a href="/transparence" className="underline font-semibold">Pourquoi ?</a>
+          </div>
         </div>
       )}
 

--- a/frontend/src/services/alertsService.ts
+++ b/frontend/src/services/alertsService.ts
@@ -1,37 +1,28 @@
-// src/services/alertsService.ts
-// Alerts service: create/read/update simple in-memory alerts for roadmap
+import { alertsDataset } from '../data/alerts';
+import type { Alert, AlertSeverity, TerritoryCode } from '../types/market';
 
-export type Alert = {
-  id: string
-  title: string
-  body?: string
-  level?: 'info' | 'warning' | 'critical'
-  createdAt?: string
-  resolved?: boolean
+const severityRank: Record<AlertSeverity, number> = {
+  critical: 3,
+  warning: 2,
+  info: 1,
+};
+
+export function isAlertActive(alert: Alert, now = new Date()): boolean {
+  const start = new Date(alert.startsAt).getTime();
+  const end = alert.endsAt ? new Date(alert.endsAt).getTime() : Number.POSITIVE_INFINITY;
+  const ts = now.getTime();
+  return ts >= start && ts <= end;
 }
 
-const _store: Alert[] = []
-
-export async function getAlerts(): Promise<Alert[]> {
-  return _store
+export function filterActiveAlerts(options: { territory?: TerritoryCode; severity?: AlertSeverity; now?: Date } = {}) {
+  const { territory, severity, now = new Date() } = options;
+  return alertsDataset
+    .filter((alert) => isAlertActive(alert, now))
+    .filter((alert) => !territory || !alert.territory || alert.territory === territory)
+    .filter((alert) => !severity || alert.severity === severity)
+    .sort((a, b) => severityRank[b.severity] - severityRank[a.severity]);
 }
 
-export async function createAlert(alert: Omit<Alert, 'id' | 'createdAt'>): Promise<Alert> {
-  const newAlert: Alert = {
-    id: String(Date.now()),
-    createdAt: new Date().toISOString(),
-    resolved: false,
-    ...alert,
-  }
-  _store.push(newAlert)
-  return newAlert
+export function getTopActiveAlert(territory?: TerritoryCode) {
+  return filterActiveAlerts({ territory })[0] ?? null;
 }
-
-export async function markResolved(id: string): Promise<boolean> {
-  const a = _store.find((x) => x.id === id)
-  if (!a) return false
-  a.resolved = true
-  return true
-}
-
-export default { getAlerts, createAlert, markResolved }

--- a/frontend/src/services/observationsService.ts
+++ b/frontend/src/services/observationsService.ts
@@ -1,0 +1,42 @@
+import { observationsMock } from '../data/observationsMock';
+import type { NormalizedPriceObservation, ObservationDataStatus } from '../types/market';
+
+export function normalizeObservation(input: Partial<NormalizedPriceObservation> & { barcode: string; territory: string; price: number; observedAt: string; storeName?: string; source?: string }): NormalizedPriceObservation {
+  return {
+    id: input.id ?? `${input.barcode}-${input.territory}-${input.observedAt}`,
+    barcode: input.barcode,
+    productName: input.productName ?? 'Produit non précisé',
+    territory: input.territory as NormalizedPriceObservation['territory'],
+    storeId: input.storeId,
+    storeName: input.storeName ?? 'Magasin non précisé',
+    price: Number(input.price),
+    currency: 'EUR',
+    observedAt: new Date(input.observedAt).toISOString(),
+    source: input.source ?? 'source non précisée',
+    reliability: input.reliability ?? 'medium',
+  };
+}
+
+export function computeObservationStatus(observations: NormalizedPriceObservation[]): ObservationDataStatus {
+  if (!observations.length) return 'NO_DATA';
+  if (observations.length < 2) return 'PARTIAL';
+  return 'OK';
+}
+
+export function getObservationsForQuery(query: { territory?: string; barcode?: string; q?: string }) {
+  const normalized = observationsMock.map((item) => normalizeObservation(item));
+  const filtered = normalized
+    .filter((obs) => !query.territory || obs.territory === query.territory)
+    .filter((obs) => !query.barcode || obs.barcode === query.barcode)
+    .filter((obs) => !query.q || obs.productName.toLowerCase().includes(query.q.toLowerCase()))
+    .sort((a, b) => +new Date(b.observedAt) - +new Date(a.observedAt));
+
+  return {
+    observations: filtered,
+    metadata: {
+      status: computeObservationStatus(filtered),
+      total: filtered.length,
+      lastUpdatedAt: filtered[0]?.observedAt ?? null,
+    },
+  };
+}

--- a/frontend/src/services/priceSearch/price.types.ts
+++ b/frontend/src/services/priceSearch/price.types.ts
@@ -77,6 +77,9 @@ export interface PriceSearchInput {
   brand?: string;
   category?: string;
   territory?: TerritoryCode;
+  storeId?: string;
+  serviceMode?: 'inStore' | 'drive' | 'delivery';
+  metadata?: Record<string, string>;
 }
 
 export type { PriceInterval };

--- a/frontend/src/services/scanHub/scanToPriceBridge.ts
+++ b/frontend/src/services/scanHub/scanToPriceBridge.ts
@@ -13,6 +13,8 @@ export function buildPriceSearchInput(params: {
   brand?: string;
   category?: string;
   territory?: TerritoryCode;
+  storeId?: string;
+  serviceMode?: 'inStore' | 'drive' | 'delivery';
 }): PriceSearchInput {
   const barcode = params.barcode ?? (params.text ? extractBarcode(params.text) : undefined);
   const query = params.text?.trim();
@@ -23,5 +25,12 @@ export function buildPriceSearchInput(params: {
     brand: params.brand,
     category: params.category,
     territory: params.territory,
+    storeId: params.storeId,
+    serviceMode: params.serviceMode,
+    metadata: {
+      storeId: params.storeId ?? '',
+      serviceMode: params.serviceMode ?? '',
+      territory: params.territory ?? '',
+    },
   };
 }

--- a/frontend/src/test/alerts.filterActive.test.ts
+++ b/frontend/src/test/alerts.filterActive.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { filterActiveAlerts } from '../services/alertsService';
+
+describe('filterActiveAlerts', () => {
+  it('filters active alerts by territory', () => {
+    const alerts = filterActiveAlerts({ territory: 'gp', now: new Date('2026-02-13T10:00:00.000Z') });
+    expect(alerts.length).toBeGreaterThan(0);
+    expect(alerts.every((a) => !a.territory || a.territory === 'gp')).toBe(true);
+  });
+});

--- a/frontend/src/test/observations.normalize.test.ts
+++ b/frontend/src/test/observations.normalize.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { computeObservationStatus, normalizeObservation } from '../services/observationsService';
+
+describe('observations normalization', () => {
+  it('normalizes an observation payload', () => {
+    const normalized = normalizeObservation({ barcode: '123', territory: 'gp', price: 1.2, observedAt: '2026-02-12', storeName: 'Test store' });
+    expect(normalized.currency).toBe('EUR');
+    expect(normalized.storeName).toBe('Test store');
+    expect(normalized.id).toContain('123-gp');
+  });
+
+  it('computes NO_DATA/PARTIAL/OK status', () => {
+    expect(computeObservationStatus([])).toBe('NO_DATA');
+    expect(computeObservationStatus([normalizeObservation({ barcode: '1', territory: 'gp', price: 1, observedAt: '2026-01-01' })])).toBe('PARTIAL');
+    expect(computeObservationStatus([
+      normalizeObservation({ barcode: '1', territory: 'gp', price: 1, observedAt: '2026-01-01' }),
+      normalizeObservation({ barcode: '1', territory: 'gp', price: 1.1, observedAt: '2026-01-02' }),
+    ])).toBe('OK');
+  });
+});

--- a/frontend/src/test/storeSelection.test.ts
+++ b/frontend/src/test/storeSelection.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearSelection, getSelection, LEGACY_STORE_SELECTION_KEY, setSelection, STORE_SELECTION_KEY } from '../modules/store/storeSelection';
+
+const sample = {
+  storeId: 'gp-leclerc-bas-du-fort',
+  territory: 'gp',
+  serviceMode: 'drive' as const,
+  updatedAt: '2026-02-14T10:00:00.000Z',
+};
+
+describe('storeSelection storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns null when empty', () => {
+    expect(getSelection()).toBeNull();
+  });
+
+  it('setSelection/getSelection round-trip', () => {
+    setSelection(sample);
+    expect(getSelection()).toEqual(sample);
+  });
+
+  it('clearSelection removes value', () => {
+    setSelection(sample);
+    clearSelection();
+    expect(getSelection()).toBeNull();
+  });
+
+  it('migrates legacy key to v1', () => {
+    localStorage.setItem(LEGACY_STORE_SELECTION_KEY, JSON.stringify(sample));
+    expect(getSelection()).toEqual(sample);
+    expect(localStorage.getItem(STORE_SELECTION_KEY)).toEqual(JSON.stringify(sample));
+    expect(localStorage.getItem(LEGACY_STORE_SELECTION_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/types/market.ts
+++ b/frontend/src/types/market.ts
@@ -1,0 +1,44 @@
+export type TerritoryCode = 'gp' | 'mq' | 'fr' | 'gf' | 're' | 'yt';
+
+export type PromoSource = {
+  id: string;
+  name: string;
+  territory: TerritoryCode;
+  storeId?: string;
+  title: string;
+  periodStart: string;
+  periodEnd: string;
+  url: string;
+  tags?: string[];
+};
+
+export type AlertSeverity = 'info' | 'warning' | 'critical';
+
+export type Alert = {
+  id: string;
+  severity: AlertSeverity;
+  territory?: TerritoryCode;
+  storeId?: string;
+  title: string;
+  message: string;
+  sourceName: string;
+  sourceUrl?: string;
+  startsAt: string;
+  endsAt?: string;
+};
+
+export type ObservationDataStatus = 'OK' | 'PARTIAL' | 'NO_DATA';
+
+export type NormalizedPriceObservation = {
+  id: string;
+  barcode: string;
+  productName: string;
+  territory: TerritoryCode;
+  storeId?: string;
+  storeName: string;
+  price: number;
+  currency: 'EUR';
+  observedAt: string;
+  source: string;
+  reliability: 'high' | 'medium' | 'low';
+};

--- a/frontend/src/utils/userPreferences.ts
+++ b/frontend/src/utils/userPreferences.ts
@@ -1,0 +1,11 @@
+import type { TerritoryCode } from '../types/market';
+
+const DEFAULT_TERRITORY: TerritoryCode = 'gp';
+const ALLOWED: TerritoryCode[] = ['gp', 'mq', 'fr', 'gf', 're', 'yt'];
+
+export function getPreferredTerritory(): TerritoryCode {
+  if (typeof window === 'undefined') return DEFAULT_TERRITORY;
+  const raw = localStorage.getItem('akiprisaye-territory') ?? DEFAULT_TERRITORY;
+  const territory = raw.toLowerCase() as TerritoryCode;
+  return ALLOWED.includes(territory) ? territory : DEFAULT_TERRITORY;
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['src/services/openFoodFacts.test.ts', 'functions/**/*.test.ts'],
+    include: ['src/services/openFoodFacts.test.ts', 'functions/**/*.test.ts', 'src/test/alerts.filterActive.test.ts', 'src/test/observations.normalize.test.ts', 'src/test/storeSelection.test.ts'],
   },
 });


### PR DESCRIPTION
### Motivation
- Prevent runtime and architectural risks before merging the `store-selector` feature by removing circular imports, protecting browser-only APIs for SSR/build, normalizing query parameters, hardening the functions API, and keeping the UX non-blocking when no store is selected.
- Ensure services can read an "effective" selection without depending on React context so non-UI code (API calls, drivers) remain decoupled and testable.

### Description
- Hardened storage helpers in `src/modules/store/storeSelection.ts` by adding `hasBrowserStorage()`, validating `serviceMode` against `SERVICE_MODES`, and exporting `getEffectiveSelection()` so services can obtain selection data without importing the React context. 
- Normalized and validated search query construction in `src/pages/Comparateur.jsx` by using `URLSearchParams`, validating service mode against allowed values, encoding `storeId`/`mode` only when present, and falling back to territory `'gp'` so searches remain non-blocking. 
- Secured the Cloudflare Function `functions/api/observations.ts` with `ALLOWED_MODES`, safe parsing of query params, conditional inclusion of `metadata` fields (`territory`, `storeId`, `mode`) only when provided, and added POST JSON body validation to return `INVALID_INPUT` for malformed payloads. 
- Added a short `Verification` paragraph to `frontend/docs/store-selector-mvp.md` documenting the pre-merge checks performed.

### Testing
- Ran dependency install with `cd frontend && npm ci --include=dev` which completed successfully. 
- Ran unit tests with `npm test` and all tests passed (`6 test files` / `19 tests`). 
- Built the production bundle with `npm run build` which completed successfully without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990630dbf6c83219925f386ef5032c5)