### PR TITLE
perf(frontend): isolate admin startup cost and harden chunk splitting

### DIFF
--- a/.github/workflows/observatory-pipeline.yml
+++ b/.github/workflows/observatory-pipeline.yml
@@ -268,7 +268,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: akiprisaye-web
           directory: dist
-          functionsDirectory: functions
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📊 Deployment summary

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,82 +17,88 @@ import AnalyticsTracker from './components/analytics/AnalyticsTracker';
 import { StoreSelectionProvider } from './context/StoreSelectionContext';
 import { logDebug } from './utils/logger';
 
-// Lazy-loaded pages - Main routes
-const Home = React.lazy(() => import('./pages/Home'));
-const Carte = React.lazy(() => import('./pages/Carte'));
-const MapPage = React.lazy(() => import('./pages/MapPage'));
-const AdminDashboard = React.lazy(() => import('./pages/AdminDashboard'));
-const Comparateur = React.lazy(() => import('./pages/Comparateur'));
+const lazyPage = <T extends React.ComponentType<any>>(
+  loader: () => Promise<{ default: T }>
+) => React.lazy(loader);
 
-// New Admin pages
-const AdminLayout = React.lazy(() => import('./pages/admin/AdminLayout'));
-const AdminDashboardNew = React.lazy(() => import('./pages/admin/AdminDashboard'));
-const StoreList = React.lazy(() => import('./pages/admin/stores/StoreList'));
-const StoreForm = React.lazy(() => import('./pages/admin/stores/StoreForm'));
-const StoreDetail = React.lazy(() => import('./pages/admin/stores/StoreDetail'));
-const ProductList = React.lazy(() => import('./pages/admin/products/ProductList').then(m => ({ default: m.ProductList })));
-const ProductForm = React.lazy(() => import('./pages/admin/products/ProductForm').then(m => ({ default: m.ProductForm })));
-const ProductDetail = React.lazy(() => import('./pages/admin/products/ProductDetail').then(m => ({ default: m.ProductDetail })));
-const ImportPage = React.lazy(() => import('./pages/admin/import/ImportPage'));
-const ObservatoireHub = React.lazy(() => import('./pages/ObservatoireHub'));
-const Methodologie = React.lazy(() => import('./pages/Methodologie'));
-const Faq = React.lazy(() => import('./pages/Faq'));
-const Contact = React.lazy(() => import('./pages/Contact'));
-const MentionsLegales = React.lazy(() => import('./pages/MentionsLegales'));
+const prefetch = (loader: () => Promise<unknown>) => {
+  const run = () => loader().catch(() => undefined);
+
+  if (typeof window === 'undefined') return;
+
+  if ('requestIdleCallback' in window) {
+    (window as Window & {
+      requestIdleCallback: (callback: IdleRequestCallback) => number;
+    }).requestIdleCallback(run);
+    return;
+  }
+
+  window.setTimeout(run, 1500);
+};
+
+// Lazy-loaded pages - Main routes
+const Home = lazyPage(() => import('./pages/Home'));
+const Carte = lazyPage(() => import('./pages/Carte'));
+const MapPage = lazyPage(() => import('./pages/MapPage'));
+const AdminDashboard = lazyPage(() => import('./pages/AdminDashboard'));
+const Comparateur = lazyPage(() => import('./pages/Comparateur'));
+const AdminRoutes = lazyPage(() => import('./pages/admin/AdminRoutes'));
+const ObservatoireHub = lazyPage(() => import('./pages/ObservatoireHub'));
+const Methodologie = lazyPage(() => import('./pages/Methodologie'));
+const Faq = lazyPage(() => import('./pages/Faq'));
+const Contact = lazyPage(() => import('./pages/Contact'));
+const MentionsLegales = lazyPage(() => import('./pages/MentionsLegales'));
 
 // Additional feature pages
