### PR TITLE
fix(api): stabilize product-image json/image negotiation

### DIFF
--- a/frontend/functions/__tests__/product-image.test.ts
+++ b/frontend/functions/__tests__/product-image.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { onRequestGet } from '../api/product-image';
+
+function makeRequest(path: string, accept = 'text/html'): Request {
+  return new Request(`https://example.com${path}`, {
+    headers: { Accept: accept },
+  });
+}
+
+describe('/api/product-image content negotiation', () => {
+  const cacheStore = new Map<string, Response>();
+
+  beforeEach(() => {
+    cacheStore.clear();
+    vi.restoreAllMocks();
+
+    const cacheApi = {
+      match: vi.fn(async (request: Request) => cacheStore.get(`${request.url}|${request.headers.get('accept') ?? ''}`)),
+      put: vi.fn(async (request: Request, response: Response) => {
+        cacheStore.set(`${request.url}|${request.headers.get('accept') ?? ''}`, response);
+      }),
+    };
+
+    Object.defineProperty(globalThis, 'caches', {
+      configurable: true,
+      value: { default: cacheApi },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns image-compatible response in default mode', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 0 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const response = await onRequestGet({ request: makeRequest('/api/product-image?ean=3274080005003&v=1', 'text/html') } as never);
+
+    expect([302, 200]).toContain(response.status);
+    if (response.status === 302) {
+      expect(response.headers.get('location')).toBe('/assets/placeholders/placeholder-default.svg');
+    }
+
+    expect(response.headers.get('vary')).toContain('Accept');
+  });
+
+  it('returns JSON when format=json is provided', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 0 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const response = await onRequestGet({ request: makeRequest('/api/product-image?ean=3274080005003&format=json&v=1', 'text/html') } as never);
+    const body = await response.json() as { source: string; url?: string };
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    expect(response.headers.get('vary')).toContain('Accept');
+    expect(body.source).toBe('placeholder');
+    expect(body.url).toBe('/assets/placeholders/placeholder-default.svg');
+  });
+
+  it('returns JSON when Accept requests application/json', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 0 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const response = await onRequestGet({ request: makeRequest('/api/product-image?ean=3274080005003&v=1', 'application/json') } as never);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toContain('application/json');
+    expect(response.headers.get('vary')).toContain('Accept');
+    await expect(response.json()).resolves.toMatchObject({ source: 'placeholder' });
+  });
+});

--- a/frontend/functions/api/product-image.ts
+++ b/frontend/functions/api/product-image.ts
@@ -2,7 +2,9 @@ const OFF_BASE_URL = 'https://world.openfoodfacts.org';
 const EDGE_CACHE_TTL = 7 * 24 * 60 * 60;
 const FETCH_TIMEOUT_MS = 5000;
 
-type ImageSource = 'off' | 'placeholder' | 'none';
+type ImageSource = 'off' | 'placeholder';
+
+const DEFAULT_PLACEHOLDER_URL = '/assets/placeholders/placeholder-default.svg';
 
 type OffImagePayload = {
   image_url?: unknown;
@@ -36,12 +38,12 @@ function normalizeCategory(category: string): string {
     .trim();
 }
 
-function getPlaceholderUrl(category?: string | null): string | undefined {
+function getPlaceholderUrl(category?: string | null): string {
   if (!category || !category.trim()) {
-    return undefined;
+    return DEFAULT_PLACEHOLDER_URL;
   }
 
-  return PLACEHOLDER_BY_CATEGORY[normalizeCategory(category)] ?? '/assets/placeholders/placeholder-default.svg';
+  return PLACEHOLDER_BY_CATEGORY[normalizeCategory(category)] ?? DEFAULT_PLACEHOLDER_URL;
 }
 
 function asNonEmptyString(value: unknown): string | undefined {
@@ -62,6 +64,7 @@ function jsonResponse(body: { url?: string; source: ImageSource }, status = 200)
     headers: {
       'content-type': 'application/json; charset=utf-8',
       'Cache-Control': `public, max-age=${EDGE_CACHE_TTL}`,
+      Vary: 'Accept',
     },
   });
 }
@@ -70,6 +73,7 @@ function imageModeHeaders(contentType: string): HeadersInit {
   return {
     'content-type': contentType,
     'Cache-Control': `public, max-age=${EDGE_CACHE_TTL}`,
+    Vary: 'Accept',
   };
 }
 
