### PR TITLE
ci: consolidate Cloudflare Pages deployment workflows

### DIFF
--- a/.github/workflows/ci-cd-industrial.yml
+++ b/.github/workflows/ci-cd-industrial.yml
@@ -1,14 +1,7 @@
+# NOTE: manual-only to avoid duplicate Cloudflare deployments. Primary workflow: deploy-cloudflare-pages.yml
 name: 🚀 CI/CD Pipeline Industriel
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - '*'
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - work
   pull_request:
     branches:
       - main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,4 @@
+# NOTE: manual-only to avoid duplicate Cloudflare deployments. Primary workflow: deploy-cloudflare-pages.yml
 name: Deploy to Cloudflare Pages
 
 on:

--- a/.github/workflows/observatory-pipeline.yml
+++ b/.github/workflows/observatory-pipeline.yml
@@ -1,24 +1,8 @@
+# NOTE: manual-only to avoid duplicate Cloudflare deployments. Primary workflow: deploy-cloudflare-pages.yml
 name: A KI PRI SA YÉ - Observatoire Pipeline
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'data/**'
-      - 'scripts/**'
-      - 'backend/**'
-      - '.github/workflows/observatory-pipeline.yml'
-  pull_request:
-    branches: [main]
-    paths:
-      - 'data/**'
-      - 'scripts/**'
-      - 'backend/**'
-      - '.github/workflows/observatory-pipeline.yml'
   workflow_dispatch:
-  schedule:
-    # Exécution mensuelle pour vérification régulière (1er du mois à 3h)
-    - cron: '0 3 1 * *'
 
 env:
   NODE_VERSION: '20'


### PR DESCRIPTION
### Motivation
- Réduire les exécutions Cloudflare Pages doublons en conservant un seul workflow automatique source-of-truth pour les déploiements Pages. 
- Neutraliser (sans supprimer) les autres workflows de déploiement Pages pour éviter des déploiements involontaires tout en gardant un accès manuel de secours. 

### Description
- Gardé `.github/workflows/deploy-cloudflare-pages.yml` comme seul workflow Cloudflare Pages automatique et restreint son `push` aux `branches: - main` (suppression de `work`) tout en conservant `pull_request` et `workflow_dispatch`. 
- Transformé les workflows secondaires en mode manuel en ajoutant `workflow_dispatch` comme unique trigger et en préfixant les fichiers par un commentaire explicite `# NOTE: manual-only to avoid duplicate Cloudflare deployments. Primary workflow: deploy-cloudflare-pages.yml` dans `.github/workflows/deploy.yml`, `.github/workflows/ci-cd-industrial.yml` et `.github/workflows/observatory-pipeline.yml`. 
- Vérifié que les workflows Cloudflare ne contiennent aucun step Android/Gradle et laissé intacts les workflows Android qui utilisent déjà `actions/setup-java@v4` avec `distribution: temurin` et `java-version: 17`. 

### Testing
- Inspecté les fichiers et triggers avec `rg` and `sed` to confirm triggers and Cloudflare action usage, which succeeded. 
- Confirmed Cloudflare workflows do not reference `android` or `gradle` using `rg`, which returned no matches. 
- Parsed updated YAML workflow files with Ruby `YAML.load_file(...)` to validate syntax, which succeeded. 
- Attempted `git push` in this environment to publish changes but it failed due to no configured remote (expected in this sandbox).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994ce0cdec08321985b64f57a67cc44)