### PR TITLE
feat(alerts): connect sanitary alerts to live source with edge caching

### DIFF
--- a/frontend/functions/api/sanitary-alerts.ts
+++ b/frontend/functions/api/sanitary-alerts.ts
@@ -1,0 +1,124 @@
+import { errorResponse, handleOptions, jsonResponse, parseQuery } from '../_lib/http';
+import { normalizeRappelConsoAlert } from '../../src/services/sanitaryAlertsNormalizer';
+import type { SanitaryAlert, TerritoryCode } from '../../src/types/alerts';
+
+const SOURCE_URL = 'https://data.economie.gouv.fr/api/explore/v2.1/catalog/datasets/rappelconso0/records';
+const ALLOWED_TERRITORIES: TerritoryCode[] = ['fr', 'gp', 'mq', 'gf', 're', 'yt', 'pm', 'bl', 'mf'];
+const API_TIMEOUT_MS = 8_000;
+const EDGE_TTL_SECONDS = 1_200;
+
+const fallbackAlerts: SanitaryAlert[] = [
+  {
+    id: 'fallback-gp-1',
+    territory: 'gp',
+    territories: ['gp'],
+    severity: 'important',
+    riskLevel: 'important',
+    status: 'active',
+    title: 'Rappel local (mode dégradé)',
+    productName: 'Produit temporaire',
+    brand: 'A KI PRI SA YÉ',
+    category: 'épicerie',
+    publishedAt: new Date().toISOString(),
+    sourceName: 'Fallback local',
+    sourceUrl: 'https://rappel.conso.gouv.fr',
+  },
+];
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function fetchWithTimeoutAndRetry(url: string, retries = 1): Promise<Response> {
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(url, {
+        headers: { Accept: 'application/json' },
+        signal: controller.signal,
+      });
+      clearTimeout(timeout);
+      if (response.ok) return response;
+      throw new Error(`upstream_${response.status}`);
+    } catch (error) {
+      clearTimeout(timeout);
+      if (attempt >= retries) throw error;
+      await wait(300 * (attempt + 1));
+    }
+  }
+  throw new Error('unreachable');
+}
+
+function buildUpstreamUrl(query: URLSearchParams): string {
+  const limit = Math.min(Number(query.get('limit') ?? '50') || 50, 100);
+  const cursor = query.get('cursor') ?? '';
+  const q = query.get('q')?.trim();
+
+  const params = new URLSearchParams({
+    limit: String(limit),
+  });
+  if (cursor) params.set('offset', cursor);
+  if (q) params.set('q', q);
+
+  return `${SOURCE_URL}?${params.toString()}`;
+}
+
+function filterAlerts(alerts: SanitaryAlert[], query: URLSearchParams): SanitaryAlert[] {
+  const territory = (query.get('territory') ?? '').toLowerCase() as TerritoryCode;
+  const category = (query.get('category') ?? '').toLowerCase();
+  const severity = (query.get('severity') ?? '').toLowerCase();
+  const activeOnly = (query.get('activeOnly') ?? 'false').toLowerCase() === 'true';
+  const id = query.get('id');
+
+  return alerts
+    .filter((alert) => !id || alert.id === id)
+    .filter((alert) => !territory || !ALLOWED_TERRITORIES.includes(territory) || alert.territories?.includes(territory) || alert.territory === territory)
+    .filter((alert) => !category || alert.category?.toLowerCase() === category)
+    .filter((alert) => !severity || alert.severity === severity)
+    .filter((alert) => !activeOnly || alert.status === 'active');
+}
+
+export const onRequestOptions: PagesFunction = async ({ request }) => handleOptions(request, ['GET']) ?? new Response(null, { status: 204 });
+
+export const onRequestGet: PagesFunction = async ({ request }) => {
+  const query = parseQuery(request);
+  const cache = caches.default;
+  const cacheKey = new Request(request.url, { method: 'GET' });
+  const cached = await cache.match(cacheKey);
+  if (cached) return cached;
+
+  try {
+    const upstreamUrl = buildUpstreamUrl(query);
+    const upstreamResponse = await fetchWithTimeoutAndRetry(upstreamUrl, 1);
+    const upstreamPayload = await upstreamResponse.json() as { results?: Array<Record<string, unknown>>; total_count?: number; next_offset?: string | null };
+    const normalized = (upstreamPayload.results ?? []).map((raw) => normalizeRappelConsoAlert(raw));
+    const filtered = filterAlerts(normalized, query);
+
+    const payload = {
+      alerts: filtered,
+      nextCursor: upstreamPayload.next_offset ?? undefined,
+      metadata: {
+        source: 'rappelconso' as const,
+        fetchedAt: new Date().toISOString(),
+        total: upstreamPayload.total_count ?? filtered.length,
+      },
+    };
+
+    const response = jsonResponse(payload, {
+      request,
+      headers: { 'Cache-Control': `public, max-age=${EDGE_TTL_SECONDS}` },
+    });
+    await cache.put(cacheKey, response.clone());
+    return response;
+  } catch {
+    const fallback = filterAlerts(fallbackAlerts, query);
+    return jsonResponse({
+      alerts: fallback,
+      metadata: {
+        source: 'fallback' as const,
+        fetchedAt: new Date().toISOString(),
+        total: fallback.length,
+      },
+    }, { request });
+  }
+};

