### PR TITLE
Make /api/product-image return image-compatible responses by default and add `format=json` opt-in

### DIFF
--- a/frontend/src/services/alertProductImageService.test.ts
+++ b/frontend/src/services/alertProductImageService.test.ts
@@ -42,18 +42,20 @@ describe('alertProductImageService fallback and cache', () => {
   });
 
   it('returns category placeholder when backend has no image', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => ({
-        ok: true,
-        json: async () => ({ source: 'none' }),
-      }) as unknown as globalThis.Response)
-    );
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ source: 'none' }),
+    }) as unknown as globalThis.Response);
+    vi.stubGlobal('fetch', fetchMock);
 
     const result = await getProductImageUrl('3760123456789', 'bébé');
 
     expect(result.source).toBe('placeholder');
     expect(result.url).toBe('/assets/placeholders/placeholder-bebe.svg');
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('format=json'),
+      expect.objectContaining({ method: 'GET' })
+    );
   });
 
   it('returns placeholder on network error and keeps local cache entry', async () => {

--- a/frontend/src/services/alertProductImageService.ts
+++ b/frontend/src/services/alertProductImageService.ts
@@ -123,6 +123,7 @@ async function fetchFromApi(ean: string, category?: string): Promise<{ url?: str
     if (category) {
       params.set('category', category);
     }
+    params.set('format', 'json');
 
     const response = await fetch(`/api/product-image?${params.toString()}`, {
       method: 'GET',

--- a/functions/api/product-image.ts
+++ b/functions/api/product-image.ts
@@ -66,16 +66,51 @@ function jsonResponse(body: { url?: string; source: ImageSource }, status = 200)
   });
 }
 
+function imageModeHeaders(contentType: string): HeadersInit {
+  return {
+    'content-type': contentType,
+    'Cache-Control': `public, max-age=${EDGE_CACHE_TTL}`,
+  };
+}
+
+function imageRedirectResponse(targetUrl: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: targetUrl,
+      'Cache-Control': `public, max-age=${EDGE_CACHE_TTL}`,
+    },
+  });
+}
+
+function placeholderSvgResponse(status = 200): Response {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="640" height="640" viewBox="0 0 640 640" role="img" aria-label="Image produit indisponible"><rect width="640" height="640" fill="#f3f4f6"/><g fill="none" stroke="#9ca3af" stroke-width="24" stroke-linecap="round" stroke-linejoin="round"><rect x="120" y="150" width="400" height="300" rx="24"/><path d="M165 395l92-92 74 74 54-54 90 90"/><circle cx="250" cy="240" r="38"/></g><text x="320" y="520" text-anchor="middle" fill="#6b7280" font-family="Arial, Helvetica, sans-serif" font-size="36">Image indisponible</text></svg>`;
+
+  return new Response(svg, {
+    status,
+    headers: imageModeHeaders('image/svg+xml; charset=utf-8'),
+  });
+}
+
 export const onRequestGet: PagesFunction = async ({ request }) => {
   const url = new URL(request.url);
   const ean = (url.searchParams.get('ean') ?? '').trim();
   const category = url.searchParams.get('category');
+  const wantsJson = url.searchParams.get('format') === 'json';
 
   if (!ean) {
     const placeholder = getPlaceholderUrl(category);
-    return jsonResponse(placeholder
-      ? { url: placeholder, source: 'placeholder' }
-      : { source: 'none' });
+    if (wantsJson) {
+      return jsonResponse(placeholder
+        ? { url: placeholder, source: 'placeholder' }
+        : { source: 'none' });
+    }
+
+    if (placeholder) {
+      return imageRedirectResponse(placeholder);
+    }
+
+    return placeholderSvgResponse();
   }
 
   const cache = caches.default;
@@ -117,12 +152,28 @@ export const onRequestGet: PagesFunction = async ({ request }) => {
       body = placeholder ? { url: placeholder, source: 'placeholder' } : { source: 'none' };
     }
 
-    const result = jsonResponse(body);
+    let result: Response;
+    if (wantsJson) {
+      result = jsonResponse(body);
+    } else if (body.url) {
+      result = imageRedirectResponse(body.url);
+    } else {
+      result = placeholderSvgResponse();
+    }
+
     await cache.put(cacheKey, result.clone());
     return result;
   } catch {
     const placeholder = getPlaceholderUrl(category);
-    return jsonResponse(placeholder ? { url: placeholder, source: 'placeholder' } : { source: 'none' });
+    if (wantsJson) {
+      return jsonResponse(placeholder ? { url: placeholder, source: 'placeholder' } : { source: 'none' });
+    }
+
+    if (placeholder) {
+      return imageRedirectResponse(placeholder);
+    }
+
+    return placeholderSvgResponse();
   } finally {
     clearTimeout(timeoutId);
   }


### PR DESCRIPTION
### Motivation
- `<img src="/api/product-image?...">` currently receives JSON (e.g. `{ "source": "none" }`) which cannot be rendered and produces a broken image icon.
- The endpoint must provide an image-compatible response by default (redirect or image/svg+xml) while keeping a JSON debug/fetch mode available.

### Description
- Added an optional `format=json` query param to `functions/api/product-image.ts` so consumers using `fetch` can explicitly request JSON, while default mode always returns an image-compatible response. 
- Default behavior now returns a `302` redirect to the OFF image when found, a `302` redirect to a category/default placeholder when available, or an inline SVG placeholder with `Content-Type: image/svg+xml` when no image URL exists. 
- Preserved and applied edge caching using `caches.default` and ensured `Cache-Control` headers are set on JSON and image responses. 
- Updated frontend `alertProductImageService` to append `format=json` to its `/api/product-image` requests and adjusted `alertProductImageService.test.ts` to assert the fetch includes `format=json`.

### Testing
- Ran the unit test file `src/services/alertProductImageService.test.ts` with `vitest`, all tests passed. 
- Ran the frontend production build with `npm --prefix frontend run build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990b45445808321916bc36f24d681df)