### PR TITLE
ci: enforce manual-only deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,6 @@
 name: Deploy to Cloudflare Pages
 
 on:
-  push:
-    branches:
-      - main        # déclenchement sur main
-      - copilot/create-citizen-support-service  # déclenchement sur la branche de développement
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/observatory-pipeline.yml
+++ b/.github/workflows/observatory-pipeline.yml
@@ -248,7 +248,7 @@ jobs:
     name: 🚀 Deploy to Cloudflare Pages
     runs-on: ubuntu-latest
     needs: [build-frontend, validate-security]
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    if: github.event_name == 'workflow_dispatch'
     
     steps:
       - name: 📥 Checkout code


### PR DESCRIPTION
### Motivation
- Prevent unintended automatic Cloudflare Pages deployments from secondary workflows so that automatic deployment remains controlled by the industrial pipeline.

### Description
- Make `.github/workflows/deploy.yml` manual-only by removing the `push` trigger and keeping `workflow_dispatch` only.
- Restrict the `deploy-cloudflare` job in `.github/workflows/observatory-pipeline.yml` to run only on `workflow_dispatch` instead of matching pushes to `main` and non-PR events.
- Keep the industrial pipeline (`.github/workflows/ci-cd-industrial.yml`) as the sole automatic deployer with a job-level concurrency lock for Pages deploys.

### Testing
- Ran `rg -n "on:\s*$|^\s+push:\s*$|cloudflare/pages-action@v1|wrangler@3 pages deploy"` to verify workflow triggers and deploy steps and confirmed the deploy workflows are correctly targeted.
- Loaded the modified workflows with `ruby -e 'require "yaml"; ...'` to ensure YAML validity and received OK for each file.
- Checked repository state with `git status --branch` to confirm a clean working tree in the environment.
- Attempted `git fetch origin` which failed because no remote `origin` is configured in this environment, so remote validation was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69920a8c6b2c8321bd61f213ddceba74)