-const DonneesPubliques = React.lazy(() => import('./pages/DonneesPubliques'));
-const Contribuer = React.lazy(() => import('./pages/Contribuer'));
-const ContribuerPrix = React.lazy(() => import('./pages/ContribuerPrix'));
-const Comparateurs = React.lazy(() => import('./pages/Comparateurs'));
-const CarteItinerairesHub = React.lazy(() => import('./pages/CarteItinerairesHub'));
-const ComparateurCitoyen = React.lazy(() => import('./pages/ComparateurCitoyen'));
-const LutteVieChere = React.lazy(() => import('./pages/LutteVieChereIndexPage'));
+const DonneesPubliques = lazyPage(() => import('./pages/DonneesPubliques'));
+const Contribuer = lazyPage(() => import('./pages/Contribuer'));
+const ContribuerPrix = lazyPage(() => import('./pages/ContribuerPrix'));
+const Comparateurs = lazyPage(() => import('./pages/Comparateurs'));
+const CarteItinerairesHub = lazyPage(() => import('./pages/CarteItinerairesHub'));
+const ComparateurCitoyen = lazyPage(() => import('./pages/ComparateurCitoyen'));
+const LutteVieChere = lazyPage(() => import('./pages/LutteVieChereIndexPage'));
 
 // Scanner & OCR pages
-const ScannerHub = React.lazy(() => import('./pages/ScannerHub'));
-const OCRHub = React.lazy(() => import('./pages/ocr/OCRHub'));
-const ScanEAN = React.lazy(() => import('./pages/ScanEAN'));
-const ProductPhotoAnalysis = React.lazy(() => import('./pages/ProductPhotoAnalysis'));
-const ComparaisonEnseignes = React.lazy(() => import('./pages/ComparaisonEnseignes'));
-const BasketComparison = React.lazy(() => import('./pages/BasketComparison'));
+const ScannerHub = lazyPage(() => import('./pages/ScannerHub'));
+const OCRHub = lazyPage(() => import('./pages/ocr/OCRHub'));
+const ScanEAN = lazyPage(() => import('./pages/ScanEAN'));
+const ProductPhotoAnalysis = lazyPage(() => import('./pages/ProductPhotoAnalysis'));
+const ComparaisonEnseignes = lazyPage(() => import('./pages/ComparaisonEnseignes'));
+const BasketComparison = lazyPage(() => import('./pages/BasketComparison'));
 
 // Settings & History
-const Settings = React.lazy(() => import('./pages/Settings'));
-const HistoriquePrix = React.lazy(() => import('./pages/HistoriquePrix'));
-const RecherchePrix = React.lazy(() => import('./pages/RecherchePrix'));
-const ProductDetailPage = React.lazy(() => import('./pages/ProductDetail'));
-const Alertes = React.lazy(() => import('./pages/Alertes'));
-const AlerteDetail = React.lazy(() => import('./pages/AlerteDetail'));
-const Promos = React.lazy(() => import('./pages/Promos'));
-const MesListes = React.lazy(() => import('./pages/MesListes'));
+const Settings = lazyPage(() => import('./pages/Settings'));
+const HistoriquePrix = lazyPage(() => import('./pages/HistoriquePrix'));
+const RecherchePrix = lazyPage(() => import('./pages/RecherchePrix'));
+const ProductDetailPage = lazyPage(() => import('./pages/ProductDetail'));
+const Alertes = lazyPage(() => import('./pages/Alertes'));
+const AlerteDetail = lazyPage(() => import('./pages/AlerteDetail'));
+const Promos = lazyPage(() => import('./pages/Promos'));
+const MesListes = lazyPage(() => import('./pages/MesListes'));
 
 // Savings Dashboard
-const MesEconomies = React.lazy(() => import('./pages/MesEconomies'));
+const MesEconomies = lazyPage(() => import('./pages/MesEconomies'));
 
 // Auth pages
-const Login = React.lazy(() => import('./pages/Login'));
-const Inscription = React.lazy(() => import('./pages/Inscription'));
-const ResetPassword = React.lazy(() => import('./pages/ResetPassword'));
-const MonCompte = React.lazy(() => import('./pages/MonCompte'));
-const AuthHub = React.lazy(() => import('./pages/AuthHub'));
+const Login = lazyPage(() => import('./pages/Login'));
+const Inscription = lazyPage(() => import('./pages/Inscription'));
+const ResetPassword = lazyPage(() => import('./pages/ResetPassword'));
+const MonCompte = lazyPage(() => import('./pages/MonCompte'));
+const AuthHub = lazyPage(() => import('./pages/AuthHub'));
 
 // Pricing & Subscription