@@ -79,6 +83,7 @@ function imageRedirectResponse(targetUrl: string): Response {
     headers: {
       Location: targetUrl,
       'Cache-Control': `public, max-age=${EDGE_CACHE_TTL}`,
+      Vary: 'Accept',
     },
   });
 }
@@ -96,25 +101,25 @@ export const onRequestGet: PagesFunction = async ({ request }) => {
   const url = new URL(request.url);
   const ean = (url.searchParams.get('ean') ?? '').trim();
   const category = url.searchParams.get('category');
-  const wantsJson = url.searchParams.get('format') === 'json';
+  const accept = request.headers.get('accept') ?? '';
+  const wantsJson =
+    url.searchParams.get('format') === 'json'
+    || accept.includes('application/json');
 
   if (!ean) {
     const placeholder = getPlaceholderUrl(category);
     if (wantsJson) {
-      return jsonResponse(placeholder
-        ? { url: placeholder, source: 'placeholder' }
-        : { source: 'none' });
+      return jsonResponse({ url: placeholder, source: 'placeholder' });
     }
 
-    if (placeholder) {
-      return imageRedirectResponse(placeholder);
-    }
-
-    return placeholderSvgResponse();
+    return imageRedirectResponse(placeholder);
   }
 
   const cache = caches.default;
-  const cacheKey = new Request(url.toString(), { method: 'GET' });
+  const cacheKey = new Request(url.toString(), {
+    method: 'GET',
+    headers: { Accept: accept },
+  });
   const cached = await cache.match(cacheKey);
 
   if (cached) {
@@ -144,12 +149,10 @@ export const onRequestGet: PagesFunction = async ({ request }) => {
       if (offImage) {
         body = { url: offImage, source: 'off' };
       } else {
-        const placeholder = getPlaceholderUrl(category);
-        body = placeholder ? { url: placeholder, source: 'placeholder' } : { source: 'none' };
+        body = { url: getPlaceholderUrl(category), source: 'placeholder' };
       }
     } else {
-      const placeholder = getPlaceholderUrl(category);
-      body = placeholder ? { url: placeholder, source: 'placeholder' } : { source: 'none' };
+      body = { url: getPlaceholderUrl(category), source: 'placeholder' };
     }
 
     let result: Response;
@@ -166,14 +169,10 @@ export const onRequestGet: PagesFunction = async ({ request }) => {
   } catch {
     const placeholder = getPlaceholderUrl(category);
     if (wantsJson) {
-      return jsonResponse(placeholder ? { url: placeholder, source: 'placeholder' } : { source: 'none' });
+      return jsonResponse({ url: placeholder, source: 'placeholder' });
     }
 
-    if (placeholder) {
-      return imageRedirectResponse(placeholder);
-    }
-
-    return placeholderSvgResponse();
+    return imageRedirectResponse(placeholder);
   } finally {
     clearTimeout(timeoutId);
   }

--- a/frontend/scripts/verify-pages-api.mjs
+++ b/frontend/scripts/verify-pages-api.mjs
@@ -10,7 +10,9 @@ async function checkHealth() {
 }
 
 async function checkProductImageJson() {
-  const response = await fetch(`${baseUrl}/api/product-image?ean=3274080005003&format=json&v=2`);
+  const response = await fetch(`${baseUrl}/api/product-image?ean=3274080005003&format=json&v=2`, {
+    headers: { Accept: 'text/html' },
+  });
   const body = await response.text();
   if (response.status !== 200) {
     throw new Error(`/api/product-image?format=json expected 200, received ${response.status}. body=${body.slice(0, 180)}`);
@@ -23,15 +25,23 @@ async function checkProductImageJson() {
     throw new Error(`/api/product-image?format=json did not return JSON. body=${body.slice(0, 180)}`);
   }
 
-  if (!['off', 'placeholder', 'none'].includes(parsed?.source)) {
+  if (!['off', 'placeholder'].includes(parsed?.source)) {
     throw new Error(`/api/product-image?format=json returned unexpected payload: ${body.slice(0, 180)}`);
+  }
+
+  const vary = response.headers.get('vary') || '';
+  if (!vary.toLowerCase().includes('accept')) {
+    throw new Error(`/api/product-image?format=json expected Vary: Accept, received "${vary}"`);
   }
 
   console.log(`OK /api/product-image?format=json -> ${response.status} source=${parsed.source}`);
 }
 
 async function checkProductImageMode() {
-  const response = await fetch(`${baseUrl}/api/product-image?ean=3274080005003&v=2`, { redirect: 'manual' });
+  const response = await fetch(`${baseUrl}/api/product-image?ean=3274080005003&v=2`, {
+    redirect: 'manual',
+    headers: { Accept: 'text/html' },
+  });
   const contentType = response.headers.get('content-type') || '';
   const isRedirect = response.status === 302;
   const isSvg = response.status === 200 && contentType.includes('image/svg+xml');
@@ -41,13 +51,48 @@ async function checkProductImageMode() {
     throw new Error(`/api/product-image image mode expected 302 or 200 image/svg+xml, received ${response.status} content-type=${contentType}. body=${body.slice(0, 180)}`);
   }
 
+  const vary = response.headers.get('vary') || '';
+  if (!vary.toLowerCase().includes('accept')) {
+    throw new Error(`/api/product-image image mode expected Vary: Accept, received "${vary}"`);
+  }
+
   console.log(`OK /api/product-image image mode -> ${response.status} content-type=${contentType || 'n/a'}`);
+}
+
+async function checkProductImageJsonByAccept() {
+  const response = await fetch(`${baseUrl}/api/product-image?ean=3274080005003&v=2`, {
+    headers: { Accept: 'application/json' },
+  });
+  const body = await response.text();
+
+  if (response.status !== 200) {
+    throw new Error(`/api/product-image Accept: application/json expected 200, received ${response.status}. body=${body.slice(0, 180)}`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(`/api/product-image Accept: application/json did not return JSON. body=${body.slice(0, 180)}`);
+  }
+
+  if (!['off', 'placeholder'].includes(parsed?.source)) {
+    throw new Error(`/api/product-image Accept: application/json returned unexpected payload: ${body.slice(0, 180)}`);
+  }
+
+  const vary = response.headers.get('vary') || '';
+  if (!vary.toLowerCase().includes('accept')) {
+    throw new Error(`/api/product-image Accept: application/json expected Vary: Accept, received "${vary}"`);
+  }
+
+  console.log(`OK /api/product-image Accept: application/json -> ${response.status} source=${parsed.source}`);
 }
 
 async function run() {
   await checkHealth();
   await checkProductImageJson();
   await checkProductImageMode();
+  await checkProductImageJsonByAccept();
   console.log('API verification completed successfully.');
 }
 

--- a/functions/api/product-image.ts
+++ b/functions/api/product-image.ts
@@ -2,7 +2,9 @@ const OFF_BASE_URL = 'https://world.openfoodfacts.org';
 const EDGE_CACHE_TTL = 7 * 24 * 60 * 60;
 const FETCH_TIMEOUT_MS = 5000;
 
-type ImageSource = 'off' | 'placeholder' | 'none';
+type ImageSource = 'off' | 'placeholder';
+
+const DEFAULT_PLACEHOLDER_URL = '/assets/placeholders/placeholder-default.svg';
 
 type OffImagePayload = {
   image_url?: unknown;
@@ -36,12 +38,12 @@ function normalizeCategory(category: string): string {
     .trim();
 }
 
-function getPlaceholderUrl(category?: string | null): string | undefined {
+function getPlaceholderUrl(category?: string | null): string {
   if (!category || !category.trim()) {
-    return undefined;
+    return DEFAULT_PLACEHOLDER_URL;
   }
 
-  return PLACEHOLDER_BY_CATEGORY[normalizeCategory(category)] ?? '/assets/placeholders/placeholder-default.svg';
+  return PLACEHOLDER_BY_CATEGORY[normalizeCategory(category)] ?? DEFAULT_PLACEHOLDER_URL;
 }
 
 function asNonEmptyString(value: unknown): string | undefined {
@@ -62,6 +64,7 @@ function jsonResponse(body: { url?: string; source: ImageSource }, status = 200)
     headers: {
       'content-type': 'application/json; charset=utf-8',
       'Cache-Control': `public, max-age=${EDGE_CACHE_TTL}`,
+      Vary: 'Accept',
     },
   });
 }
@@ -70,6 +73,7 @@ function imageModeHeaders(contentType: string): HeadersInit {
   return {
     'content-type': contentType,
     'Cache-Control': `public, max-age=${EDGE_CACHE_TTL}`,
+    Vary: 'Accept',
   };
 }
 
@@ -79,6 +83,7 @@ function imageRedirectResponse(targetUrl: string): Response {
     headers: {
       Location: targetUrl,
       'Cache-Control': `public, max-age=${EDGE_CACHE_TTL}`,
+      Vary: 'Accept',
     },
   });
 }
@@ -96,25 +101,25 @@ export const onRequestGet: PagesFunction = async ({ request }) => {
   const url = new URL(request.url);
   const ean = (url.searchParams.get('ean') ?? '').trim();
   const category = url.searchParams.get('category');
-  const wantsJson = url.searchParams.get('format') === 'json';
+  const accept = request.headers.get('accept') ?? '';
+  const wantsJson =
+    url.searchParams.get('format') === 'json'
+    || accept.includes('application/json');
 
   if (!ean) {
     const placeholder = getPlaceholderUrl(category);
     if (wantsJson) {
-      return jsonResponse(placeholder
-        ? { url: placeholder, source: 'placeholder' }
-        : { source: 'none' });
+      return jsonResponse({ url: placeholder, source: 'placeholder' });
     }
 
-    if (placeholder) {
-      return imageRedirectResponse(placeholder);
-    }
-
-    return placeholderSvgResponse();
+    return imageRedirectResponse(placeholder);
   }
 
   const cache = caches.default;
-  const cacheKey = new Request(url.toString(), { method: 'GET' });
+  const cacheKey = new Request(url.toString(), {
+    method: 'GET',
+    headers: { Accept: accept },
+  });
   const cached = await cache.match(cacheKey);
 
   if (cached) {
@@ -144,12 +149,10 @@ export const onRequestGet: PagesFunction = async ({ request }) => {
       if (offImage) {
         body = { url: offImage, source: 'off' };
       } else {
-        const placeholder = getPlaceholderUrl(category);
-        body = placeholder ? { url: placeholder, source: 'placeholder' } : { source: 'none' };
+        body = { url: getPlaceholderUrl(category), source: 'placeholder' };
       }
     } else {
-      const placeholder = getPlaceholderUrl(category);
-      body = placeholder ? { url: placeholder, source: 'placeholder' } : { source: 'none' };
+      body = { url: getPlaceholderUrl(category), source: 'placeholder' };
     }
 
     let result: Response;
@@ -166,14 +169,10 @@ export const onRequestGet: PagesFunction = async ({ request }) => {
   } catch {
     const placeholder = getPlaceholderUrl(category);
     if (wantsJson) {
-      return jsonResponse(placeholder ? { url: placeholder, source: 'placeholder' } : { source: 'none' });
+      return jsonResponse({ url: placeholder, source: 'placeholder' });
     }
 
-    if (placeholder) {
-      return imageRedirectResponse(placeholder);
-    }
-
-    return placeholderSvgResponse();
+    return imageRedirectResponse(placeholder);
   } finally {
     clearTimeout(timeoutId);
   }


### PR DESCRIPTION
### Motivation
- Eliminate ambiguous responses from `/api/product-image` by making the JSON vs image negotiation deterministic based on query param or `Accept` header.
- Ensure Cloudflare caching does not serve the wrong variant by adding `Vary: Accept` and making the cache key respect `Accept`.
- Avoid returning `source: "none"` in image mode by always resolving to a default placeholder when no OFF image is found.

### Description
- Determine `wantsJson` using `url.searchParams.get('format') === 'json'` OR `accept.includes('application/json')` and read `Accept` from the incoming request header in `onRequestGet`.
- Add `Vary: Accept` to JSON responses, image redirect (302) responses and SVG inline responses, and include `Accept` in the constructed cache key request used with `caches.default`.
- Replace `source: 'none'` behavior by always returning the default placeholder (`/assets/placeholders/placeholder-default.svg`) and update `getPlaceholderUrl` to return that default when category is missing.
- Add unit tests `frontend/functions/__tests__/product-image.test.ts` to validate image mode, `format=json`, and `Accept: application/json` behaviors; update `frontend/scripts/verify-pages-api.mjs` to check the three scenarios and assert presence of `Vary: Accept`.

### Testing
- Ran unit tests with `cd frontend && npx vitest run functions/__tests__/product-image.test.ts`, and the test file passed (3 tests).
- Ran the verification script with `cd frontend && npm run verify:pages-api`, which failed locally with `fetch failed` because the Pages dev server was not running (expected in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ca5e0adc8321bec90d7c8953047f)