--- a/frontend/src/pages/AlerteDetail.jsx
+++ b/frontend/src/pages/AlerteDetail.jsx
@@ -1,9 +1,24 @@
+import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { getAlertById } from '../services/alertsService';
 
 export default function AlerteDetail() {
   const { id = '' } = useParams();
-  const alert = getAlertById(id);
+  const [alert, setAlert] = useState(undefined);
+
+  useEffect(() => {
+    let mounted = true;
+    getAlertById(id).then((item) => {
+      if (mounted) setAlert(item);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [id]);
+
+  if (typeof alert === 'undefined') {
+    return <main className="max-w-4xl mx-auto px-4 py-8 text-slate-100">Chargement…</main>;
+  }
 
   if (!alert) {
     return (

--- a/frontend/src/pages/Alertes.jsx
+++ b/frontend/src/pages/Alertes.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useStoreSelection } from '../context/StoreSelectionContext';
 import { getAlerts } from '../services/alertsService';
@@ -27,14 +27,27 @@ export default function Alertes() {
   const [category, setCategory] = useState(searchParams.get('category') ?? '');
   const [severity, setSeverity] = useState(searchParams.get('severity') ?? '');
   const [q, setQ] = useState(searchParams.get('q') ?? '');
+  const [alerts, setAlerts] = useState([]);
+  const [metadata, setMetadata] = useState(null);
 
-  const alerts = useMemo(() => getAlerts({
-    territory,
-    onlyActive,
-    category: category || undefined,
-    severity: severity || undefined,
-    q: q || undefined,
-  }), [territory, onlyActive, category, severity, q]);
+  useEffect(() => {
+    let mounted = true;
+    getAlerts({
+      territory,
+      onlyActive,
+      category: category || undefined,
+      severity: severity || undefined,
+      q: q || undefined,
+    }).then((result) => {
+      if (!mounted) return;
+      setAlerts(result.alerts);
+      setMetadata(result.metadata);
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, [territory, onlyActive, category, severity, q]);
 
   const syncQueryString = (next) => {
     const params = new URLSearchParams();
@@ -49,6 +62,10 @@ export default function Alertes() {
     <main className="max-w-6xl mx-auto px-4 py-8 text-slate-100">
       <h1 className="text-2xl font-bold mb-2">Alertes sanitaires</h1>
       <p className="text-sm text-slate-400 mb-6">Territoire: <strong className="uppercase">{territory}</strong></p>
+      <p className="text-xs text-slate-500 mb-6">
+        Source: {metadata?.source === 'fallback' ? 'fallback local' : 'RappelConso'}
+        {metadata?.fetchedAt ? ` • fraîcheur ${new Date(metadata.fetchedAt).toLocaleString('fr-FR')}` : ''}
+      </p>
 
       <section className="grid md:grid-cols-4 gap-3 mb-6">
         <label className="flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-900 px-3 py-2">

--- a/frontend/src/services/alertsService.ts
+++ b/frontend/src/services/alertsService.ts
@@ -1,11 +1,13 @@
 import { alertsDataset } from '../data/alerts';
-import type { AlertSeverity, SanitaryAlert, TerritoryCode } from '../types/alerts';
+import type { AlertSeverity, SanitaryAlert, SanitaryAlertsResponse, TerritoryCode } from '../types/alerts';
 
 const severityOrder: Record<AlertSeverity, number> = {
   critical: 3,
   important: 2,
   info: 1,
 };
+
+let latestSnapshot: SanitaryAlert[] = [];
 
 function parseDate(value?: string): number {
   if (!value) return 0;
@@ -64,7 +66,12 @@ interface GetAlertsOptions {
   severity?: AlertSeverity;
 }
 
-export function getAlerts(options: GetAlertsOptions = {}): SanitaryAlert[] {
+export interface FetchAlertsResult {
+  alerts: SanitaryAlert[];
+  metadata: SanitaryAlertsResponse['metadata'];
+}
+
+function localFallback(options: GetAlertsOptions = {}): FetchAlertsResult {
   const { territory, onlyActive = false, q, category, severity } = options;
   const normalizedCategory = category ? normalizeText(category) : '';
 
@@ -75,9 +82,58 @@ export function getAlerts(options: GetAlertsOptions = {}): SanitaryAlert[] {
     .filter((alert) => !normalizedCategory || normalizeText(alert.category ?? '') === normalizedCategory)
     .filter((alert) => matchesSearch(alert, q));
 
-  return sortAlerts(filtered);
+  const sorted = sortAlerts(filtered);
+  latestSnapshot = sorted;
+
+  return {
+    alerts: sorted,
+    metadata: {
+      source: 'fallback',
+      fetchedAt: new Date().toISOString(),
+      total: sorted.length,
+    },
+  };
 }
 
-export function getAlertById(id: string): SanitaryAlert | null {
-  return alertsDataset.find((alert) => alert.id === id) ?? null;
+export async function getAlerts(options: GetAlertsOptions = {}): Promise<FetchAlertsResult> {
+  const params = new URLSearchParams();
+  if (options.territory) params.set('territory', options.territory);
+  if (options.q) params.set('q', options.q);
+  if (options.category) params.set('category', options.category);
+  if (options.severity) params.set('severity', options.severity);
+  if (options.onlyActive) params.set('activeOnly', 'true');
+
+  try {
+    const response = await fetch(`/api/sanitary-alerts?${params.toString()}`, {
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    });
+
+    if (!response.ok) throw new Error(`HTTP_${response.status}`);
+
+    const payload = await response.json() as SanitaryAlertsResponse;
+    latestSnapshot = sortAlerts(payload.alerts ?? []);
+    return {
+      alerts: latestSnapshot,
+      metadata: payload.metadata,
+    };
+  } catch {
+    return localFallback(options);
+  }
+}
+
+export async function getAlertById(id: string): Promise<SanitaryAlert | null> {
+  const inSnapshot = latestSnapshot.find((alert) => alert.id === id);
+  if (inSnapshot) return inSnapshot;
+
+  try {
+    const response = await fetch(`/api/sanitary-alerts?id=${encodeURIComponent(id)}`);
+    if (!response.ok) throw new Error('id_lookup_failed');
+    const payload = await response.json() as SanitaryAlertsResponse;
+    const resolved = payload.alerts.find((alert) => alert.id === id) ?? null;
+    if (resolved) latestSnapshot = [resolved, ...latestSnapshot.filter((alert) => alert.id !== id)];
+    return resolved;
+  } catch {
+    return alertsDataset.find((alert) => alert.id === id) ?? null;
+  }
 }

--- a/frontend/src/services/sanitaryAlertsNormalizer.ts
+++ b/frontend/src/services/sanitaryAlertsNormalizer.ts
@@ -1,0 +1,85 @@
+import type { AlertSeverity, SanitaryAlert, TerritoryCode } from '../types/alerts';
+
+const RISK_CRITICAL = ['listeria', 'salmonella', 'corps etranger', 'corps étranger', 'etouffement', 'étouffement', 'allergene', 'allergène', 'escherichia coli', 'e. coli'];
+
+const CATEGORY_MAP: Array<{ match: RegExp; value: string }> = [
+  { match: /(lait|infantile|bebe|bébé|nourrisson)/i, value: 'bébé' },
+  { match: /(poisson|viande|charcuterie|volaille|thon)/i, value: 'viande/poisson' },
+  { match: /(gel douche|cosmetique|cosmétique|hygiene|hygiène|savon)/i, value: 'hygiène' },
+  { match: /.*/, value: 'épicerie' },
+];
+
+const TERRITORY_ALIASES: Record<string, TerritoryCode> = {
+  france: 'fr',
+  guadeloupe: 'gp',
+  martinique: 'mq',
+  guyane: 'gf',
+  reunion: 're',
+  'la réunion': 're',
+  mayotte: 'yt',
+  'saint-pierre-et-miquelon': 'pm',
+  'saint-barthelemy': 'bl',
+  'saint-barthélemy': 'bl',
+  'saint-martin': 'mf',
+};
+
+const normalizeText = (value: string) => value
+  .normalize('NFD')
+  .replace(/[\u0300-\u036f]/g, '')
+  .toLowerCase()
+  .trim();
+
+const inferCategory = (rawCategory: string, title: string, productName: string): string => {
+  const raw = `${rawCategory} ${title} ${productName}`;
+  return CATEGORY_MAP.find((item) => item.match.test(raw))?.value ?? 'épicerie';
+};
+
+const inferSeverity = (hazards: string, title: string): AlertSeverity => {
+  const full = normalizeText(`${hazards} ${title}`);
+  return RISK_CRITICAL.some((token) => full.includes(token)) ? 'critical' : 'important';
+};
+
+const toTerritories = (raw: unknown): TerritoryCode[] => {
+  if (!raw) return ['fr'];
+  const source = Array.isArray(raw) ? raw : [raw];
+  const mapped = source
+    .map((item) => normalizeText(String(item)))
+    .map((item) => TERRITORY_ALIASES[item])
+    .filter(Boolean) as TerritoryCode[];
+
+  return mapped.length > 0 ? Array.from(new Set(mapped)) : ['fr'];
+};
+
+export type RawRappelConsoAlert = Record<string, unknown>;
+
+export function normalizeRappelConsoAlert(raw: RawRappelConsoAlert): SanitaryAlert {
+  const title = String(raw.titre_rappel ?? raw.title ?? 'Alerte sanitaire');
+  const brand = String(raw.marque_produit ?? raw.brand ?? '').trim();
+  const productName = String(raw.noms_des_modeles_ou_references ?? raw.product_name ?? '').trim();
+  const reason = String(raw.motif_du_rappel ?? raw.reason ?? '').trim();
+  const risk = String(raw.risques_encourus_par_le_consommateur ?? raw.risk ?? '').trim();
+  const procedures = String(raw.preconisations_sanitaires ?? raw.conduites_a_tenir_par_le_consommateur ?? '').trim();
+  const territories = toTerritories(raw.zones_geographiques_de_vente ?? raw.territories ?? raw.zone);
+  const severity = inferSeverity(`${reason} ${risk}`, title);
+
+  return {
+    id: String(raw.reference_fiche ?? raw.id ?? `${title}-${productName}`),
+    territory: territories[0] ?? 'fr',
+    territories,
+    severity,
+    riskLevel: severity,
+    status: String(raw.date_de_fin_de_la_procedure_de_rappel ?? raw.status ?? '').trim() ? 'resolved' : 'active',
+    title,
+    brand: brand || undefined,
+    productName: productName || undefined,
+    category: inferCategory(String(raw.categorie_de_produit ?? raw.category ?? ''), title, productName),
+    lot: String(raw.identification_des_produits ?? raw.lot ?? '').trim() || undefined,
+    publishedAt: String(raw.date_de_publication ?? raw.publishedAt ?? '').trim() || undefined,
+    updatedAt: String(raw.date_de_derniere_mise_a_jour ?? raw.updatedAt ?? '').trim() || undefined,
+    reason: reason || undefined,
+    risk: risk || undefined,
+    instructions: procedures || undefined,
+    sourceName: 'RappelConso',
+    sourceUrl: String(raw.lien_vers_la_fiche_rappel ?? raw.sourceUrl ?? 'https://rappel.conso.gouv.fr').trim(),
+  };
+}

--- a/frontend/src/test/alerts.filterActive.test.ts
+++ b/frontend/src/test/alerts.filterActive.test.ts
@@ -2,15 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { getAlerts } from '../services/alertsService';
 
 describe('alertsService onlyActive filter', () => {
-  it('returns only active alerts when onlyActive=true', () => {
-    const alerts = getAlerts({ territory: 'gp', onlyActive: true });
+  it('returns only active alerts when onlyActive=true', async () => {
+    const { alerts } = await getAlerts({ territory: 'gp', onlyActive: true });
 
     expect(alerts.length).toBeGreaterThan(0);
     expect(alerts.every((alert) => alert.status === 'active')).toBe(true);
   });
 
-  it('keeps resolved alerts when onlyActive=false', () => {
-    const alerts = getAlerts({ territory: 'gp', onlyActive: false });
+  it('keeps resolved alerts when onlyActive=false', async () => {
+    const { alerts } = await getAlerts({ territory: 'gp', onlyActive: false });
     expect(alerts.some((alert) => alert.status === 'resolved')).toBe(true);
   });
 });

--- a/frontend/src/test/alerts.searchSort.test.ts
+++ b/frontend/src/test/alerts.searchSort.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { getAlerts } from '../services/alertsService';
 
 describe('alertsService search and sort', () => {
-  it('sorts by severity then by publishedAt desc', () => {
-    const alerts = getAlerts({ territory: 'gp' });
+  it('sorts by severity then by publishedAt desc', async () => {
+    const { alerts } = await getAlerts({ territory: 'gp' });
     const criticalIndex = alerts.findIndex((a) => a.severity === 'critical');
     const importantIndex = alerts.findIndex((a) => a.severity === 'important');
     const infoIndex = alerts.findIndex((a) => a.severity === 'info');
@@ -18,10 +18,10 @@ describe('alertsService search and sort', () => {
     );
   });
 
-  it('matches q against title, brand, productName, ean and lot', () => {
-    expect(getAlerts({ territory: 'gp', q: 'omega croissance' }).length).toBeGreaterThan(0);
-    expect(getAlerts({ territory: 'gp', q: 'Omega Baby' }).length).toBeGreaterThan(0);
-    expect(getAlerts({ territory: 'gp', q: '3760123456789' }).length).toBeGreaterThan(0);
-    expect(getAlerts({ territory: 'gp', q: 'L24011A' }).length).toBeGreaterThan(0);
+  it('matches q against title, brand, productName, ean and lot', async () => {
+    expect((await getAlerts({ territory: 'gp', q: 'omega croissance' })).alerts.length).toBeGreaterThan(0);
+    expect((await getAlerts({ territory: 'gp', q: 'Omega Baby' })).alerts.length).toBeGreaterThan(0);
+    expect((await getAlerts({ territory: 'gp', q: '3760123456789' })).alerts.length).toBeGreaterThan(0);
+    expect((await getAlerts({ territory: 'gp', q: 'L24011A' })).alerts.length).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/test/alerts.serviceFallback.test.ts
+++ b/frontend/src/test/alerts.serviceFallback.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getAlerts } from '../services/alertsService';
+
+describe('alertsService fallback', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns local fallback when API fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'));
+
+    const result = await getAlerts({ territory: 'gp', onlyActive: true });
+
+    expect(result.metadata.source).toBe('fallback');
+    expect(result.alerts.length).toBeGreaterThan(0);
+    expect(result.alerts.every((alert) => alert.territory === 'gp')).toBe(true);
+  });
+});

--- a/frontend/src/test/sanitaryAlerts.normalizer.test.ts
+++ b/frontend/src/test/sanitaryAlerts.normalizer.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeRappelConsoAlert } from '../services/sanitaryAlertsNormalizer';
+
+describe('normalizeRappelConsoAlert', () => {
+  it('maps minimal fields and severity rules', () => {
+    const normalized = normalizeRappelConsoAlert({
+      reference_fiche: 'F-123',
+      titre_rappel: 'Rappel produit',
+      marque_produit: 'Marque X',
+      noms_des_modeles_ou_references: 'Lait infantile',
+      categorie_de_produit: 'Alimentation',
+      risques_encourus_par_le_consommateur: 'Risque de listeria',
+      date_de_publication: '2026-02-12T00:00:00Z',
+      lien_vers_la_fiche_rappel: 'https://rappel.conso.gouv.fr/fiche/123',
+      zones_geographiques_de_vente: ['Guadeloupe', 'Martinique'],
+    });
+
+    expect(normalized.id).toBe('F-123');
+    expect(normalized.riskLevel).toBe('critical');
+    expect(normalized.severity).toBe('critical');
+    expect(normalized.territories).toEqual(['gp', 'mq']);
+    expect(normalized.sourceUrl).toContain('rappel.conso.gouv.fr');
+  });
+});

--- a/frontend/src/types/alerts.ts
+++ b/frontend/src/types/alerts.ts
@@ -7,7 +7,9 @@ export type AlertStatus = 'active' | 'resolved';
 export interface SanitaryAlert {
   id: string;
   territory: TerritoryCode;
+  territories?: TerritoryCode[];
   severity: AlertSeverity;
+  riskLevel?: AlertSeverity;
   status: AlertStatus;
   title: string;
   productName?: string;
@@ -24,4 +26,16 @@ export interface SanitaryAlert {
   sourceName: string;
   sourceUrl?: string;
   updatedAt?: string;
+}
+
+export interface SanitaryAlertsMetadata {
+  source: 'rappelconso' | 'fallback';
+  fetchedAt: string;
+  total: number;
+}
+
+export interface SanitaryAlertsResponse {
+  alerts: SanitaryAlert[];
+  metadata: SanitaryAlertsMetadata;
+  nextCursor?: string;
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,6 +4,16 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['src/services/openFoodFacts.test.ts', 'functions/**/*.test.ts', 'src/test/alerts.filterActive.test.ts', 'src/test/observations.normalize.test.ts', 'src/test/storeSelection.test.ts', 'src/test/promosService.test.ts'],
+    include: [
+      'src/services/openFoodFacts.test.ts',
+      'functions/**/*.test.ts',
+      'src/test/alerts.filterActive.test.ts',
+      'src/test/alerts.searchSort.test.ts',
+      'src/test/alerts.serviceFallback.test.ts',
+      'src/test/sanitaryAlerts.normalizer.test.ts',
+      'src/test/observations.normalize.test.ts',
+      'src/test/storeSelection.test.ts',
+      'src/test/promosService.test.ts',
+    ],
   },
 });


### PR DESCRIPTION
### Motivation
- Convert the existing "Alertes sanitaires" module to a V1 data-driven implementation using the official RappelConso dataset while preserving the current UX and detail page behavior. 
- Make the integration resilient and performant by using a Cloudflare Pages Function with edge caching and a deterministic local fallback to avoid regressions when the upstream is unavailable.

### Description
- Added a Pages Function `GET /api/sanitary-alerts` (`frontend/functions/api/sanitary-alerts.ts`) that accepts `territory,q,category,severity,activeOnly,limit,cursor` and `id` for detail lookup, fetches the RappelConso dataset, normalizes records, applies server-side filtering, caches responses at the edge (`Cache API`, ~20min TTL), and implements a fetch timeout + one retry with a local fallback when upstream fails.
- Implemented a dedicated normalizer (`frontend/src/services/sanitaryAlertsNormalizer.ts`) that maps RappelConso fields into our `SanitaryAlert` shape and applies explicit rules: category mapping to existing categories, territory aliases → `fr|gp|mq|gf|re|yt|pm|bl|mf`, and severity inference (explicit `critical` tokens → `critical`, otherwise `important`).
- Evolved types (`frontend/src/types/alerts.ts`) to include `territories`, `riskLevel`, and `SanitaryAlertsResponse` / metadata (`source`, `fetchedAt`, `total`).
- Updated frontend data flow: `frontend/src/services/alertsService.ts` now calls `/api/sanitary-alerts` (returns `alerts + metadata`), maintains an in-memory snapshot for detail lookups, and falls back to the local dataset if the API is unreachable; `/alertes` page (`frontend/src/pages/Alertes.jsx`) and detail page (`frontend/src/pages/AlerteDetail.jsx`) were adapted to load data asynchronously and display a small label showing the source and freshness timestamp without changing existing UI structure or navigation.
- Tests: added unit test for the normalizer and a service fallback test, and adapted existing alerts tests to the async service contract; updated `vitest` include list to run the new/modified tests.

### Testing
- `npm ci` (frontend) executed successfully and installed dependencies. 
- `npm test` (Vitest) executed successfully and all included tests passed (tests updated to cover normalization and fallback; full run showed all tests green).
- `npm run build` (frontend) completed successfully producing a production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a3aa6fa08321bf2a91133adc6a67)