-const Pricing = React.lazy(() => import('./pages/Pricing'));
-const Subscribe = React.lazy(() => import('./pages/Subscribe'));
+const Pricing = lazyPage(() => import('./pages/Pricing'));
+const Subscribe = lazyPage(() => import('./pages/Subscribe'));
 
 // Observatory real-time
-const ObservatoireTempsReel = React.lazy(() => import('./pages/ObservatoireTempsReel'));
+const ObservatoireTempsReel = lazyPage(() => import('./pages/ObservatoireTempsReel'));
 
 // Transparency & reporting
-const Transparence = React.lazy(() => import('./pages/Transparence'));
-const SignalerAbus = React.lazy(() => import('./pages/SignalerAbus'));
-
-// Admin Sync Dashboard
-const SyncDashboard = React.lazy(() => import('./pages/admin/sync/SyncDashboard'));
+const Transparence = lazyPage(() => import('./pages/Transparence'));
+const SignalerAbus = lazyPage(() => import('./pages/SignalerAbus'));
 
 // i18n Test page (for development/testing)
-const I18nTest = React.lazy(() => import('./pages/I18nTest'));
+const I18nTest = lazyPage(() => import('./pages/I18nTest'));
 
 function LoadingFallback() {
   const [showTimeout, setShowTimeout] = useState(false);
@@ -151,6 +157,11 @@ export default function App() {
     }
   }, []);
 
