### PR TITLE
perf(frontend): code-split routes and vendor bundles (lazyPage + manualChunks)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { Suspense, useState, useEffect } from 'react';
+import { lazyPage } from './router/lazy';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 
 // Import Layout synchronously to prevent loading block
@@ -18,81 +19,81 @@ import { StoreSelectionProvider } from './context/StoreSelectionContext';
 import { logDebug } from './utils/logger';
 
 // Lazy-loaded pages - Main routes
-const Home = React.lazy(() => import('./pages/Home'));
-const Carte = React.lazy(() => import('./pages/Carte'));
-const MapPage = React.lazy(() => import('./pages/MapPage'));
-const AdminDashboard = React.lazy(() => import('./pages/AdminDashboard'));
-const Comparateur = React.lazy(() => import('./pages/Comparateur'));
+const Home = lazyPage(() => import('./pages/Home'));
+const Carte = lazyPage(() => import('./pages/Carte'));
+const MapPage = lazyPage(() => import('./pages/MapPage'));
+const AdminDashboard = lazyPage(() => import('./pages/AdminDashboard'));
+const Comparateur = lazyPage(() => import('./pages/Comparateur'));
 
 // New Admin pages
-const AdminLayout = React.lazy(() => import('./pages/admin/AdminLayout'));
-const AdminDashboardNew = React.lazy(() => import('./pages/admin/AdminDashboard'));
-const StoreList = React.lazy(() => import('./pages/admin/stores/StoreList'));
-const StoreForm = React.lazy(() => import('./pages/admin/stores/StoreForm'));
-const StoreDetail = React.lazy(() => import('./pages/admin/stores/StoreDetail'));
-const ProductList = React.lazy(() => import('./pages/admin/products/ProductList').then(m => ({ default: m.ProductList })));
-const ProductForm = React.lazy(() => import('./pages/admin/products/ProductForm').then(m => ({ default: m.ProductForm })));
-const ProductDetail = React.lazy(() => import('./pages/admin/products/ProductDetail').then(m => ({ default: m.ProductDetail })));
-const ImportPage = React.lazy(() => import('./pages/admin/import/ImportPage'));
-const ObservatoireHub = React.lazy(() => import('./pages/ObservatoireHub'));
-const Methodologie = React.lazy(() => import('./pages/Methodologie'));
-const Faq = React.lazy(() => import('./pages/Faq'));
-const Contact = React.lazy(() => import('./pages/Contact'));
-const MentionsLegales = React.lazy(() => import('./pages/MentionsLegales'));
+const AdminLayout = lazyPage(() => import('./pages/admin/AdminLayout'));
+const AdminDashboardNew = lazyPage(() => import('./pages/admin/AdminDashboard'));
+const StoreList = lazyPage(() => import('./pages/admin/stores/StoreList'));
+const StoreForm = lazyPage(() => import('./pages/admin/stores/StoreForm'));
+const StoreDetail = lazyPage(() => import('./pages/admin/stores/StoreDetail'));
+const ProductList = lazyPage(() => import('./pages/admin/products/ProductList').then(m => ({ default: m.ProductList })));
+const ProductForm = lazyPage(() => import('./pages/admin/products/ProductForm').then(m => ({ default: m.ProductForm })));
+const ProductDetail = lazyPage(() => import('./pages/admin/products/ProductDetail').then(m => ({ default: m.ProductDetail })));
+const ImportPage = lazyPage(() => import('./pages/admin/import/ImportPage'));
+const ObservatoireHub = lazyPage(() => import('./pages/ObservatoireHub'));
+const Methodologie = lazyPage(() => import('./pages/Methodologie'));
+const Faq = lazyPage(() => import('./pages/Faq'));
+const Contact = lazyPage(() => import('./pages/Contact'));
+const MentionsLegales = lazyPage(() => import('./pages/MentionsLegales'));
 
 // Additional feature pages
-const DonneesPubliques = React.lazy(() => import('./pages/DonneesPubliques'));
-const Contribuer = React.lazy(() => import('./pages/Contribuer'));
-const ContribuerPrix = React.lazy(() => import('./pages/ContribuerPrix'));
-const Comparateurs = React.lazy(() => import('./pages/Comparateurs'));
-const CarteItinerairesHub = React.lazy(() => import('./pages/CarteItinerairesHub'));
-const ComparateurCitoyen = React.lazy(() => import('./pages/ComparateurCitoyen'));
-const LutteVieChere = React.lazy(() => import('./pages/LutteVieChereIndexPage'));
+const DonneesPubliques = lazyPage(() => import('./pages/DonneesPubliques'));
+const Contribuer = lazyPage(() => import('./pages/Contribuer'));
+const ContribuerPrix = lazyPage(() => import('./pages/ContribuerPrix'));
+const Comparateurs = lazyPage(() => import('./pages/Comparateurs'));
+const CarteItinerairesHub = lazyPage(() => import('./pages/CarteItinerairesHub'));
+const ComparateurCitoyen = lazyPage(() => import('./pages/ComparateurCitoyen'));
+const LutteVieChere = lazyPage(() => import('./pages/LutteVieChereIndexPage'));
 
 // Scanner & OCR pages
