### PR TITLE
ci: inject build id and mark service-worker no-store to avoid stale SW

### DIFF
--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -89,6 +89,9 @@ jobs:
         if: steps.detect_scripts.outputs.has_test != 'true'
         run: echo "No test script found in frontend/package.json, skipping."
 
+      - name: Inject build id
+        run: echo "VITE_APP_BUILD_ID=${GITHUB_SHA}" >> $GITHUB_ENV
+
       - name: Build
         working-directory: frontend
         run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,10 @@ jobs:
         working-directory: ./frontend
         run: npm ci
 
+      - name: Inject build id
+        working-directory: ./frontend
+        run: echo "VITE_APP_BUILD_ID=${GITHUB_SHA}" >> $GITHUB_ENV
+
       # Build de l'application Vite/React (génère le dossier dist)
       - name: Build application
         working-directory: ./frontend

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -10,6 +10,9 @@
 /index.html
   Cache-Control: no-store, must-revalidate
 
+/service-worker.js
+  Cache-Control: no-store, must-revalidate
+
 # Optional: other html pages
 /*.html
   Cache-Control: no-store, must-revalidate


### PR DESCRIPTION
### Motivation
- Guarantee each deployment emits a unique build identifier so the app, service worker and served HTML remain version-coherent across deployments. 
- Prevent Cloudflare from caching the service worker at the edge to avoid stale SW behavior on some devices.

### Description
- Add an `Inject build id` step that exports `VITE_APP_BUILD_ID=${GITHUB_SHA}` before the build in ` .github/workflows/deploy-cloudflare-pages.yml`.
- Add the same `Inject build id` step in the manual deploy workflow ` .github/workflows/deploy.yml` before `npm run build`.
- Add a `/service-worker.js` rule with `Cache-Control: no-store, must-revalidate` to `frontend/public/_headers` to force the edge to not cache the SW file.

### Testing
- Ran `npm run build` from the `frontend/` directory and the build completed successfully (Vite produced the `dist` output).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994c4cb775c8321b7efd1b9e4ec8578)