### PR TITLE
Add /Login -> /login alias and client routing/component fixes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,7 @@ const StoreDetail = lazyPage(() => import('./pages/admin/stores/StoreDetail'));
 const ProductList = lazyPage(() => import('./pages/admin/products/ProductList').then(m => ({ default: m.ProductList })));
 const ProductForm = lazyPage(() => import('./pages/admin/products/ProductForm').then(m => ({ default: m.ProductForm })));
 const ProductDetail = lazyPage(() => import('./pages/admin/products/ProductDetail').then(m => ({ default: m.ProductDetail })));
-const ImportPage = lazyPage(() => import('./pages/admin/import/ImportPage'));
+const ImportPage = lazyPage(() => import('./pages/admin/import/ImportPage').then(m => ({ default: m.ImportPage })));
 const ObservatoireHub = lazyPage(() => import('./pages/ObservatoireHub'));
 const Methodologie = lazyPage(() => import('./pages/Methodologie'));
 const Faq = lazyPage(() => import('./pages/Faq'));
@@ -247,6 +247,7 @@ export default function App() {
                       {/* Auth routes */}
                       <Route path="login" element={<Login />} />
                       <Route path="connexion" element={<Login />} />
+                      <Route path="Login" element={<Navigate to="/login" replace />} />
                       <Route path="auth/login" element={<Navigate to="/login" replace />} />
                       <Route path="signin" element={<Navigate to="/login" replace />} />
 

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,74 +1,24 @@
 import { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-
-/**
- * Header sécurisé :
- * - Aucun crash si AuthContext absent
- * - Aucun crash si Router pas encore monté
- * - Aucun accès direct non protégé à window / localStorage
- * - Compatible ErrorBoundary
- */
-
-// Import optionnels protégés
-let useAuthSafe = null;
-try {
-  ({ useAuth: useAuthSafe } = await import('../context/AuthContext'));
-} catch {
-  useAuthSafe = null;
-}
-
-let ThemeToggleSafe = null;
-try {
-  ({ default: ThemeToggleSafe } = await import('./ThemeToggle'));
-} catch {
-  ThemeToggleSafe = null;
-}
-
-let LanguageSelectorSafe = null;
-try {
-  ({ LanguageSelector: LanguageSelectorSafe } = await import('./i18n/LanguageSelector'));
-} catch {
-  LanguageSelectorSafe = null;
-}
+import { useAuth } from '../context/AuthContext';
+import ThemeToggle from './ThemeToggle';
+import { LanguageSelector } from './i18n/LanguageSelector';
 
 export default function Header() {
-  // Sécurité Router
-  let location = null;
-  try {
-    location = useLocation();
-  } catch {
-    location = { pathname: '/' };
-  }
-
-  // Sécurité Auth
-  let user = null;
-  let isAuthenticated = false;
-  let signOutAction = null;
-
-  if (useAuthSafe) {
-    try {
-      const auth = useAuthSafe();
-      user = auth?.user ?? null;
-      isAuthenticated = Boolean(user);
-      signOutAction = auth?.signOutUser ?? null;
-    } catch {
-      user = null;
-      isAuthenticated = false;
-    }
-  }
+  const location = useLocation();
+  const auth = useAuth();
+  const user = auth?.user ?? null;
+  const isAuthenticated = Boolean(user);
+  const signOutAction = auth?.signOutUser ?? null;
 
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    // Empêche tout rendu prématuré
     setMounted(true);
   }, []);
 
   if (!mounted) {
-    // Rendu neutre ultra-safe
-    return (
-      <header className="w-full h-14 bg-transparent" aria-hidden="true" />
-    );
+    return <header className="w-full h-14 bg-transparent" aria-hidden="true" />;
   }
 
   const isActive = (path) =>
@@ -76,12 +26,10 @@ export default function Header() {
 
   return (
     <header className="w-full flex items-center justify-between px-4 py-3 border-b border-white/10 bg-black/40 backdrop-blur">
-      {/* Logo */}
       <Link to="/" className="text-white font-bold text-lg">
         A KI PRI SA YÉ
       </Link>
 
-      {/* Navigation */}
       <nav className="flex items-center gap-4">
         <Link to="/" className={isActive('/')}>
           Accueil
@@ -95,7 +43,6 @@ export default function Header() {
           Paramètres
         </Link>
 
-        {/* Auth (safe) */}
         {isAuthenticated ? (
           <div className="flex items-center gap-3">
             <span className="text-sm text-gray-400">
@@ -115,11 +62,8 @@ export default function Header() {
           <span className="text-sm text-gray-500">Invité</span>
         )}
 
-        {/* Theme toggle (safe) */}
-        {ThemeToggleSafe ? <ThemeToggleSafe /> : null}
-
-        {/* Language selector (safe) */}
-        {LanguageSelectorSafe ? <LanguageSelectorSafe variant="compact" /> : null}
+        <ThemeToggle />
+        <LanguageSelector variant="compact" />
       </nav>
     </header>
   );

--- a/frontend/src/components/PriceComparisonTable.tsx
+++ b/frontend/src/components/PriceComparisonTable.tsx
@@ -13,14 +13,6 @@ export default function PriceComparisonTable({
   observations,
   groupedByStore,
 }: PriceComparisonTableProps) {
-  if (observations.length === 0) {
-    return (
-      <div className="text-center py-8 text-white/60">
-        Aucune observation disponible pour ce produit.
-      </div>
-    )
-  }
-
   const getTimestamp = (value: string) => {
     const parsed = new Date(value)
     return Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime()
@@ -84,6 +76,14 @@ export default function PriceComparisonTable({
       persistWatchedPrices(next)
       return next
     })
+  }
+
+  if (observations.length === 0) {
+    return (
+      <div className="text-center py-8 text-white/60">
+        Aucune observation disponible pour ce produit.
+      </div>
+    )
   }
 
   return (

--- a/frontend/src/components/StoreComparisonTable.tsx
+++ b/frontend/src/components/StoreComparisonTable.tsx
@@ -20,6 +20,8 @@ export default function StoreComparisonTable({
 }: StoreComparisonTableProps) {
   const [toastMessage, setToastMessage] = useState<string | null>(null)
 
+  const { isFavorite, toggleFavorite } = useFavorites()
+
   if (!comparisons || comparisons.length === 0) {
     return (
       <GlassCard>
@@ -35,7 +37,6 @@ export default function StoreComparisonTable({
     const sign = pct > 0 ? '+' : ''
     return sign + pct.toFixed(1) + '%'
   }
-  const { isFavorite, toggleFavorite } = useFavorites()
   const showToast = (message: string) => {
     setToastMessage(message)
     window.setTimeout(() => setToastMessage(null), 1400)

--- a/frontend/src/context/ScanFlowContext.tsx
+++ b/frontend/src/context/ScanFlowContext.tsx
@@ -176,6 +176,12 @@ export function ScanFlowProvider({ children }: ScanFlowProviderProps) {
   );
 }
 
+
+export function useOptionalScanFlow(): ScanFlowContextType | null {
+  const context = useContext(ScanFlowContext);
+  return context ?? null;
+}
+
 /**
  * Hook pour utiliser le contexte de flux de scan
  * @throws Error si utilisé en dehors du provider

--- a/frontend/src/pages/ScanEAN.tsx
+++ b/frontend/src/pages/ScanEAN.tsx
@@ -5,7 +5,7 @@ import { useSearchParams, useNavigate } from 'react-router-dom'
 import { useEANScanner } from '../hooks/useEANScanner'
 import { useEANResolver } from '../hooks/useEANResolver'
 import { useScanHistory } from '../hooks/useScanHistory'
-import { useScanFlow } from '../context/ScanFlowContext'
+import { useOptionalScanFlow } from '../context/ScanFlowContext'
 import { validateEAN, getAllProducts } from '../services/eanPublicCatalog'
 import { runOCR, GENERIC_OCR_ERROR } from '../services/ocrService'
 import { extractProductHints, fuzzySearchProducts } from '../services/textProductRecognition'
@@ -37,7 +37,7 @@ export default function ScanEAN() {
   const scanner = useEANScanner()
   const resolver = useEANResolver()
   const { history, addToHistory, removeFromHistory, clearHistory } = useScanHistory()
-  const scanFlow = isUnifiedFlow ? useScanFlow() : null
+  const scanFlow = useOptionalScanFlow()
   
   // Cache product catalog to avoid repeated calls
   const productCatalog = React.useMemo(() => getAllProducts().map(p => ({ label: p.name, ean: p.ean })), [])

--- a/frontend/src/router/lazy.ts
+++ b/frontend/src/router/lazy.ts
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export function lazyPage<T extends React.ComponentType<any>>(
+export function lazyPage<T extends React.ComponentType<unknown>>(
   factory: () => Promise<{ default: T }>
 ) {
   return React.lazy(factory)

--- a/frontend/src/test/cloudflareRouting.test.ts
+++ b/frontend/src/test/cloudflareRouting.test.ts
@@ -34,6 +34,7 @@ describe('Cloudflare SPA routing config', () => {
     const appSource = readFileSync(appPath, 'utf8');
 
     const expectedAliases = [
+      ['Login', '/login'],
       ['auth/login', '/login'],
       ['signin', '/login'],
       ['auth/register', '/inscription'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "target": "ES2022",
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "useDefineForClassFields": true,
+    "jsx": "react-jsx",
 
     /* =========================
        MODULES & BUNDLER


### PR DESCRIPTION
### Motivation
- Prevent React Router case-sensitivity regressions where `/Login` (mixed-case) could hit the app NotFound instead of the canonical `/login` route. 
- Make some components safer to mount when optional providers/hooks are absent and fix hook ordering issues observed during lazy/hook usage. 
- Tighten type/TSX configuration and expand routing tests to catch regressions in aliasing. 

### Description
- Add an explicit alias route `<Route path="Login" element={<Navigate to="/login" replace />} />` in `frontend/src/App.tsx` while keeping the canonical `path="login"` and existing aliases intact. 
- Update `frontend/src/test/cloudflareRouting.test.ts` to assert the new `Login -> /login` alias is present. 
- Simplify `Header.jsx` by using direct imports (`useAuth`, `ThemeToggle`, `LanguageSelector`) and standardize the mount/auth handling to a clearer pattern. 
- Fix hook-ordering/early-return issue in `PriceComparisonTable.tsx` by moving the empty-observations guard after hook/state initialization. 
- Move `useFavorites` destructuring to the top of `StoreComparisonTable.tsx` so hooks are consistently ordered. 
- Add `useOptionalScanFlow` to `ScanFlowContext.tsx` and switch `ScanEAN.tsx` to call the optional hook so the page can run outside of a provider. 
- Relax the generic on `lazyPage` in `frontend/src/router/lazy.ts` and fix a few lazy import shapes (e.g. `ImportPage`) to preserve default exports. 
- Enable JSX transform in `tsconfig.json` by adding `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948964fe8c8321b0651db6b88cafce)