-const ScannerHub = React.lazy(() => import('./pages/ScannerHub'));
-const OCRHub = React.lazy(() => import('./pages/ocr/OCRHub'));
-const ScanEAN = React.lazy(() => import('./pages/ScanEAN'));
-const ProductPhotoAnalysis = React.lazy(() => import('./pages/ProductPhotoAnalysis'));
-const ComparaisonEnseignes = React.lazy(() => import('./pages/ComparaisonEnseignes'));
-const BasketComparison = React.lazy(() => import('./pages/BasketComparison'));
+const ScannerHub = lazyPage(() => import('./pages/ScannerHub'));
+const OCRHub = lazyPage(() => import('./pages/ocr/OCRHub'));
+const ScanEAN = lazyPage(() => import('./pages/ScanEAN'));
+const ProductPhotoAnalysis = lazyPage(() => import('./pages/ProductPhotoAnalysis'));
+const ComparaisonEnseignes = lazyPage(() => import('./pages/ComparaisonEnseignes'));
+const BasketComparison = lazyPage(() => import('./pages/BasketComparison'));
 
 // Settings & History
-const Settings = React.lazy(() => import('./pages/Settings'));
-const HistoriquePrix = React.lazy(() => import('./pages/HistoriquePrix'));
-const RecherchePrix = React.lazy(() => import('./pages/RecherchePrix'));
-const ProductDetailPage = React.lazy(() => import('./pages/ProductDetail'));
-const Alertes = React.lazy(() => import('./pages/Alertes'));
-const AlerteDetail = React.lazy(() => import('./pages/AlerteDetail'));
-const Promos = React.lazy(() => import('./pages/Promos'));
-const MesListes = React.lazy(() => import('./pages/MesListes'));
+const Settings = lazyPage(() => import('./pages/Settings'));
+const HistoriquePrix = lazyPage(() => import('./pages/HistoriquePrix'));
+const RecherchePrix = lazyPage(() => import('./pages/RecherchePrix'));
+const ProductDetailPage = lazyPage(() => import('./pages/ProductDetail'));
+const Alertes = lazyPage(() => import('./pages/Alertes'));
+const AlerteDetail = lazyPage(() => import('./pages/AlerteDetail'));
+const Promos = lazyPage(() => import('./pages/Promos'));
+const MesListes = lazyPage(() => import('./pages/MesListes'));
 
 // Savings Dashboard
-const MesEconomies = React.lazy(() => import('./pages/MesEconomies'));
+const MesEconomies = lazyPage(() => import('./pages/MesEconomies'));
 
 // Auth pages
-const Login = React.lazy(() => import('./pages/Login'));
-const Inscription = React.lazy(() => import('./pages/Inscription'));
-const ResetPassword = React.lazy(() => import('./pages/ResetPassword'));
-const MonCompte = React.lazy(() => import('./pages/MonCompte'));
-const AuthHub = React.lazy(() => import('./pages/AuthHub'));
+const Login = lazyPage(() => import('./pages/Login'));
+const Inscription = lazyPage(() => import('./pages/Inscription'));
+const ResetPassword = lazyPage(() => import('./pages/ResetPassword'));
+const MonCompte = lazyPage(() => import('./pages/MonCompte'));
+const AuthHub = lazyPage(() => import('./pages/AuthHub'));
 
 // Pricing & Subscription
-const Pricing = React.lazy(() => import('./pages/Pricing'));
-const Subscribe = React.lazy(() => import('./pages/Subscribe'));
+const Pricing = lazyPage(() => import('./pages/Pricing'));
+const Subscribe = lazyPage(() => import('./pages/Subscribe'));
 
 // Observatory real-time
-const ObservatoireTempsReel = React.lazy(() => import('./pages/ObservatoireTempsReel'));
+const ObservatoireTempsReel = lazyPage(() => import('./pages/ObservatoireTempsReel'));
 
 // Transparency & reporting
-const Transparence = React.lazy(() => import('./pages/Transparence'));
-const SignalerAbus = React.lazy(() => import('./pages/SignalerAbus'));
+const Transparence = lazyPage(() => import('./pages/Transparence'));
+const SignalerAbus = lazyPage(() => import('./pages/SignalerAbus'));
 
 // Admin Sync Dashboard
-const SyncDashboard = React.lazy(() => import('./pages/admin/sync/SyncDashboard'));
+const SyncDashboard = lazyPage(() => import('./pages/admin/sync/SyncDashboard'));
 
 // i18n Test page (for development/testing)
