### PR TITLE
Lock legacy deploy workflows to manual only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,6 @@
 name: Deploy to Cloudflare Pages
 
 on:
-  push:
-    branches:
-      - main        # déclenchement sur main
-      - copilot/create-citizen-support-service  # déclenchement sur la branche de développement
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/observatory-pipeline.yml
+++ b/.github/workflows/observatory-pipeline.yml
@@ -248,7 +248,7 @@ jobs:
     name: 🚀 Deploy to Cloudflare Pages
     runs-on: ubuntu-latest
     needs: [build-frontend, validate-security]
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    if: github.event_name == 'workflow_dispatch'
     
     steps:
       - name: 📥 Checkout code


### PR DESCRIPTION
### Motivation
- Prevent accidental automatic deployments by disabling `push` triggers and requiring manual dispatch via `workflow_dispatch`.
- Ensure the observatory pipeline only performs Cloudflare deploys when explicitly triggered to reduce risk of unintended releases.
- Establish a simple anti-regression state so future changes do not re-enable automated pushes without review.

### Description
- Removed the `push` trigger from `.github/workflows/deploy.yml`, leaving only `workflow_dispatch` as the entrypoint.
- Modified `.github/workflows/observatory-pipeline.yml` to change the `deploy-cloudflare` job condition to `if: github.event_name == 'workflow_dispatch'` so it runs only on manual dispatch.
- Saved and committed the updated workflow files and prepared this PR to lock legacy deploys to manual only.

### Testing
- Verified absence of `push` with `grep -n "^[[:space:]]*push:" .github/workflows/deploy.yml` and confirmed `deploy.yml` is manual-only.
- Applied the `sed` replacement to update the `if` condition and verified the change with `grep -n "if: github.event_name == 'workflow_dispatch'" .github/workflows/observatory-pipeline.yml` which succeeded.
- Reviewed `if:` occurrences using `grep -n "if:" .github/workflows/observatory-pipeline.yml | head -n 20` to confirm conditional logic.
- Confirmed the repository working tree reflected the staged changes and that the workflow files were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992188ba66883218ca9d58d7fb187ea)