### PR TITLE
ci: add timeout to production UX audit steps in strict workflow

### DIFF
--- a/.github/workflows/ci-strict.yml
+++ b/.github/workflows/ci-strict.yml
@@ -156,6 +156,7 @@ jobs:
       - name: Production UX audit (PR report-only)
         if: github.event_name == 'pull_request'
         working-directory: frontend
+        timeout-minutes: 15
         env:
           UX_AUDIT_STRICT: '0'
         run: npm run e2e
@@ -164,6 +165,7 @@ jobs:
       - name: Production UX audit (push strict)
         if: github.event_name == 'push'
         working-directory: frontend
+        timeout-minutes: 15
         env:
           UX_AUDIT_STRICT: '1'
         run: npm run e2e


### PR DESCRIPTION
### Motivation

- Prevent long-running or stuck Playwright production UX audits from blocking the CI run by failing fast with a per-step timeout while preserving the current PR/report-only and push/strict semantics.

### Description

- Add `timeout-minutes: 15` to the `Production UX audit (PR report-only)` and `Production UX audit (push strict)` steps in `.github/workflows/ci-strict.yml`.

### Testing

- Verified the updated workflow file parses with Ruby (`ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci-strict.yml')"` returned `ok`), and a Python-based parse attempt failed only because `PyYAML` is not installed in the environment; no application code was changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991463961908321ae6dede4ce8458e6)