### PR TITLE
feat(frontend): add modular tips engine with savings score and premium badge

### DIFF
--- a/frontend/src/features/tips/engine.ts
+++ b/frontend/src/features/tips/engine.ts
@@ -1,0 +1,15 @@
+import type { Tip, TipContext, TipRule } from './types';
+
+export function runTips(rules: TipRule[], ctx: TipContext): Tip[] {
+  const tips = rules.flatMap((rule) => rule.run(ctx));
+
+  const byId = new Map<string, Tip>();
+  for (const tip of tips) {
+    const previous = byId.get(tip.id);
+    if (!previous || tip.confidence > previous.confidence) {
+      byId.set(tip.id, tip);
+    }
+  }
+
+  return Array.from(byId.values()).sort((a, b) => b.confidence - a.confidence);
+}

--- a/frontend/src/features/tips/index.ts
+++ b/frontend/src/features/tips/index.ts
@@ -1,0 +1,41 @@
+import { runTips } from './engine';
+import { computeSavingsScore, isPremiumTipEnabled } from './scorer';
+import { ruleHighVariance } from './rules/ruleHighVariance';
+import { rulePriceAboveMedian } from './rules/rulePriceAboveMedian';
+import { ruleSeasonality } from './rules/ruleSeasonality';
+import { ruleTerritoryHeuristics } from './rules/ruleTerritoryHeuristics';
+import type { Tip, TipContext, TipRule } from './types';
+
+export const tipRules: TipRule[] = [
+  rulePriceAboveMedian,
+  ruleHighVariance,
+  ruleTerritoryHeuristics,
+  ruleSeasonality,
+];
+
+export function buildTips(ctx: TipContext): { tips: Tip[]; score: number; premiumEnabled: boolean } {
+  const score = computeSavingsScore(ctx);
+  const tips = runTips(tipRules, ctx);
+  const premiumEnabled = isPremiumTipEnabled(score);
+
+  const premiumTip: Tip[] = premiumEnabled
+    ? [
+        {
+          id: 'tip.premium',
+          message:
+            'Astuce Premium : comparez 2 enseignes + marque distributeur, l’économie potentielle est élevée.',
+          severity: 'premium',
+          confidence: 0.9,
+          tags: ['premium', 'économie'],
+        },
+      ]
+    : [];
+
+  return {
+    tips: [...premiumTip, ...tips],
+    score,
+    premiumEnabled,
+  };
+}
+
+export type { Tip, TipContext, TipRule } from './types';

--- a/frontend/src/features/tips/rules/ruleHighVariance.ts
+++ b/frontend/src/features/tips/rules/ruleHighVariance.ts
@@ -1,0 +1,28 @@
+import type { TipRule } from '../types';
+
+export const ruleHighVariance: TipRule = {
+  id: 'high-variance',
+  run(ctx) {
+    const min = ctx.interval?.min;
+    const max = ctx.interval?.max;
+
+    if (!min || !max || max <= 0 || min <= 0 || max <= min) {
+      return [];
+    }
+
+    const spread = (max - min) / max;
+    if (spread < 0.2) {
+      return [];
+    }
+
+    return [
+      {
+        id: 'tip.highVariance',
+        message: 'Écart important entre enseignes : vous pouvez économiser en changeant de magasin.',
+        severity: 'info',
+        confidence: Math.min(1, spread * 2),
+        tags: ['écart', 'enseignes'],
+      },
+    ];
+  },
+};

