### PR TITLE
ci: allow manual production deploy and remove checkout from deploy jobs

### DIFF
--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -1,25 +1,37 @@
-name: Deploy Cloudflare Pages (Final)
+name: Deploy Cloudflare Pages
 
 on:
   push:
     branches:
       - main
+      - work
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:
-  group: deploy-cloudflare-pages-${{ github.ref }}
+  group: pages-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: '20'
   PAGES_PROJECT: akiprisaye-web
 
+permissions:
+  contents: read
+  deployments: write
+  pull-requests: write
+
 jobs:
-  deploy:
+  ci:
+    name: CI (lint, typecheck, test, build)
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      deployments: write
+
+    outputs:
+      has_lint: ${{ steps.detect_scripts.outputs.has_lint }}
+      has_typecheck: ${{ steps.detect_scripts.outputs.has_typecheck }}
+      has_test: ${{ steps.detect_scripts.outputs.has_test }}
 
     steps:
       - name: Checkout
@@ -36,16 +48,133 @@ jobs:
         working-directory: frontend
         run: npm ci
 
-      - name: Build production
+      - name: Detect optional npm scripts
+        id: detect_scripts
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const pkg = JSON.parse(fs.readFileSync('frontend/package.json', 'utf8'));
+          const scripts = pkg.scripts || {};
+          const out = process.env.GITHUB_OUTPUT;
+          fs.appendFileSync(out, `has_lint=${Boolean(scripts.lint)}\n`);
+          fs.appendFileSync(out, `has_typecheck=${Boolean(scripts.typecheck)}\n`);
+          fs.appendFileSync(out, `has_test=${Boolean(scripts.test)}\n`);
+          NODE
+
+      - name: Lint (if script exists)
+        if: steps.detect_scripts.outputs.has_lint == 'true'
+        working-directory: frontend
+        run: npm run lint
+
+      - name: Lint skipped
+        if: steps.detect_scripts.outputs.has_lint != 'true'
+        run: echo "No lint script found in frontend/package.json, skipping."
+
+      - name: Typecheck (if script exists)
+        if: steps.detect_scripts.outputs.has_typecheck == 'true'
+        working-directory: frontend
+        run: npm run typecheck
+
+      - name: Typecheck skipped
+        if: steps.detect_scripts.outputs.has_typecheck != 'true'
+        run: echo "No typecheck script found in frontend/package.json, skipping."
+
+      - name: Test (if script exists)
+        if: steps.detect_scripts.outputs.has_test == 'true'
+        working-directory: frontend
+        run: npm run test
+
+      - name: Test skipped
+        if: steps.detect_scripts.outputs.has_test != 'true'
+        run: echo "No test script found in frontend/package.json, skipping."
+
+      - name: Build
         working-directory: frontend
         run: npm run build
 
       - name: Verify build
+        shell: bash
         run: |
           ls -la frontend/dist
           test -f frontend/dist/index.html
+          test -f frontend/dist/404.html
 