-const I18nTest = React.lazy(() => import('./pages/I18nTest'));
+const I18nTest = lazyPage(() => import('./pages/I18nTest'));
 
 function LoadingFallback() {
   const [showTimeout, setShowTimeout] = useState(false);

--- a/frontend/src/router/lazy.ts
+++ b/frontend/src/router/lazy.ts
@@ -1,0 +1,8 @@
+import React from 'react'
+
+export function lazyPage<T extends React.ComponentType<any>>(
+  factory: () => Promise<{ default: T }>
+) {
+  return React.lazy(factory)
+}
+

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -63,6 +63,93 @@ export default defineConfig({
     minify: 'esbuild',
     sourcemap: false,
     chunkSizeWarningLimit: 300,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) {
+            return
+          }
+
+          if (id.includes('leaflet.markercluster')) {
+            return 'leaflet-cluster'
+          }
+
+          if (id.includes('leaflet')) {
+            return 'leaflet'
+          }
+
+          if (id.includes('zod')) {
+            return 'zod'
+          }
+
+          if (id.includes('/firebase/firestore') || id.includes('@firebase/firestore') || id.includes('firebase-firestore')) {
+            return 'firebase-firestore'
+          }
+
+          if (id.includes('/firebase/auth') || id.includes('@firebase/auth')) {
+            return 'firebase-auth'
+          }
+
+          if (id.includes('/firebase/analytics') || id.includes('@firebase/analytics')) {
+            return 'firebase-analytics'
+          }
+
+          if (id.includes('node_modules/recharts')) {
+            return 'recharts'
+          }
+
+          if (id.includes('node_modules/chart.js') || id.includes('node_modules/react-chartjs-2')) {
+            return 'chartjs'
+          }
+
+          if (id.includes('node_modules/d3-')) {
+            return 'd3'
+          }
+
+          if (id.includes('node_modules/victory')) {
+            return 'victory'
+          }
+
+          const modulePath = id.split('node_modules/')[1]
+          if (!modulePath) {
+            return 'vendor'
+          }
+
+          const parts = modulePath.split('/')
+          const packageName = parts[0].startsWith('@') ? `${parts[0]}/${parts[1]}` : parts[0]
+
+          if (['react', 'react-dom', 'react-router', 'react-router-dom', 'scheduler'].includes(packageName)) {
+            return 'react-vendor'
+          }
+
+          if (packageName.startsWith('firebase') || packageName.startsWith('@firebase/')) {
+            return 'firebase-core'
+          }
+
+          if (packageName.startsWith('@tanstack/')) {
+            return 'tanstack'
+          }
+
+          if (['i18next', 'react-i18next', 'i18next-http-backend'].includes(packageName)) {
+            return 'i18n'
+          }
+
+          if (packageName === 'tesseract.js') {
+            return 'tesseract'
+          }
+
+          if (packageName === 'lucide-react') {
+            return 'icons'
+          }
+
+          if (['lodash', 'fuse.js', 'papaparse'].includes(packageName)) {
+            return 'data-utils'
+          }
+
+          return 'vendor'
+        }
+      }
+    }
   },
   server: {
     port: 3000,


### PR DESCRIPTION
### Motivation
- Réduire la taille du bundle principal (<300 kB visé) et améliorer le LCP/mobile en différant le chargement des pages lourdes et en isolant les grosses dépendances.

### Description
- Ajout d'un helper `lazyPage` dans `frontend/src/router/lazy.ts` et migration des imports de pages dans `frontend/src/App.tsx` pour utiliser `lazyPage(...)` de façon homogène.
- Ajout d'une stratégie `build.rollupOptions.output.manualChunks` dans `frontend/vite.config.ts` pour extraire les bibliothèques lourdes en chunks dédiés (`leaflet`, `leaflet-cluster`, `zod`, sous-bundles `firebase-*`, `recharts`, `chartjs`, `d3`, `@tanstack/*`, `i18n`, `tesseract`, icônes, `data-utils`, etc.) avec un fallback `vendor`.
- Ajustements itératifs de la logique `manualChunks` pour réduire les problèmes de chunks circulaires et isoler correctement les sous-modules Firebase et charting.

### Testing
- Exécuté `cd frontend && npm run build` plusieurs fois et les builds se sont terminés avec succès, la sortie montre une entrée principale réduite (~100–110 kB minifié) et des chunks séparés pour les libs lourdes.
- Exécuté `cd frontend && npx vite-bundle-visualizer` et un `dist/stats.html` a été généré pour inspection visuelle des chunks.
- Les builds automatisés ont réussi mais ont encore produit quelques gros vendor-chunks isolés (analytics/charting/firebase) qui restent visibles et pourront être affinés ultérieurement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699278fd4208832194f25af7b6abfd65)