### PR TITLE
Fix /api/product-image default image behavior and barcode support

### DIFF
--- a/frontend/functions/__tests__/product-image.test.ts
+++ b/frontend/functions/__tests__/product-image.test.ts
@@ -78,6 +78,22 @@ describe('/api/product-image content negotiation', () => {
     expect(response.headers.get('content-type')).toBeNull();
   });
 
+
+  it('supports barcode as alias and redirects to an image by default', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 0 }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const response = await onRequestGet({ request: makeRequest('/api/product-image?barcode=3017620422003&v=1', 'text/html') } as never);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe('/assets/placeholders/placeholder-default.svg');
+    expect(response.headers.get('content-type')).toBeNull();
+  });
+
   it('returns JSON when format=json is provided', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
       new Response(JSON.stringify({ status: 0 }), {

--- a/frontend/functions/api/product-image.ts
+++ b/frontend/functions/api/product-image.ts
@@ -108,7 +108,7 @@ function placeholderSvgResponse(status = 200): Response {
 
 export const onRequestGet: PagesFunction = async ({ request }) => {
   const url = new URL(request.url);
-  const ean = (url.searchParams.get('ean') ?? '').trim();
+  const ean = (url.searchParams.get('ean') ?? url.searchParams.get('barcode') ?? '').trim();
   const category = url.searchParams.get('category');
   const accept = request.headers.get('accept') ?? '';
   const wantsJson = wantsJsonResponse(request, url.searchParams);

--- a/frontend/public/_redirects
+++ b/frontend/public/_redirects
@@ -1,3 +1,6 @@
+# API: never SPA-fallback
+/api/*    /api/:splat    200
+
 # Assets: never SPA-fallback (serve files as-is)
 /assets/*  /assets/:splat  200
 

--- a/functions/api/product-image.ts
+++ b/functions/api/product-image.ts
@@ -108,7 +108,7 @@ function placeholderSvgResponse(status = 200): Response {
 
 export const onRequestGet: PagesFunction = async ({ request }) => {
   const url = new URL(request.url);
-  const ean = (url.searchParams.get('ean') ?? '').trim();
+  const ean = (url.searchParams.get('ean') ?? url.searchParams.get('barcode') ?? '').trim();
   const category = url.searchParams.get('category');
   const accept = request.headers.get('accept') ?? '';
   const wantsJson = wantsJsonResponse(request, url.searchParams);


### PR DESCRIPTION
### Motivation
- Corriger le comportement actuel de l’endpoint `/api/product-image` qui renvoyait du JSON par défaut et empêchait l’affichage direct dans un `<img>`; l’objectif est de renvoyer une image (redirect ou contenu) sauf si JSON est explicitement demandé via `format=json` ou `Accept: application/json`.
- Supporter le paramètre `barcode` comme alias de `ean` pour les appels existants du type `/api/product-image?barcode=...` sans changer la logique métier.
- Prévenir que le fallback SPA n’intercepte les routes API en production en s’assurant qu’une règle `/api/*` existe avant le fallback.

### Description
- La Pages Function `onRequestGet` a été modifiée (copies mises à jour en `frontend/functions/api/product-image.ts` et `functions/api/product-image.ts`) pour lire `barcode` si `ean` est absent: `const ean = (url.searchParams.get('ean') ?? url.searchParams.get('barcode') ?? '').trim();`.
- La négociation de contenu reste inchangée: redirect (302 + `Location`) vers l’image/placeholder par défaut pour les requêtes image/browser, et réponse JSON (`{ url, source }`, `Content-Type: application/json; charset=utf-8`) uniquement si `format=json` est présent ou `Accept: application/json` est demandé.
- Ajout d’un test unitaire couvrant le cas `barcode` (fichier `frontend/functions/__tests__/product-image.test.ts`) pour vérifier le mode image par défaut (302 + `Location` vers le placeholder).
- Ajout d’une règle de passthrough `/api/*    /api/:splat    200` dans `frontend/public/_redirects` pour empêcher le fallback SPA de catcher les routes API.

### Testing
- `npm --prefix frontend run test -- functions/__tests__/product-image.test.ts` a été exécuté et a réussi (6 tests passés).
- `npm --prefix frontend run build` (Vite build) a été exécuté et a réussi sans erreur de build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699103142dcc83218ef04fb7890a9665)