### PR TITLE
fix(api): make /api/product-image reachable on Pages + avoid redirect interference

### DIFF
--- a/SITE_VERIFICATION_REPORT_2026-02-14.md
+++ b/SITE_VERIFICATION_REPORT_2026-02-14.md
@@ -1,0 +1,69 @@
+# Vérification du site https://akiprisaye-web.pages.dev/
+
+Date: 2026-02-14
+
+## Méthode de vérification
+- Contrôle de la page d'accueil en navigateur headless (Playwright): titre, contenu principal, logs console, erreurs réseau.
+- Test d'accès direct sur routes principales (navigation profonde) pour valider la configuration d'hébergement SPA.
+- Vérification SEO/accessibilité de base: langue du document, meta description, structure des titres.
+
+## Constats
+
+### 1) Point critique — Les routes profondes renvoient 404
+Accès direct testé sur plusieurs routes clés:
+- `/comparateur` → 404
+- `/observatoire` → 404
+- `/methodologie` → 404
+- `/faq` → 404
+- `/contact` → 404
+- `/mentions-legales` → 404
+
+Impact:
+- liens partagés cassés (ouverture directe impossible),
+- SEO fortement dégradé sur pages internes,
+- mauvaise expérience utilisateur (refresh sur une page interne = erreur).
+
+Recommandation prioritaire:
+- Ajouter une règle de réécriture SPA côté hébergeur (Cloudflare Pages) pour rediriger toutes les routes applicatives vers `index.html`.
+- Vérifier ensuite qu'un rafraîchissement navigateur fonctionne sur chaque route.
+
+### 2) Point élevé — Erreur console module/MIME observée
+Sur la page d'accueil, une erreur console apparaît:
+- `Failed to load module script ... MIME type of "text/jsx"`
+
+Interprétation:
+- un script/module est servi avec un `Content-Type` incorrect, ou une ancienne référence (cache/service worker) tente de charger un fichier JSX brut.
+
+Recommandation:
+- Vérifier les en-têtes `Content-Type` des bundles JS produits en build (doivent être `text/javascript` ou `application/javascript`).
+- Purger le cache CDN et invalider le service worker s'il référence d'anciens assets.
+
+### 3) Point moyen — Logs debug très verbeux en production
+De nombreux logs console détaillés sont visibles (`AuthProvider`, `App`, `LoadingFallback`, etc.).
+
+Impact:
+- bruit en production,
+- exposition potentielle d'informations internes d'exécution,
+- rendu moins propre pour le diagnostic réel.
+
+Recommandation:
+- Introduire un niveau de log conditionnel (ex: seulement en développement),
+- conserver en production uniquement les logs d'erreur utiles.
+
+## Points positifs
+- La page d'accueil répond correctement en `200`.
+- Le document est bien déclaré en langue française (`lang="fr"`).
+- La meta description est présente.
+- La structure de titres est globalement cohérente avec un `H1` unique.
+
+## Plan d'amélioration recommandé (ordre d'exécution)
+1. Corriger la réécriture SPA (bloquant principal).
+2. Corriger l'erreur MIME/module et purger les caches.
+3. Réduire/normaliser les logs de production.
+4. Refaire une passe QA rapide sur desktop + mobile + routes profondes.
+
+## Critères de validation après correctifs
+- Ouvrir directement `/comparateur`, `/faq`, `/contact` sans 404.
+- Zéro erreur console de type module/MIME en chargement initial.
+- Console production sans logs debug non essentiels.
+- Vérification manuelle: accueil + navigation + refresh sur routes internes.

--- a/frontend/functions/_routes.json
+++ b/frontend/functions/_routes.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "include": ["/api/*"],
+  "exclude": []
+}