+  useEffect(() => {
+    prefetch(() => import('./pages/Comparateur'));
+    prefetch(() => import('./pages/ObservatoireHub'));
+  }, []);
+
   if (providerError) {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center bg-slate-900 text-white p-4">
@@ -177,20 +188,8 @@ export default function App() {
               <BrowserRouter>
                 <Suspense fallback={<LoadingFallback />}>
                   <Routes>
-                    {/* Admin routes with dedicated layout */}
-                    <Route path="/admin" element={<AdminLayout />}>
-                      <Route index element={<AdminDashboardNew />} />
-                      <Route path="stores" element={<StoreList />} />
-                      <Route path="stores/new" element={<StoreForm />} />
-                      <Route path="stores/:id" element={<StoreDetail />} />
-                      <Route path="stores/:id/edit" element={<StoreForm />} />
-                      <Route path="products" element={<ProductList />} />
-                      <Route path="products/new" element={<ProductForm />} />
-                      <Route path="products/:id" element={<ProductDetail />} />
-                      <Route path="products/:id/edit" element={<ProductForm />} />
-                      <Route path="import" element={<ImportPage />} />
-                      <Route path="sync" element={<SyncDashboard />} />
-                    </Route>
+                    {/* Admin routes as isolated lazy bundle */}
+                    <Route path="/admin/*" element={<AdminRoutes />} />
                     
                     {/* Main site routes with Layout */}
                     <Route path="/" element={<Layout />}>
@@ -261,9 +260,6 @@ export default function App() {
                       {/* Transparency & reporting */}
                       <Route path="transparence" element={<Transparence />} />
                       <Route path="signaler-abus" element={<SignalerAbus />} />
-                      
-                      {/* Admin routes */}
-                      <Route path="admin/sync" element={<SyncDashboard />} />
                       
                       {/* i18n Test (development/testing) */}
                       <Route path="test-i18n" element={<I18nTest />} />

--- a/frontend/src/pages/admin/AdminRoutes.tsx
+++ b/frontend/src/pages/admin/AdminRoutes.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Route, Routes } from 'react-router-dom';
+
+const AdminLayout = React.lazy(() => import('./AdminLayout'));
+const AdminDashboard = React.lazy(() => import('./AdminDashboard'));
+const StoreList = React.lazy(() => import('./stores/StoreList'));
+const StoreForm = React.lazy(() => import('./stores/StoreForm'));
+const StoreDetail = React.lazy(() => import('./stores/StoreDetail'));
+const ProductList = React.lazy(() => import('./products/ProductList').then((m) => ({ default: m.ProductList })));
+const ProductForm = React.lazy(() => import('./products/ProductForm').then((m) => ({ default: m.ProductForm })));
+const ProductDetail = React.lazy(() => import('./products/ProductDetail').then((m) => ({ default: m.ProductDetail })));
+const ImportPage = React.lazy(() => import('./import/ImportPage'));
+const SyncDashboard = React.lazy(() => import('./sync/SyncDashboard'));
+
+export default function AdminRoutes() {
+  return (
+    <Routes>
+      <Route element={<AdminLayout />}>
+        <Route index element={<AdminDashboard />} />
+        <Route path="stores" element={<StoreList />} />
+        <Route path="stores/new" element={<StoreForm />} />
+        <Route path="stores/:id" element={<StoreDetail />} />
+        <Route path="stores/:id/edit" element={<StoreForm />} />
+        <Route path="products" element={<ProductList />} />
+        <Route path="products/new" element={<ProductForm />} />
+        <Route path="products/:id" element={<ProductDetail />} />
+        <Route path="products/:id/edit" element={<ProductForm />} />
+        <Route path="import" element={<ImportPage />} />
+        <Route path="sync" element={<SyncDashboard />} />
+      </Route>
+    </Routes>
+  );
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -62,7 +62,41 @@ export default defineConfig({
     target: 'es2019',
     minify: 'esbuild',
     sourcemap: false,
-    chunkSizeWarningLimit: 300,
+    cssCodeSplit: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return;
+
+          if (id.includes('leaflet.markercluster')) {
+            return 'leaflet-cluster-vendor';
+          }
+
+          if (id.includes('leaflet') || id.includes('react-leaflet')) {
+            return 'leaflet-vendor';
+          }
+
+          if (id.includes('zod')) {
+            return 'zod-vendor';
+          }
+
+          if (id.includes('recharts') || id.includes('d3') || id.includes('chart.js') || id.includes('react-chartjs-2')) {
+            return 'charts-vendor';
+          }
+
+          if (id.includes('@tanstack')) {
+            return 'tanstack-vendor';
+          }
+
+          if (id.includes('i18next') || id.includes('react-i18next')) {
+            return 'i18n-vendor';
+          }
+
+          return 'vendor';
+        }
+      }
+    },
+    chunkSizeWarningLimit: 700,
   },
   server: {
     port: 3000,


### PR DESCRIPTION
### Motivation
- Reduce first-load bundle for mobile (4G / DOM-TOM) by removing heavy deps from entry bundles.
- Ensure large modules like `leaflet`, charts and admin pages never load at startup to lower TTI and data usage.
- Make vendor chunks stable and cacheable to reduce re-downloads across deployments.

### Description
- Add explicit `manualChunks` and `cssCodeSplit` in `frontend/vite.config.ts` to split `leaflet`, `leaflet.markercluster`, `charts`, `zod`, `@tanstack`, `i18n` and a `vendor` fallback into dedicated, stable chunks and raise `chunkSizeWarningLimit`. 
- Refactor `frontend/src/App.tsx` to introduce a `lazyPage` helper, an idle-time `prefetch` helper, convert route imports to the helper and prefetch likely next pages (`Comparateur`, `ObservatoireHub`) after load. 
- Isolate the entire admin UI behind a single lazy boundary by adding `frontend/src/pages/admin/AdminRoutes.tsx` and routing `/admin/*` to that module so admin code emits as one separate chunk. 
- Remove unsupported `functionsDirectory` input from `.github/workflows/observatory-pipeline.yml` to remove the Cloudflare Pages warning.

### Testing
- Ran a full production build with `cd frontend && npm run build` and the build completed successfully without errors. 
- Verified assets with `ls -lh dist/assets | sort -hk5 | tail -n 30` and observed dedicated `leaflet-vendor*`, `charts-vendor*`, `zod-vendor*`, `tanstack-vendor*` and an isolated `AdminRoutes-*.js` loader chunk. 
- Checked entry bundle for eager leaflet imports using `INDEX="$(ls dist/assets/index-*.js | head -n 1)"; grep -n "leaflet" "$INDEX"` and confirmed there is no static eager import of `leaflet` in the entry chunk. 
- Noted a non-blocking circular-chunk warning (`i18n-vendor <-> vendor`) reported by the bundler which does not prevent the build but can be tuned in a follow-up PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69927c17227483218256ab1104ff4b9e)