### PR TITLE
fix(ci): deploy pages functions via wrangler safely

### DIFF
--- a/.github/workflows/ci-cd-industrial.yml
+++ b/.github/workflows/ci-cd-industrial.yml
@@ -212,7 +212,7 @@ jobs:
     needs: [preflight, build, integrity-check, routing-check]
     runs-on: ubuntu-latest
     outputs:
-      deployment-url: ${{ steps.deploy.outputs.url }}
+      deployment-url: https://akiprisaye-web.pages.dev
       environment: ${{ steps.set-env.outputs.environment }}
     steps:
       - name: 📥 Checkout code
@@ -223,6 +223,31 @@ jobs:
         with:
           name: dist
           path: frontend/dist
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      # Pages Functions are bundled as frontend/dist/_worker.js before deploy.
+      - name: 🧱 Build Pages Functions bundle (_worker.js)
+        run: |
+          npx wrangler@3 pages functions build functions --outfile frontend/dist/_worker.js
+
+      - name: ✅ Verify worker bundle
+        run: |
+          test -s frontend/dist/_worker.js
+
+      - name: 🔀 Resolve Pages branch
+        id: pages-branch
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "branch=main" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "branch=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: 🎯 Determine environment
         id: set-env
@@ -235,20 +260,18 @@ jobs:
             echo "📦 Deploying to PREVIEW"
           fi
 
-      - name: 🚀 Deploy to Cloudflare Pages
+      - name: 🚀 Deploy to Cloudflare Pages with Wrangler
         id: deploy
-        uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: akiprisaye-web
-          directory: frontend/dist
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler@3 pages deploy frontend/dist --project-name akiprisaye-web --branch "${{ steps.pages-branch.outputs.branch }}"
 
       - name: 📝 Log deployment
         run: |
           echo "🎉 Deployment completed"
-          echo "URL: ${{ steps.deploy.outputs.url }}"
+          echo "URL: https://akiprisaye-web.pages.dev"
           echo "Environment: ${{ steps.set-env.outputs.environment }}"
           echo "Timestamp: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
@@ -273,6 +296,13 @@ jobs:
         id: validate
         run: |
           ./scripts/post-deploy-validation.sh "${{ env.DEPLOYMENT_URL }}" 3 15
