### PR TITLE
CI: make legacy deploy.yml a safe manual static fallback

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,10 +40,12 @@ jobs:
 
       # Installation des dépendances du projet
       - name: Install dependencies
+        working-directory: frontend
         run: npm ci
 
       # Build de l'application Vite/React (génère le dossier dist)
       - name: Build application
+        working-directory: frontend
         run: npm run build
 
       # Déploiement du contenu du dossier dist vers Cloudflare Pages
@@ -54,7 +56,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: akiprisaye-web
           directory: frontend/dist             # important : dossier de build
-          functionsDirectory: functions
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       # Purge du cache inutile (pas de domaine personnalisé)


### PR DESCRIPTION
### Motivation
- Keep the legacy manual deploy as a safe fallback that only publishes the static frontend output and cannot accidentally deploy mismatched Functions.
- Ensure `npm` install/build run from `frontend` to match `frontend/package-lock.json` and the Vite project layout.
- Avoid deploying an outdated or misplaced Functions source by removing the `functionsDirectory` setting.

### Description
- Added `working-directory: frontend` to the `Install dependencies` and `Build application` steps in `.github/workflows/deploy.yml` so `npm ci` and `npm run build` run from the frontend folder.
- Removed the `functionsDirectory` key from the `cloudflare/pages-action` configuration so the workflow only publishes `directory: frontend/dist`.
- Preserved the manual-only trigger via `workflow_dispatch` and kept the existing `cache-dependency-path: 'frontend/package-lock.json'`.

### Testing
- Ran `git diff -- .github/workflows/deploy.yml` to verify the two `working-directory: frontend` additions and the removal of `functionsDirectory`, which reported the expected changes.
- Inspected the workflow file with `nl -ba .github/workflows/deploy.yml | sed -n '1,70p'` and `nl -ba .github/workflows/deploy.yml | sed -n '50,70p'` to confirm the file layout, `workflow_dispatch`, and `directory: frontend/dist`, and both inspections succeeded.
- Confirmed no other workflow keys were unintentionally modified during the change and the checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992322dc924832190edf20ed65775da)