### PR TITLE
Fix: prevent stale cache after deploy (SW + build version)

### DIFF
--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,5 +1,5 @@
-// 🔹 Cache version - incremented to v4 for complete cache invalidation
-const CACHE_NAME = 'akiprisaye-smart-cache-v4';
+// 🔹 Cache version - incremented to v5 for complete cache invalidation
+const CACHE_NAME = 'akiprisaye-smart-cache-v5';
 
 // 🔹 Only precache essential non-HTML assets
 const ASSETS_TO_CACHE = [

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -13,6 +13,7 @@ import ErrorBoundary from './components/ErrorBoundary';
 import { safeToText } from './utils/safeToText';
 import { installRuntimeCrashProbe } from './monitoring/runtimeCrashProbe';
 import { logDebug } from './utils/logger';
+import { applyBuildVersionGuard, registerServiceWorker } from './utils/buildVersionGuard';
 
 const BUILD_SHA = import.meta.env.VITE_BUILD_SHA || 'unknown';
 window.__BUILD_SHA__ = BUILD_SHA;
@@ -62,11 +63,16 @@ const globalLoadTimeout = setTimeout(() => {
   }
 }, 15000);
 
-const rootElement = document.getElementById('root');
+const bootstrap = async () => {
+  await applyBuildVersionGuard();
 
-if (!rootElement) {
-  console.error('❌ Root element #root not found');
-} else {
+  const rootElement = document.getElementById('root');
+
+  if (!rootElement) {
+    console.error('❌ Root element #root not found');
+    return;
+  }
+
   logDebug('✅ main.jsx: Starting React render');
 
   ReactDOM.createRoot(rootElement).render(
@@ -87,5 +93,8 @@ if (!rootElement) {
     clearTimeout(globalLoadTimeout);
   });
 
+  await registerServiceWorker();
   logDebug('✅ main.jsx: React render initiated');
-}
+};
+
+bootstrap();

--- a/frontend/src/test/serviceWorkerCacheStrategy.test.ts
+++ b/frontend/src/test/serviceWorkerCacheStrategy.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentFileDir = path.dirname(fileURLToPath(import.meta.url));
+const resolveFromFrontend = (...segments: string[]) => path.resolve(currentFileDir, '..', '..', ...segments);
+
+describe('service worker cache strategy', () => {
+  it('does not precache index.html', () => {
+    const serviceWorker = readFileSync(resolveFromFrontend('public', 'service-worker.js'), 'utf-8');
+
+    expect(serviceWorker).not.toContain('index.html');
+  });
+
+  it('uses no-store for HTML document fetches', () => {
+    const serviceWorker = readFileSync(resolveFromFrontend('public', 'service-worker.js'), 'utf-8');
+
+    expect(serviceWorker).toContain("fetch(request, { cache: 'no-store' })");
+  });
+
+  it('applies build version guard before mount', () => {
+    const mainFile = readFileSync(resolveFromFrontend('src', 'main.jsx'), 'utf-8');
+    const guardFile = readFileSync(resolveFromFrontend('src', 'utils', 'buildVersionGuard.ts'), 'utf-8');
+
+    expect(mainFile).toContain('await applyBuildVersionGuard()');
+    expect(guardFile).toContain('akiprisaye-build-id');
+    expect(guardFile).toContain('registration.waiting.postMessage');
+  });
+});

--- a/frontend/src/types/vite-env.d.ts
+++ b/frontend/src/types/vite-env.d.ts
@@ -2,6 +2,8 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
+  readonly VITE_BUILD_SHA?: string;
+  readonly VITE_APP_BUILD_ID?: string;
   readonly VITE_FIREBASE_API_KEY?: string;
   readonly VITE_FIREBASE_AUTH_DOMAIN?: string;
   readonly VITE_FIREBASE_PROJECT_ID?: string;

