### PR TITLE
ci: add deploy-regression-guard job and ensure ripgrep is available

### DIFF
--- a/.github/workflows/ci-cd-industrial.yml
+++ b/.github/workflows/ci-cd-industrial.yml
@@ -70,11 +70,48 @@ jobs:
           echo "ℹ️ Pull request detected: Cloudflare secret checks are skipped."
 
   # ========================================
+  # 1️⃣bis DEPLOY REGRESSION GUARD (BLOQUANT)
+  # ========================================
+  deploy-regression-guard:
+    name: 1️⃣bis Deploy Regression Guard
+    needs: preflight
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 🧰 Install ripgrep
+        run: |
+          if ! command -v rg >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y ripgrep
+          fi
+
+      - name: 🔍 Ensure legacy deploy.yml is manual-only
+        run: |
+          set -euo pipefail
+
+          DEPLOY_WORKFLOW=".github/workflows/deploy.yml"
+          test -f "$DEPLOY_WORKFLOW"
+
+          if ! rg -n '^\s*workflow_dispatch\s*:' "$DEPLOY_WORKFLOW" >/dev/null; then
+            echo "❌ $DEPLOY_WORKFLOW must expose workflow_dispatch"
+            exit 1
+          fi
+
+          if rg -n '^\s*(push|pull_request|schedule|workflow_run|repository_dispatch)\s*:' "$DEPLOY_WORKFLOW"; then
+            echo "❌ $DEPLOY_WORKFLOW must remain manual-only"
+            exit 1
+          fi
+
+          echo "✅ deploy.yml is manual-only"
+
+  # ========================================
   # 2️⃣ INSTALL & BUILD
   # ========================================
   build:
     name: 2️⃣ Install & Build
-    needs: preflight
+    needs: [preflight, deploy-regression-guard]
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout code


### PR DESCRIPTION
### Motivation
- The pipeline was failing due to missing `rg` (ripgrep) when verifying that the legacy deploy workflow is manual-only. 
- Add a blocking guard that verifies `.github/workflows/deploy.yml` remains manual-only to prevent accidental automatic deploy triggers. 

### Description
- Add a new blocking job `deploy-regression-guard` to `.github/workflows/ci-cd-industrial.yml` that runs after `preflight` and before build. 
- Install `ripgrep` at the start of the guard job and use it to check that `deploy.yml` exposes `workflow_dispatch` and does not contain automatic triggers (`push`, `pull_request`, `schedule`, `workflow_run`, `repository_dispatch`). 
- Make the `build` job depend on `deploy-regression-guard` so the guard must pass before continuing the pipeline. 

### Testing
- Parsed the modified YAML with Ruby using `YAML.load_file(...)` which succeeded. 
- Verified presence of the new job and expected strings with `rg -n "deploy-regression-guard|Install ripgrep|Ensure legacy deploy.yml is manual-only" .github/workflows/ci-cd-industrial.yml` which returned matches. 
- Basic syntax/line checks of the updated workflow file were inspected and produced expected contents.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922c24da948321b166224e61f860a0)