--- a/frontend/src/features/tips/rules/rulePriceAboveMedian.ts
+++ b/frontend/src/features/tips/rules/rulePriceAboveMedian.ts
@@ -1,0 +1,28 @@
+import type { TipRule } from '../types';
+
+export const rulePriceAboveMedian: TipRule = {
+  id: 'price-above-median',
+  run(ctx) {
+    const price = ctx.price;
+    const median = ctx.interval?.median;
+
+    if (!price || !median || price <= 0 || median <= 0) {
+      return [];
+    }
+
+    const ratio = price / median;
+    if (ratio < 1.15) {
+      return [];
+    }
+
+    return [
+      {
+        id: 'tip.priceAboveMedian',
+        message: 'Prix au-dessus de la médiane locale : comparez avant d’acheter.',
+        severity: 'warn',
+        confidence: Math.min(1, (ratio - 1) / 0.5),
+        tags: ['prix', 'comparaison'],
+      },
+    ];
+  },
+};

--- a/frontend/src/features/tips/rules/ruleSeasonality.ts
+++ b/frontend/src/features/tips/rules/ruleSeasonality.ts
@@ -1,0 +1,39 @@
+import type { TipRule } from '../types';
+
+const PEAK_MONTHS_BY_CATEGORY: Record<string, number[]> = {
+  fruit: [6, 7, 8],
+  fruits: [6, 7, 8],
+  legumes: [11, 12, 1, 2],
+  légume: [11, 12, 1, 2],
+  laits: [8, 9],
+};
+
+export const ruleSeasonality: TipRule = {
+  id: 'seasonality',
+  run(ctx) {
+    const month = ctx.month;
+    if (!month || month < 1 || month > 12) {
+      return [];
+    }
+
+    const categoryKey = ctx.category?.trim().toLowerCase();
+    if (!categoryKey) {
+      return [];
+    }
+
+    const peakMonths = PEAK_MONTHS_BY_CATEGORY[categoryKey];
+    if (!peakMonths || peakMonths.includes(month)) {
+      return [];
+    }
+
+    return [
+      {
+        id: `tip.seasonality.${categoryKey}`,
+        message: 'Produit hors période de prix favorable : vérifiez une alternative de saison.',
+        severity: 'info',
+        confidence: 0.45,
+        tags: ['saisonnalité'],
+      },
+    ];
+  },
+};

--- a/frontend/src/features/tips/rules/ruleTerritoryHeuristics.ts
+++ b/frontend/src/features/tips/rules/ruleTerritoryHeuristics.ts
@@ -1,0 +1,22 @@
+import type { TipRule } from '../types';
+
+const DOM_TERRITORIES = new Set(['gp', 'mq', 'gf', 're', 'yt']);
+
+export const ruleTerritoryHeuristics: TipRule = {
+  id: 'territory-heuristics',
+  run(ctx) {
+    if (!ctx.territory || !DOM_TERRITORIES.has(ctx.territory)) {
+      return [];
+    }
+
+    return [
+      {
+        id: 'tip.domHeuristic',
+        message: 'En DOM-TOM, les arrivages influencent fortement les prix : surveillez les variations hebdomadaires.',
+        severity: 'info',
+        confidence: 0.75,
+        tags: ['domtom', 'arrivages'],
+      },
+    ];
+  },
+};

--- a/frontend/src/features/tips/scorer.ts
+++ b/frontend/src/features/tips/scorer.ts
@@ -1,0 +1,32 @@
+import type { TipContext } from './types';
+
+const DOM_TERRITORIES = new Set(['gp', 'mq', 'gf', 're', 'yt']);
+
+export function computeSavingsScore(ctx: TipContext): number {
+  const observedPrice = ctx.price ?? null;
+  const median = ctx.interval?.median ?? null;
+  const min = ctx.interval?.min ?? null;
+  const max = ctx.interval?.max ?? null;
+
+  let score = 0;
+
+  if (observedPrice !== null && median !== null && observedPrice > 0 && median > 0) {
+    const overMedianRatio = (observedPrice - median) / observedPrice;
+    score += Math.min(60, Math.max(0, overMedianRatio * 120));
+  }
+
+  if (min !== null && max !== null && min > 0 && max > min) {
+    const spread = (max - min) / max;
+    score += Math.min(30, spread * 80);
+  }
+
+  if (ctx.territory && DOM_TERRITORIES.has(ctx.territory)) {
+    score += 10;
+  }
+
+  return Math.max(0, Math.min(100, Math.round(score)));
+}
+
+export function isPremiumTipEnabled(score: number): boolean {
+  return score >= 70;
+}