--- a/frontend/src/utils/buildVersionGuard.ts
+++ b/frontend/src/utils/buildVersionGuard.ts
@@ -1,0 +1,74 @@
+const BUILD_ID_STORAGE_KEY = 'akiprisaye-build-id';
+
+const getBuildId = () => {
+  const appBuildId = import.meta.env.VITE_APP_BUILD_ID;
+  const buildSha = import.meta.env.VITE_BUILD_SHA;
+  return appBuildId || buildSha || 'unknown';
+};
+
+const purgeServiceWorkersAndCaches = async () => {
+  if (!('serviceWorker' in navigator)) {
+    return;
+  }
+
+  const registrations = await navigator.serviceWorker.getRegistrations();
+  await Promise.all(registrations.map((registration) => registration.unregister()));
+
+  if ('caches' in window) {
+    const cacheKeys = await window.caches.keys();
+    await Promise.all(cacheKeys.map((cacheKey) => window.caches.delete(cacheKey)));
+  }
+};
+
+export const applyBuildVersionGuard = async () => {
+  if (!import.meta.env.PROD) {
+    return;
+  }
+
+  const currentBuildId = getBuildId();
+  const previousBuildId = localStorage.getItem(BUILD_ID_STORAGE_KEY);
+
+  if (!previousBuildId) {
+    localStorage.setItem(BUILD_ID_STORAGE_KEY, currentBuildId);
+    return;
+  }
+
+  if (previousBuildId === currentBuildId) {
+    return;
+  }
+
+  localStorage.setItem(BUILD_ID_STORAGE_KEY, currentBuildId);
+  await purgeServiceWorkersAndCaches();
+  window.location.reload();
+
+  await new Promise(() => {});
+};
+
+export const registerServiceWorker = async () => {
+  if (!import.meta.env.PROD || !('serviceWorker' in navigator)) {
+    return;
+  }
+
+  try {
+    const registration = await navigator.serviceWorker.register('/service-worker.js');
+
+    if (registration.waiting) {
+      registration.waiting.postMessage('SKIP_WAITING');
+    }
+
+    registration.addEventListener('updatefound', () => {
+      const newWorker = registration.installing;
+      if (!newWorker) {
+        return;
+      }
+
+      newWorker.addEventListener('statechange', () => {
+        if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+          newWorker.postMessage('SKIP_WAITING');
+        }
+      });
+    });
+  } catch (error) {
+    console.warn('[sw] registration failed', error);
+  }
+};

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -25,6 +25,8 @@ const buildSha = process.env.BUILD_SHA || (() => {
   }
 })()
 
+const appBuildId = process.env.VITE_APP_BUILD_ID || buildSha
+
 export default defineConfig({
   base: '/',
   plugins: [
@@ -160,6 +162,7 @@ export default defineConfig({
   },
   define: {
     'import.meta.env.VITE_BUILD_SHA': JSON.stringify(buildSha),
+    'import.meta.env.VITE_APP_BUILD_ID': JSON.stringify(appBuildId),
     'process.env.VITE_FIREBASE_API_KEY': JSON.stringify(process.env.VITE_FIREBASE_API_KEY),
     'process.env.VITE_FIREBASE_AUTH_DOMAIN': JSON.stringify(process.env.VITE_FIREBASE_AUTH_DOMAIN),
     'process.env.VITE_FIREBASE_PROJECT_ID': JSON.stringify(process.env.VITE_FIREBASE_PROJECT_ID)

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       'src/test/promosService.test.ts',
       'src/test/freemium.test.ts',
       'src/test/cloudflareRouting.test.ts',
+      'src/test/serviceWorkerCacheStrategy.test.ts',
       'scripts/verify-pages-api.test.ts',
     ],
   },


### PR DESCRIPTION
### Motivation

- Prevent users from seeing stale HTML/app shell after a deploy caused by a combination of HTML/CDN/browser caches and Service Worker lifecycle quirks.  
- Ensure navigations/documents are always fetched from network (no-store) so the SPA shell never goes stale after a release.  
- Provide an automatic client-side kill-switch when a new build is deployed so old Service Workers and CacheStorage are removed without requiring manual user actions.

### Description

- Service worker: bumped cache version to `v5`, precaches only non-HTML assets, enforces network-first `fetch(request, { cache: 'no-store' })` for navigations/documents, keeps `skipWaiting`/`clients.claim`, and listens for `SKIP_WAITING` messages.  
- Build-version guard: added `frontend/src/utils/buildVersionGuard.ts` that derives a build id from `VITE_APP_BUILD_ID` (fallback `VITE_BUILD_SHA`), compares it to `localStorage`, and on change unregisters SWs, purges CacheStorage and forces a reload.  
- App bootstrap and SW registration: `frontend/src/main.jsx` now applies the build guard before mounting React and registers the service worker in production while nudging new workers to `SKIP_WAITING`.  
- Tooling/types/tests: injected `VITE_APP_BUILD_ID` into `vite.config.ts` (fallback to build SHA), added `VITE_BUILD_SHA`/`VITE_APP_BUILD_ID` to `vite-env.d.ts`, added `frontend/src/test/serviceWorkerCacheStrategy.test.ts` and included it in `frontend/vitest.config.ts` to assert the SW strategy and guard wiring.

### Testing

- Ran `npm run build` in `frontend` and the build completed successfully.  
- Ran `npm test` (Vitest) and all tests passed including the new `serviceWorkerCacheStrategy.test.ts`.  
- Ran `npm run lint` which succeeded (no new lint errors introduced; existing repo warnings remain).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c1f0243c8321a3041ce3890fb4bf)