### PR TITLE
ci: sanitize npm proxy env in strict workflow

### DIFF
--- a/.github/workflows/ci-strict.yml
+++ b/.github/workflows/ci-strict.yml
@@ -26,6 +26,18 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Sanitize npm proxy env (avoid deprecated key warnings)
+        shell: bash
+        run: |
+          {
+            echo "npm_config_http_proxy="
+            echo "npm_config_https_proxy="
+            echo "npm_config_proxy="
+            echo "NPM_CONFIG_HTTP_PROXY="
+            echo "NPM_CONFIG_HTTPS_PROXY="
+            echo "NPM_CONFIG_PROXY="
+          } >> "$GITHUB_ENV"
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
### Motivation
- Prevent noisy deprecation warnings from legacy npm proxy environment variables that appear during strict CI runs and can obscure real issues.

### Description
- Add a `Sanitize npm proxy env (avoid deprecated key warnings)` step to `.github/workflows/ci-strict.yml` which clears `npm_config_http_proxy`, `npm_config_https_proxy`, `npm_config_proxy` and the uppercase `NPM_CONFIG_*` variants by writing empty values to `GITHUB_ENV` before Node.js setup.

### Testing
- Ran `cd frontend && npm run lint:ci` (no changed JS/TS files reported) and `cd frontend && npm run test:ci` (Vitest: 12 test files, 37 tests passed) and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991469051048321a64212f4ad787e26)