--- a/frontend/functions/api/product-image.ts
+++ b/frontend/functions/api/product-image.ts
@@ -1,0 +1,180 @@
+const OFF_BASE_URL = 'https://world.openfoodfacts.org';
+const EDGE_CACHE_TTL = 7 * 24 * 60 * 60;
+const FETCH_TIMEOUT_MS = 5000;
+
+type ImageSource = 'off' | 'placeholder' | 'none';
+
+type OffImagePayload = {
+  image_url?: unknown;
+  selected_images?: {
+    front?: {
+      display?: {
+        fr?: unknown;
+        en?: unknown;
+      };
+    };
+  };
+};
+
+type OffProductResponse = {
+  status?: unknown;
+  product?: OffImagePayload;
+};
+
+const PLACEHOLDER_BY_CATEGORY: Record<string, string> = {
+  bebe: '/assets/placeholders/placeholder-bebe.svg',
+  epicerie: '/assets/placeholders/placeholder-epicerie.svg',
+  'viande/poisson': '/assets/placeholders/placeholder-viande-poisson.svg',
+  hygiene: '/assets/placeholders/placeholder-hygiene.svg',
+};
+
+function normalizeCategory(category: string): string {
+  return category
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim();
+}
+
+function getPlaceholderUrl(category?: string | null): string | undefined {
+  if (!category || !category.trim()) {
+    return undefined;
+  }
+
+  return PLACEHOLDER_BY_CATEGORY[normalizeCategory(category)] ?? '/assets/placeholders/placeholder-default.svg';
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function extractOffImageUrl(payload: OffProductResponse): string | undefined {
+  if (payload.status === 0 || !payload.product) return undefined;
+
+  return asNonEmptyString(payload.product.selected_images?.front?.display?.fr)
+    ?? asNonEmptyString(payload.product.selected_images?.front?.display?.en)
+    ?? asNonEmptyString(payload.product.image_url);
+}
+
+function jsonResponse(body: { url?: string; source: ImageSource }, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'Cache-Control': `public, max-age=${EDGE_CACHE_TTL}`,
+    },
+  });
+}
+
+function imageModeHeaders(contentType: string): HeadersInit {
+  return {
+    'content-type': contentType,
+    'Cache-Control': `public, max-age=${EDGE_CACHE_TTL}`,
+  };
+}
+
+function imageRedirectResponse(targetUrl: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: targetUrl,
+      'Cache-Control': `public, max-age=${EDGE_CACHE_TTL}`,
+    },
+  });
+}
+
+function placeholderSvgResponse(status = 200): Response {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="640" height="640" viewBox="0 0 640 640" role="img" aria-label="Image produit indisponible"><rect width="640" height="640" fill="#f3f4f6"/><g fill="none" stroke="#9ca3af" stroke-width="24" stroke-linecap="round" stroke-linejoin="round"><rect x="120" y="150" width="400" height="300" rx="24"/><path d="M165 395l92-92 74 74 54-54 90 90"/><circle cx="250" cy="240" r="38"/></g><text x="320" y="520" text-anchor="middle" fill="#6b7280" font-family="Arial, Helvetica, sans-serif" font-size="36">Image indisponible</text></svg>`;
+
+  return new Response(svg, {
+    status,
+    headers: imageModeHeaders('image/svg+xml; charset=utf-8'),
+  });
+}
+
+export const onRequestGet: PagesFunction = async ({ request }) => {
+  const url = new URL(request.url);
+  const ean = (url.searchParams.get('ean') ?? '').trim();
+  const category = url.searchParams.get('category');
+  const wantsJson = url.searchParams.get('format') === 'json';
+
+  if (!ean) {
+    const placeholder = getPlaceholderUrl(category);
+    if (wantsJson) {
+      return jsonResponse(placeholder
+        ? { url: placeholder, source: 'placeholder' }
+        : { source: 'none' });
+    }
+
+    if (placeholder) {
+      return imageRedirectResponse(placeholder);
+    }
+
+    return placeholderSvgResponse();
+  }
+
+  const cache = caches.default;
+  const cacheKey = new Request(url.toString(), { method: 'GET' });
+  const cached = await cache.match(cacheKey);
+
+  if (cached) {
+    return cached;
+  }
+
+  const offUrl = `${OFF_BASE_URL}/api/v2/product/${encodeURIComponent(ean)}.json`;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(offUrl, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'A-KI-PRI-SA-YE (contact: support@akiprisaye.app)',
+      },
+    });
+
+    let body: { url?: string; source: ImageSource };
+
+    if (response.ok) {
+      const payload = (await response.json()) as OffProductResponse;
+      const offImage = extractOffImageUrl(payload);
+
+      if (offImage) {
+        body = { url: offImage, source: 'off' };
+      } else {
+        const placeholder = getPlaceholderUrl(category);
+        body = placeholder ? { url: placeholder, source: 'placeholder' } : { source: 'none' };
+      }
+    } else {
+      const placeholder = getPlaceholderUrl(category);
+      body = placeholder ? { url: placeholder, source: 'placeholder' } : { source: 'none' };
+    }
+
+    let result: Response;
+    if (wantsJson) {
+      result = jsonResponse(body);
+    } else if (body.url) {
+      result = imageRedirectResponse(body.url);
+    } else {
+      result = placeholderSvgResponse();
+    }
+
+    await cache.put(cacheKey, result.clone());
+    return result;
+  } catch {
+    const placeholder = getPlaceholderUrl(category);
+    if (wantsJson) {
+      return jsonResponse(placeholder ? { url: placeholder, source: 'placeholder' } : { source: 'none' });
+    }
+
+    if (placeholder) {
+      return imageRedirectResponse(placeholder);
+    }
+
+    return placeholderSvgResponse();
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
     "axe:ci": "echo \"axe check placeholder: no dedicated suite configured\"",
     "lhci": "echo \"lhci placeholder: no dedicated config found\"",
     "e2e": "playwright test",
-    "e2e:report": "playwright show-report"
+    "e2e:report": "playwright show-report",
+    "verify:pages-api": "node scripts/verify-pages-api.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/frontend/scripts/verify-pages-api.mjs
+++ b/frontend/scripts/verify-pages-api.mjs
@@ -1,0 +1,57 @@
+const baseUrl = process.env.API_BASE_URL || 'http://127.0.0.1:8788';
+
+async function checkHealth() {
+  const response = await fetch(`${baseUrl}/api/health`);
+  const body = await response.text();
+  if (response.status !== 200) {
+    throw new Error(`/api/health expected 200, received ${response.status}. body=${body.slice(0, 180)}`);
+  }
+  console.log(`OK /api/health -> ${response.status}`);
+}
+
+async function checkProductImageJson() {
+  const response = await fetch(`${baseUrl}/api/product-image?ean=3274080005003&format=json&v=2`);
+  const body = await response.text();
+  if (response.status !== 200) {
+    throw new Error(`/api/product-image?format=json expected 200, received ${response.status}. body=${body.slice(0, 180)}`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(`/api/product-image?format=json did not return JSON. body=${body.slice(0, 180)}`);
+  }
+
+  if (!['off', 'placeholder', 'none'].includes(parsed?.source)) {
+    throw new Error(`/api/product-image?format=json returned unexpected payload: ${body.slice(0, 180)}`);
+  }
+
+  console.log(`OK /api/product-image?format=json -> ${response.status} source=${parsed.source}`);
+}
+
+async function checkProductImageMode() {
+  const response = await fetch(`${baseUrl}/api/product-image?ean=3274080005003&v=2`, { redirect: 'manual' });
+  const contentType = response.headers.get('content-type') || '';
+  const isRedirect = response.status === 302;
+  const isSvg = response.status === 200 && contentType.includes('image/svg+xml');
+
+  if (!isRedirect && !isSvg) {
+    const body = await response.text();
+    throw new Error(`/api/product-image image mode expected 302 or 200 image/svg+xml, received ${response.status} content-type=${contentType}. body=${body.slice(0, 180)}`);
+  }
+
+  console.log(`OK /api/product-image image mode -> ${response.status} content-type=${contentType || 'n/a'}`);
+}
+
+async function run() {
+  await checkHealth();
+  await checkProductImageJson();
+  await checkProductImageMode();
+  console.log('API verification completed successfully.');
+}
+
+run().catch((error) => {
+  console.error('API verification failed:', error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import OnboardingAutoStart from './components/OnboardingAutoStart';
 import HelpButton from './components/HelpButton';
 import AnalyticsTracker from './components/analytics/AnalyticsTracker';
 import { StoreSelectionProvider } from './context/StoreSelectionContext';
+import { logDebug } from './utils/logger';
 
 // Lazy-loaded pages - Main routes
 const Home = React.lazy(() => import('./pages/Home'));
@@ -95,13 +96,13 @@ function LoadingFallback() {
   const [showTimeout, setShowTimeout] = useState(false);
   
   useEffect(() => {
-    console.log('⏳ LoadingFallback: Displayed');
+    logDebug('⏳ LoadingFallback: Displayed');
     const timer = setTimeout(() => {
       console.error('⚠️ Application timeout - Loading blocked for 10+ seconds');
       setShowTimeout(true);
     }, 10000);
     return () => {
-      console.log('✅ LoadingFallback: Hidden (component loaded successfully)');
+      logDebug('✅ LoadingFallback: Hidden (component loaded successfully)');
       clearTimeout(timer);
     };
   }, []);
@@ -138,13 +139,13 @@ export default function App() {
   const [providerError, setProviderError] = useState<Error | null>(null);
 
   useEffect(() => {
-    console.log('🚀 App: Starting initialization');
-    console.log('📍 App: Environment:', import.meta.env.MODE);
-    console.log('📍 App: Firebase configured:', import.meta.env.VITE_FIREBASE_API_KEY ? 'Yes' : 'No');
+    logDebug('🚀 App: Starting initialization');
+    logDebug('📍 App: Environment:', import.meta.env.MODE);
+    logDebug('📍 App: Firebase configured:', import.meta.env.VITE_FIREBASE_API_KEY ? 'Yes' : 'No');
     const fallback = document.getElementById('loading-fallback');
     if (fallback) {
       fallback.style.display = 'none';
-      console.log('✅ App: HTML loading fallback hidden');
+      logDebug('✅ App: HTML loading fallback hidden');
     }
   }, []);
 

--- a/frontend/src/context/AuthContext.jsx
+++ b/frontend/src/context/AuthContext.jsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState, useEffect } from 'react';
 import { auth, db } from '../lib/firebase';
 import { onAuthStateChanged } from 'firebase/auth';
 import { doc, getDoc } from 'firebase/firestore';
+import { logDebug } from '../utils/logger';
 
 const AuthContext = createContext();
 
@@ -19,7 +20,7 @@ export function AuthProvider({ children }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    console.log('🔄 AuthProvider: Initializing...');
+    logDebug('🔄 AuthProvider: Initializing...');
     
     // Hard timeout to prevent infinite loading - force render after 5 seconds
     const timeoutId = setTimeout(() => {
@@ -38,9 +39,9 @@ export function AuthProvider({ children }) {
       return;
     }
 
-    console.log('✅ AuthProvider: Setting up auth listener');
+    logDebug('✅ AuthProvider: Setting up auth listener');
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
-      console.log('🔄 AuthProvider: Auth state changed', currentUser ? 'User logged in' : 'No user');
+      logDebug('🔄 AuthProvider: Auth state changed', currentUser ? 'User logged in' : 'No user');
       setUser(currentUser);
       
       // Fetch user role from Firestore if available
@@ -61,7 +62,7 @@ export function AuthProvider({ children }) {
         setUserRole('guest');
       }
       
-      console.log('✅ AuthProvider: Initialization complete');
+      logDebug('✅ AuthProvider: Initialization complete');
       setLoading(false);
       clearTimeout(timeoutId);
     });

--- a/frontend/src/context/LanguageProvider.tsx
+++ b/frontend/src/context/LanguageProvider.tsx
@@ -9,6 +9,7 @@ import i18n from '../i18n';
 import { useLanguage } from '../hooks/useLanguage';
 import { LanguageSuggestionModal } from '../components/i18n/LanguageSuggestionModal';
 import { Language } from '../i18n/languages';
+import { logDebug } from '../utils/logger';
 
 interface LanguageProviderProps {
   children: ReactNode;
@@ -16,7 +17,7 @@ interface LanguageProviderProps {
 
 export function LanguageProvider({ children }: LanguageProviderProps) {
   useEffect(() => {
-    console.log('🌐 LanguageProvider: Initializing i18n');
+    logDebug('🌐 LanguageProvider: Initializing i18n');
   }, []);
 
   return (

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -7,10 +7,11 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import Backend from 'i18next-http-backend';
+import { logDebug } from '../utils/logger';
 
 const SUPPORTED_LANGUAGES = ['fr', 'gcf', 'acf', 'rcf', 'gcr'];
 
-console.log('🌐 i18n: Starting initialization');
+logDebug('🌐 i18n: Starting initialization');
 
 i18n
   .use(Backend)
@@ -122,7 +123,7 @@ i18n
     },
   })
   .then(() => {
-    console.log('✅ i18n: Initialized successfully');
+    logDebug('✅ i18n: Initialized successfully');
   })
   .catch((error) => {
     console.error('⚠️ i18n: Initialization failed', error);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -12,11 +12,11 @@ import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
 import { safeToText } from './utils/safeToText';
 import { installRuntimeCrashProbe } from './monitoring/runtimeCrashProbe';
+import { logDebug } from './utils/logger';
 
 const BUILD_SHA = import.meta.env.VITE_BUILD_SHA || 'unknown';
 window.__BUILD_SHA__ = BUILD_SHA;
-const consoleInfo = globalThis?.console?.info?.bind(globalThis.console);
-consoleInfo?.(`[build] A KI PRI SA YÉ boot sha=${BUILD_SHA}`);
+logDebug(`[build] A KI PRI SA YÉ boot sha=${BUILD_SHA}`);
 installRuntimeCrashProbe();
 
 // Load debug utilities in development
@@ -67,7 +67,7 @@ const rootElement = document.getElementById('root');
 if (!rootElement) {
   console.error('❌ Root element #root not found');
 } else {
-  console.log('✅ main.jsx: Starting React render');
+  logDebug('✅ main.jsx: Starting React render');
 
   ReactDOM.createRoot(rootElement).render(
     <React.StrictMode>
@@ -87,5 +87,5 @@ if (!rootElement) {
     clearTimeout(globalLoadTimeout);
   });
 
-  console.log('✅ main.jsx: React render initiated');
+  logDebug('✅ main.jsx: React render initiated');
 }

--- a/frontend/src/services/alertProductImageService.ts
+++ b/frontend/src/services/alertProductImageService.ts
@@ -124,6 +124,7 @@ async function fetchFromApi(ean: string, category?: string): Promise<{ url?: str
       params.set('category', category);
     }
     params.set('format', 'json');
+    params.set('v', '2');
 
     const response = await fetch(`/api/product-image?${params.toString()}`, {
       method: 'GET',

--- a/frontend/src/utils/logger.ts
+++ b/frontend/src/utils/logger.ts
@@ -1,0 +1,7 @@
+export const isProduction = import.meta.env.PROD;
+
+export function logDebug(...args: unknown[]) {
+  if (!isProduction) {
+    console.log(...args);
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -26,6 +26,7 @@ const buildSha = process.env.BUILD_SHA || (() => {
 })()
 
 export default defineConfig({
+  base: '/',
   plugins: [
     react(),
     viteStaticCopy({


### PR DESCRIPTION
### Motivation
- `/api/product-image` returned 404 in production while `/api/health` worked, meaning the product-image Pages Function was not served from the frontend Pages deployment unit.  
- A SPA `_redirects` rule for `/api/*` can interfere with Pages Functions routing and cause unpredictable resolution.  
- Stale cached JSON responses caused broken product images, and noisy `console.*` calls polluted production logs.

### Description
- Removed the API rewrite from `frontend/public/_redirects` and kept only the SPA fallback rule `/* /index.html 200` to avoid interfering with Functions.  
- Added `frontend/functions/_routes.json` with `"include": ["/api/*"]` to explicitly scope Pages Functions to `/api/*`.  
- Added the missing Pages Function `frontend/functions/api/product-image.ts` implementing `onRequestGet` (JSON mode with `format=json`, image redirect mode, SVG fallback, edge caching).  
- Bumped the product-image client call to include a cache-bust query `v=2` in `frontend/src/services/alertProductImageService.ts`, added `frontend/scripts/verify-pages-api.mjs` and an npm script `verify:pages-api` for local verification, and introduced `frontend/src/utils/logger.ts` with `logDebug` to replace high-volume `console.*` calls in production builds.

### Testing
- Built the frontend with `cd frontend && npm run build` and the build completed successfully.  
- Ran a local Pages dev server and executed the verification script with `wrangler pages dev dist --port 8788` + `node scripts/verify-pages-api.mjs`, which checked `GET /api/health`, `GET /api/product-image?ean=...&format=json&v=2`, and `GET /api/product-image?ean=...&v=2` (image mode); all checks passed locally (health 200; product-image JSON 200 with valid `source`; image mode returned a valid fallback (200 SVG) locally).  
- No automated test failures were observed during the local verification run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990c13afbd083218d7b9af9b23c0cdb)