+
+      - name: 🔍 Smoke test API health
+        if: github.ref == 'refs/heads/main'
+        run: |
+          body=$(curl -fsS https://akiprisaye-web.pages.dev/api/health)
+          echo "$body"
+          echo "$body" | grep -Eq '"ok"[[:space:]]*:[[:space:]]*true|"status"[[:space:]]*:[[:space:]]*"ok"'
 
       - name: ✅ Validation successful
         if: success()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,15 +50,40 @@ jobs:
       - name: Build application
         run: npm run build
 
-      # Déploiement du contenu du dossier dist vers Cloudflare Pages
-      - name: Deploy to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: akiprisaye-web
-          directory: frontend/dist             # important : dossier de build
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+      # Pages Functions are bundled as _worker.js before Pages deploy.
+      - name: Build Pages Functions worker bundle
+        run: |
+          npx wrangler@3 pages functions build functions --outfile frontend/dist/_worker.js
+
+      - name: Verify worker bundle
+        run: |
+          test -s frontend/dist/_worker.js
+
+      - name: Resolve Pages branch
+        id: pages-branch
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "branch=main" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "branch=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Déploiement du contenu du dossier dist + _worker.js vers Cloudflare Pages
+      - name: Deploy to Cloudflare Pages with Wrangler
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler@3 pages deploy frontend/dist --project-name akiprisaye-web --branch "${{ steps.pages-branch.outputs.branch }}"
+
+      - name: Smoke test API health on production
+        if: github.ref == 'refs/heads/main'
+        run: |
+          body=$(curl -fsS https://akiprisaye-web.pages.dev/api/health)
+          echo "$body"
+          echo "$body" | grep -Eq '"ok"[[:space:]]*:[[:space:]]*true|"status"[[:space:]]*:[[:space:]]*"ok"'
 
       # Purge du cache inutile (pas de domaine personnalisé)
       - name: Skip cache purge

--- a/.github/workflows/observatory-pipeline.yml
+++ b/.github/workflows/observatory-pipeline.yml
@@ -260,14 +260,44 @@ jobs:
           name: dist
           path: dist/
 
-      - name: 🚀 Deploy to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
+      - name: 🔧 Setup Node.js for Wrangler
+        uses: actions/setup-node@v4
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: akiprisaye-web
-          directory: dist
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          node-version: ${{ env.NODE_VERSION }}
+
+      # Pages Functions are packaged into dist/_worker.js before deploy.
+      - name: 🧱 Build Pages Functions bundle (_worker.js)
+        run: |
+          npx wrangler@3 pages functions build functions --outfile dist/_worker.js
+
+      - name: ✅ Verify worker bundle
+        run: |
+          test -s dist/_worker.js
+
+      - name: 🔀 Resolve Pages branch
+        id: pages-branch
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "branch=main" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "branch=${{ github.head_ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 🚀 Deploy to Cloudflare Pages with Wrangler
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx wrangler@3 pages deploy dist --project-name akiprisaye-web --branch "${{ steps.pages-branch.outputs.branch }}"
+
+      - name: 🔍 Smoke test API health
+        if: github.ref == 'refs/heads/main'
+        run: |
+          body=$(curl -fsS https://akiprisaye-web.pages.dev/api/health)
+          echo "$body"
+          echo "$body" | grep -Eq '"ok"[[:space:]]*:[[:space:]]*true|"status"[[:space:]]*:[[:space:]]*"ok"'
 
       - name: 📊 Deployment summary
         run: |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ Headers de diagnostic renvoyés (y compris sur `302`) :
 - `x-akps-off-status`: code HTTP OFF ou `n/a`
 - `x-akps-selected`: `front` | `small` | `thumb` | `none`
 
+
+## ☁️ Déploiement Cloudflare Pages Functions
+
+Les endpoints `/api/*` sont déployés via **Wrangler** (et non via `cloudflare/pages-action`).
+
+- Le frontend est généré dans `frontend/dist`.
+- Les Pages Functions (`functions/**`) sont compilées en `frontend/dist/_worker.js` avec :
+  - `npx wrangler pages functions build functions --outfile frontend/dist/_worker.js`
+- Le déploiement Pages est ensuite fait avec :
+  - `npx wrangler pages deploy frontend/dist --project-name akiprisaye-web --branch <branch>`
+
+Ce packaging garantit que les routes API (ex: `/api/health`) ne retombent pas sur un fallback HTML 404 en production.
+
+---
+
 ## ⚡ Performance & Web Vitals
 
 **World-class performance optimization** - **Top 1%** of websites globally! 🏆


### PR DESCRIPTION
### Motivation
- Corriger le déploiement Cloudflare Pages pour que les Pages Functions (`/api/*`) soient réellement packagées et déployées via `wrangler` sans utiliser d’expressions invalides GitHub Actions en `env`, et sans dépendre de `steps.deploy.outputs.url` (qui n’existe plus avec `npx wrangler`).

### Description
- Ajouté une step réutilisable `Resolve Pages branch` (`id: pages-branch`) dans `.github/workflows/ci-cd-industrial.yml`, `.github/workflows/deploy.yml` et `.github/workflows/observatory-pipeline.yml` qui écrit `branch=...` dans `$GITHUB_OUTPUT` selon: `main` -> `main`, PR -> `github.head_ref`, sinon -> `github.ref_name`.
- Remplacé les expressions invalides `CF_PAGES_BRANCH: ${{ ... && ... || ... }}` par l’utilisation de la sortie `steps.pages-branch.outputs.branch` dans les commandes `npx wrangler@3 pages deploy` (ex: `--branch "${{ steps.pages-branch.outputs.branch }}"`).
- Conservé la compilation Wrangler des Pages Functions puis ajouté une vérification bloquante de présence et taille non nulle du bundle Worker via `test -s <path>/_worker.js` (`frontend/dist/_worker.js` ou `dist/_worker.js` selon le workflow) avant le `pages deploy`.
- Supprimé la dépendance à `steps.deploy.outputs.url` dans `ci-cd-industrial.yml` et remplacé l’output/log par l’URL Pages stable `https://akiprisaye-web.pages.dev`.
- Fichiers modifiés: `.github/workflows/ci-cd-industrial.yml`, `.github/workflows/deploy.yml`, `.github/workflows/observatory-pipeline.yml`, `README.md` (ajout d’une note sur le packaging `frontend/dist/_worker.js` et le déploiement via Wrangler).

### Testing
- Validé la syntaxe YAML des workflows avec `ruby -e 'require "yaml"; YAML.load_file(...)'` pour les trois fichiers et obtenu un chargement correct pour chaque fichier (OK).
- Recherché les références obsolètes/invalides avec `rg` (`steps.deploy.outputs.url`, `CF_PAGES_BRANCH`) et confirmé qu’il n’en reste plus (OK).
- Vérification locale des changements de contenu des workflows (insertion des steps `Resolve Pages branch` et `test -s`), et confirmation que les nouveaux `wrangler` invocations utilisent `steps.pages-branch.outputs.branch` (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991c30f0ab883218581c9d2747c54c9)