--- a/frontend/src/features/tips/storage.ts
+++ b/frontend/src/features/tips/storage.ts
@@ -1,0 +1,35 @@
+import { safeLocalStorage } from '../../utils/safeLocalStorage';
+
+const TIPS_LAST_SEEN_KEY = 'tips:last-seen';
+
+type LastSeenMap = Record<string, number>;
+
+export function getTipsLastSeen(): LastSeenMap {
+  const value = safeLocalStorage.getItem(TIPS_LAST_SEEN_KEY);
+  if (!value) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (!parsed || typeof parsed !== 'object') {
+      return {};
+    }
+
+    const normalized: LastSeenMap = {};
+    for (const [key, timestamp] of Object.entries(parsed)) {
+      if (typeof timestamp === 'number' && Number.isFinite(timestamp)) {
+        normalized[key] = timestamp;
+      }
+    }
+    return normalized;
+  } catch {
+    return {};
+  }
+}
+
+export function markTipSeen(tipId: string, at = Date.now()): void {
+  const current = getTipsLastSeen();
+  current[tipId] = at;
+  safeLocalStorage.setItem(TIPS_LAST_SEEN_KEY, JSON.stringify(current));
+}

--- a/frontend/src/features/tips/types.ts
+++ b/frontend/src/features/tips/types.ts
@@ -1,0 +1,30 @@
+export type TipSeverity = 'info' | 'warn' | 'premium';
+
+export interface TipContext {
+  territory?: string;
+  category?: string;
+  query?: string;
+  price?: number;
+  interval?: {
+    min?: number;
+    median?: number;
+    max?: number;
+  };
+  currency?: 'EUR';
+  unit?: 'unit' | 'kg' | 'l';
+  month?: number;
+  lastSeen?: Record<string, number>;
+}
+
+export interface Tip {
+  id: string;
+  message: string;
+  severity: TipSeverity;
+  confidence: number;
+  tags?: string[];
+}
+
+export interface TipRule {
+  id: string;
+  run(ctx: TipContext): Tip[];
+}

--- a/frontend/src/features/tips/ui/TipBadge.tsx
+++ b/frontend/src/features/tips/ui/TipBadge.tsx
@@ -1,0 +1,13 @@
+import type { ReactElement } from 'react';
+
+export function TipBadge({ premium }: { premium: boolean }): ReactElement | null {
+  if (!premium) {
+    return null;
+  }
+
+  return (
+    <span className="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium border border-white/10 bg-white/5">
+      Astuce Premium
+    </span>
+  );
+}