-      - name: Deploy to Cloudflare Pages
+      - name: Verify routing files if present
+        shell: bash
+        run: |
+          for file in _redirects _headers _routes.json; do
+            target="frontend/dist/$file"
+            if [ -f "$target" ]; then
+              echo "Found $target"
+              echo "----- $target -----"
+              cat "$target"
+              echo "-------------------"
+            else
+              echo "$target not present (ok)."
+            fi
+          done
+
+      - name: Verify version.json
+        shell: bash
+        run: |
+          if [ -f frontend/dist/version.json ]; then
+            echo "Found frontend/dist/version.json"
+            cat frontend/dist/version.json
+          elif [ -f frontend/version.json ]; then
+            echo "frontend/dist/version.json missing; found frontend/version.json"
+            cat frontend/version.json
+          elif [ -f version.json ]; then
+            echo "frontend/dist/version.json missing; found version.json at repo root"
+            cat version.json
+          else
+            echo "::warning::No version.json found in frontend/dist, frontend/, or repository root."
+          fi
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ github.run_id }}
+          path: frontend/dist
+          retention-days: 7
+
+      - name: Report summary
+        shell: bash
+        run: |
+          {
+            echo "## CI summary"
+            echo "- Commit: \`${GITHUB_SHA}\`"
+            echo "- Ref: \`${GITHUB_REF}\`"
+            echo "- lint script: \`${{ steps.detect_scripts.outputs.has_lint }}\`"
+            echo "- typecheck script: \`${{ steps.detect_scripts.outputs.has_typecheck }}\`"
+            echo "- test script: \`${{ steps.detect_scripts.outputs.has_test }}\`"
+            if [ -f frontend/dist/index.html ]; then
+              echo "- dist/index.html: ✅"
+            else
+              echo "- dist/index.html: ❌"
+            fi
+            if [ -f frontend/dist/404.html ]; then
+              echo "- dist/404.html: ✅"
+            else
+              echo "- dist/404.html: ❌"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  deploy_preview:
+    name: Deploy preview (PR)
+    runs-on: ubuntu-latest
+    needs: ci
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ github.run_id }}
+          path: frontend/dist
+
+      - name: Deploy to Cloudflare Pages (Preview)
+        id: deploy_preview
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -53,3 +182,60 @@ jobs:
           projectName: ${{ env.PAGES_PROJECT }}
           directory: frontend/dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log preview URL
+        shell: bash
+        run: |
+          echo "Preview deployment URL: ${{ steps.deploy_preview.outputs.url }}"
+          {
+            echo "## Preview deployment"
+            echo "- URL: ${{ steps.deploy_preview.outputs.url }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment preview URL on PR
+        if: github.event.pull_request.number != ''
+        uses: actions/github-script@v7
+        env:
+          PREVIEW_URL: ${{ steps.deploy_preview.outputs.url }}
+        with:
+          script: |
+            const url = process.env.PREVIEW_URL || 'URL not returned by action';
+            const body = `🚀 Cloudflare Pages preview ready:\n\n${url}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body
+            });
+
+  deploy_production:
+    name: Deploy production (main)
+    runs-on: ubuntu-latest
+    needs: ci
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-${{ github.run_id }}
+          path: frontend/dist
+
+      - name: Deploy to Cloudflare Pages (Production)
+        id: deploy_production
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ env.PAGES_PROJECT }}
+          directory: frontend/dist
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log production URL
+        shell: bash
+        run: |
+          echo "Production deployment URL: ${{ steps.deploy_production.outputs.url }}"
+          {
+            echo "## Production deployment"
+            echo "- URL: ${{ steps.deploy_production.outputs.url }}"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Motivation
- Allow manual/triggered production deployments in addition to pushes to `main` by enabling `workflow_dispatch` for the production job.
- Simplify the deploy jobs so they only download the build artifact and deploy, avoiding unnecessary repository checkout on deployment runners.
- Centralize build/lint/typecheck/test steps into a dedicated `ci` job that produces and uploads the `frontend/dist` artifact for deployment.

### Description
- Changed the `deploy_production` job condition to `if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')` to support manual runs.
- Removed the `Checkout` step from `deploy_preview` and `deploy_production` so those jobs now only run `actions/download-artifact@v4` and the Cloudflare Pages deploy step.
- Reworked the original deploy job into a `ci` job that runs `npm ci`, conditionally runs `lint`, `typecheck`, and `test` based on `frontend/package.json` scripts, runs `npm run build`, verifies `frontend/dist` (including `index.html` and `404.html`), uploads the artifact with `actions/upload-artifact@v4`, and prints a CI summary to `GITHUB_STEP_SUMMARY`.
- Added `workflow` metadata and small hygiene changes including `permissions`, `concurrency` group update, `push` branches (`main` and `work`), and consistent `NODE_VERSION` quoting.

### Testing
- Validated the workflow YAML by running `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy-cloudflare-pages.yml')"`, which parsed successfully (output: `YAML OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993242f4dc883219ef8c9bafeed6f65)