### PR TITLE
fix(api): product-image returns image by default + strict content negotiation

### DIFF
--- a/frontend/functions/__tests__/product-image.test.ts
+++ b/frontend/functions/__tests__/product-image.test.ts
@@ -31,7 +31,7 @@ describe('/api/product-image content negotiation', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns image-compatible response in default mode', async () => {
+  it('returns redirect for browser requests (Accept: text/html)', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(JSON.stringify({ status: 0 }), {
         status: 200,
@@ -41,12 +41,41 @@ describe('/api/product-image content negotiation', () => {
 
     const response = await onRequestGet({ request: makeRequest('/api/product-image?ean=3274080005003&v=1', 'text/html') } as never);
 
-    expect([302, 200]).toContain(response.status);
-    if (response.status === 302) {
-      expect(response.headers.get('location')).toBe('/assets/placeholders/placeholder-default.svg');
-    }
-
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('/assets/placeholders/placeholder-default.svg');
+    expect(response.headers.get('cache-control')).toContain('max-age=');
     expect(response.headers.get('vary')).toContain('Accept');
+  });
+
+  it('returns redirect for image clients (Accept: image/*)', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 0 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const response = await onRequestGet({ request: makeRequest('/api/product-image?ean=3274080005003&v=1', 'image/*') } as never);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('/assets/placeholders/placeholder-default.svg');
+    expect(response.headers.get('cache-control')).toContain('max-age=');
+    expect(response.headers.get('vary')).toContain('Accept');
+  });
+
+  it('returns redirect for wildcard Accept and fallback is still an image', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 0 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const response = await onRequestGet({ request: makeRequest('/api/product-image?ean=3274080005003&v=1', '*/*') } as never);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('/assets/placeholders/placeholder-default.svg');
+    expect(response.headers.get('content-type')).toBeNull();
   });
 
   it('returns JSON when format=json is provided', async () => {
@@ -62,6 +91,7 @@ describe('/api/product-image content negotiation', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toContain('application/json');
+    expect(response.headers.get('cache-control')).toContain('max-age=');
     expect(response.headers.get('vary')).toContain('Accept');
     expect(body.source).toBe('placeholder');
     expect(body.url).toBe('/assets/placeholders/placeholder-default.svg');
@@ -79,6 +109,7 @@ describe('/api/product-image content negotiation', () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get('content-type')).toContain('application/json');
+    expect(response.headers.get('cache-control')).toContain('max-age=');
     expect(response.headers.get('vary')).toContain('Accept');
     await expect(response.json()).resolves.toMatchObject({ source: 'placeholder' });
   });

--- a/frontend/functions/api/product-image.ts
+++ b/frontend/functions/api/product-image.ts
@@ -88,6 +88,15 @@ function imageRedirectResponse(targetUrl: string): Response {
   });
 }
 
+function wantsJsonResponse(request: Request, searchParams: URLSearchParams): boolean {
+  if (searchParams.get('format') === 'json') {
+    return true;
+  }
+
+  const accept = request.headers.get('accept') ?? '';
+  return accept.toLowerCase().includes('application/json');
+}
+
 function placeholderSvgResponse(status = 200): Response {
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="640" height="640" viewBox="0 0 640 640" role="img" aria-label="Image produit indisponible"><rect width="640" height="640" fill="#f3f4f6"/><g fill="none" stroke="#9ca3af" stroke-width="24" stroke-linecap="round" stroke-linejoin="round"><rect x="120" y="150" width="400" height="300" rx="24"/><path d="M165 395l92-92 74 74 54-54 90 90"/><circle cx="250" cy="240" r="38"/></g><text x="320" y="520" text-anchor="middle" fill="#6b7280" font-family="Arial, Helvetica, sans-serif" font-size="36">Image indisponible</text></svg>`;
 
@@ -102,9 +111,7 @@ export const onRequestGet: PagesFunction = async ({ request }) => {
   const ean = (url.searchParams.get('ean') ?? '').trim();
   const category = url.searchParams.get('category');
   const accept = request.headers.get('accept') ?? '';
-  const wantsJson =
-    url.searchParams.get('format') === 'json'
-    || accept.includes('application/json');
+  const wantsJson = wantsJsonResponse(request, url.searchParams);
 
   if (!ean) {
     const placeholder = getPlaceholderUrl(category);

--- a/functions/api/product-image.ts
+++ b/functions/api/product-image.ts
@@ -88,6 +88,15 @@ function imageRedirectResponse(targetUrl: string): Response {
   });
 }
 
+function wantsJsonResponse(request: Request, searchParams: URLSearchParams): boolean {
+  if (searchParams.get('format') === 'json') {
+    return true;
+  }
+
+  const accept = request.headers.get('accept') ?? '';
+  return accept.toLowerCase().includes('application/json');
+}
+
 function placeholderSvgResponse(status = 200): Response {
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="640" height="640" viewBox="0 0 640 640" role="img" aria-label="Image produit indisponible"><rect width="640" height="640" fill="#f3f4f6"/><g fill="none" stroke="#9ca3af" stroke-width="24" stroke-linecap="round" stroke-linejoin="round"><rect x="120" y="150" width="400" height="300" rx="24"/><path d="M165 395l92-92 74 74 54-54 90 90"/><circle cx="250" cy="240" r="38"/></g><text x="320" y="520" text-anchor="middle" fill="#6b7280" font-family="Arial, Helvetica, sans-serif" font-size="36">Image indisponible</text></svg>`;
 
@@ -102,9 +111,7 @@ export const onRequestGet: PagesFunction = async ({ request }) => {
   const ean = (url.searchParams.get('ean') ?? '').trim();
   const category = url.searchParams.get('category');
   const accept = request.headers.get('accept') ?? '';
-  const wantsJson =
-    url.searchParams.get('format') === 'json'
-    || accept.includes('application/json');
+  const wantsJson = wantsJsonResponse(request, url.searchParams);
 
   if (!ean) {
     const placeholder = getPlaceholderUrl(category);


### PR DESCRIPTION
### Motivation
- Garantir que `/api/product-image` renvoie une IMAGE par défaut (comportement navigateur) et du JSON uniquement lorsqu'il est explicitement demandé via `format=json` ou `Accept: application/json`.
- Éviter que des valeurs larges comme `text/html`, `image/*` ou `*/*` déclenchent une réponse JSON par erreur.
- Maintenir un fallback placeholder qui est une image et conserver des en-têtes de cache et de négociation (`Vary: Accept`, `Cache-Control`).

### Description
- Ajout d'une helper `wantsJsonResponse(request, searchParams)` appliquée dans les deux variantes de la Pages function (`frontend/functions/api/product-image.ts` et `functions/api/product-image.ts`) pour centraliser la logique de négociation de contenu.
- Remplacement de la détection inline précédente par l'appel à `wantsJsonResponse`, de sorte que JSON n'est retourné que si `format=json` OU si l'en-tête `Accept` contient `application/json`.
- Comportement par défaut inchangé pour le mode image : redirection 302 vers l'URL d'image (OpenFoodFacts si disponible, sinon `/assets/placeholders/placeholder-default.svg`) et fallback direct en SVG si nécessaire, avec `Vary: Accept` et `Cache-Control` appliqués.
- Mise à jour des tests unitaires `frontend/functions/__tests__/product-image.test.ts` pour couvrir les cas demandés et vérifier les en-têtes pertinents (redirect pour `Accept: text/html`, `Accept: image/*`, JSON pour `format=json` et `Accept: application/json`, et comportement pour `*/*`).

### Testing
- Exécution (filtre incorrect) : `npm test -- frontend/functions/__tests__/product-image.test.ts` a retourné « No test files found » (aucun fichier trouvé) et a échoué pour ce chemin de filtre.
- Exécution correcte depuis `frontend/` : `npm test -- functions/__tests__/product-image.test.ts` a réussi avec `5 tests passed`, couvrant les scénarios suivants : `Accept: text/html` => redirect/image, `Accept: image/*` => redirect/image, `format=json` => JSON, `Accept: application/json` => JSON, et `Accept: */*` vérifiant que le fallback reste une image.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990d13f55048321b41fc917b57d2e32)