--- a/frontend/src/features/tips/ui/TipsPanel.tsx
+++ b/frontend/src/features/tips/ui/TipsPanel.tsx
@@ -1,0 +1,33 @@
+import type { ReactElement } from 'react';
+import { buildTips, type TipContext } from '../index';
+import { TipBadge } from './TipBadge';
+
+export function TipsPanel({ ctx }: { ctx: TipContext }): ReactElement | null {
+  const { tips, score, premiumEnabled } = buildTips(ctx);
+
+  if (!tips.length) {
+    return null;
+  }
+
+  return (
+    <div className="mt-4 rounded-2xl border border-white/10 bg-white/5 p-4">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-sm font-semibold">Astuces intelligentes</div>
+        <TipBadge premium={premiumEnabled} />
+      </div>
+
+      <div className="mt-2 text-xs opacity-80">
+        Score économies : <span className="font-semibold">{score}/100</span>
+      </div>
+
+      <ul className="mt-3 space-y-2 text-sm">
+        {tips.slice(0, 4).map((tip) => (
+          <li key={tip.id} className="leading-snug">
+            {tip.severity === 'premium' ? '★ ' : tip.severity === 'warn' ? '⚠ ' : '• '}
+            {tip.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/pages/RechercheProduits.tsx
+++ b/frontend/src/pages/RechercheProduits.tsx
@@ -10,6 +10,8 @@ import { searchProductPrices } from '../services/priceSearch/priceSearch.service
 import type { PriceSearchResult, TerritoryCode } from '../services/priceSearch/price.types';
 import type { ScanData, ScanHubResult } from '../types/scanHubResult';
 import type { ProductCard } from '../types/productCard';
+import { TipsPanel } from '../features/tips/ui/TipsPanel';
+import type { TipContext } from '../features/tips';
 import { getProductImageFallback } from '../utils/productImageFallback';
 import { safeLocalStorage } from '../utils/safeLocalStorage';
 
@@ -475,6 +477,28 @@ export function PriceResults({
       .join(' ');
   }, [filteredObservations]);
 
+  const tipsContext = useMemo<TipContext>(() => {
+    const normalizedQuery = searchQuery?.trim();
+    const normalizedProductName = result.productName?.trim();
+
+    return {
+      territory: result.territory,
+      category: normalizedProductName,
+      query: normalizedQuery,
+      price: latestObservation?.price,
+      interval: priceSummary
+        ? {
+            min: priceSummary.min,
+            median: priceSummary.median,
+            max: priceSummary.max,
+          }
+        : undefined,
+      currency: 'EUR',
+      unit: 'unit',
+      month: new Date().getMonth() + 1,
+    };
+  }, [latestObservation?.price, priceSummary, result.productName, result.territory, searchQuery]);
+
   return (
     <section className="space-y-4">
       <div className="bg-slate-900/70 border border-slate-700 rounded-2xl p-6 space-y-3">
@@ -647,6 +671,8 @@ export function PriceResults({
                 />
               </svg>
             )}
+
+            <TipsPanel ctx={tipsContext} />
           </div>
         )}
 


### PR DESCRIPTION
### Motivation
- Provide a scalable, client-side “tips” system that can surface contextual saving suggestions without adding manual work or heavy UI changes.
- Allow adding new heuristics/rules independently from presentation by using a small rules engine and typed contracts (`TipContext`, `TipRule`).
- Support a single “premium” badge when the computed savings opportunity is high so communications can be gated by a numeric signal.

### Description
- Added a new feature module at `frontend/src/features/tips/` containing typed contracts (`types.ts`), an execution engine with deduplication (`engine.ts`), a savings `scorer.ts` with `isPremiumTipEnabled`, and local exposure helpers (`storage.ts`).
- Implemented an initial, extensible rules set under `rules/` (`rulePriceAboveMedian.ts`, `ruleHighVariance.ts`, `ruleTerritoryHeuristics.ts`, `ruleSeasonality.ts`) that return `Tip` objects with `confidence` and `tags`.
- Added compact UI primitives `TipsPanel.tsx` and `TipBadge.tsx` and wired them into `PriceResults` in `frontend/src/pages/RechercheProduits.tsx` by building a typed `tipsContext` from `latestObservation`, `priceSummary`, territory and query metadata and rendering `<TipsPanel ctx={tipsContext} />` in the observation summary block.
- Engine behavior: run all rules, dedupe tips by `id` keeping the highest `confidence`, sort by confidence, and prepend a conditional premium tip when `isPremiumTipEnabled(score)` is true.

### Testing
- Ran `npm run build` (frontend) and the production build completed successfully. ✅
- Ran the test suite with `npm test` and the project's automated tests passed (`Test Files 15 passed`, `Tests 44 passed`). ✅
- Ran lint check `npx eslint src/features/tips src/pages/RechercheProduits.tsx` which completed without errors but reported one pre-existing warning about the `AbortController` global in `RechercheProduits.tsx`. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699287383ae08321a37835dfbab4eb38)