### PR TITLE
feat: add local product + territorial price override fallbacks

### DIFF
--- a/frontend/src/data/price_overrides.ts
+++ b/frontend/src/data/price_overrides.ts
@@ -1,0 +1,143 @@
+import type { TerritoryCode } from '../services/priceSearch/price.types';
+
+export type RetailerId = 'carrefour' | 'leclerc' | 'intermarche' | 'superu';
+
+export interface LocalPriceOverride {
+  ean: string;
+  territory: TerritoryCode;
+  retailer: RetailerId;
+  price: number | null;
+  currency: 'EUR';
+  unit?: 'unit' | 'l' | 'kg';
+  observedAt?: string;
+  sourceNote?: string;
+}
+
+export const PRICE_OVERRIDES: LocalPriceOverride[] = [
+  {
+    ean: '3560070894222',
+    territory: 'fr',
+    retailer: 'carrefour',
+    price: null,
+    currency: 'EUR',
+    unit: 'unit',
+    sourceNote: 'Prix non renseigné (catalogue interne à compléter).',
+  },
+  {
+    ean: '3560070894222',
+    territory: 'fr',
+    retailer: 'leclerc',
+    price: null,
+    currency: 'EUR',
+    unit: 'unit',
+    sourceNote: 'Prix non renseigné (catalogue interne à compléter).',
+  },
+  {
+    ean: '3560070894222',
+    territory: 'fr',
+    retailer: 'intermarche',
+    price: null,
+    currency: 'EUR',
+    unit: 'unit',
+    sourceNote: 'Prix non renseigné (catalogue interne à compléter).',
+  },
+  {
+    ean: '3560070894222',
+    territory: 'fr',
+    retailer: 'superu',
+    price: null,
+    currency: 'EUR',
+    unit: 'unit',
+    sourceNote: 'Prix non renseigné (catalogue interne à compléter).',
+  },
+  {
+    ean: '3560070894222',
+    territory: 'gp',
+    retailer: 'carrefour',
+    price: null,
+    currency: 'EUR',
+    unit: 'unit',
+    sourceNote: 'Prix non renseigné (catalogue interne à compléter).',
+  },
+  {
+    ean: '3560070894222',
+    territory: 'gp',
+    retailer: 'leclerc',
+    price: null,
+    currency: 'EUR',
+    unit: 'unit',
+    sourceNote: 'Prix non renseigné (catalogue interne à compléter).',
+  },
+  {
+    ean: '3560070894222',
+    territory: 'gp',
+    retailer: 'intermarche',
+    price: null,
+    currency: 'EUR',
+    unit: 'unit',
+    sourceNote: 'Prix non renseigné (catalogue interne à compléter).',
+  },
+  {
+    ean: '3560070894222',
+    territory: 'gp',
+    retailer: 'superu',
+    price: null,
+    currency: 'EUR',
+    unit: 'unit',
+    sourceNote: 'Prix non renseigné (catalogue interne à compléter).',
+  },
+  {
+    ean: '3560070894222',
+    territory: 'mq',
+    retailer: 'carrefour',
+    price: null,
+    currency: 'EUR',
+    unit: 'unit',
+    sourceNote: 'Prix non renseigné (catalogue interne à compléter).',
+  },
+  {
+    ean: '3560070894222',
+    territory: 'mq',
+    retailer: 'leclerc',
+    price: null,
+    currency: 'EUR',
+    unit: 'unit',
+    sourceNote: 'Prix non renseigné (catalogue interne à compléter).',
+  },
+  {
+    ean: '3560070894222',
+    territory: 'mq',
+    retailer: 'intermarche',
+    price: null,
+    currency: 'EUR',
+    unit: 'unit',
+    sourceNote: 'Prix non renseigné (catalogue interne à compléter).',
+  },
+  {
+    ean: '3560070894222',
+    territory: 'mq',
+    retailer: 'superu',
+    price: null,
+    currency: 'EUR',
+    unit: 'unit',
+    sourceNote: 'Prix non renseigné (catalogue interne à compléter).',
+  },
+];
+
+export function findLocalPriceOverrides(
+  ean: string,
+  territory: TerritoryCode,
+  retailer?: RetailerId
+): LocalPriceOverride[] {
+  return PRICE_OVERRIDES.filter((entry) => {
+    if (entry.ean !== ean || entry.territory !== territory) {
+      return false;
+    }
+
+    if (retailer && entry.retailer !== retailer) {
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/frontend/src/data/product_overrides.ts
+++ b/frontend/src/data/product_overrides.ts
@@ -1,0 +1,50 @@
+export interface ProductOverride {
+  ean: string;
+  productName: string;
+  brand?: string;
+  quantity?: string;
+  nutriScore?: string;
+  ingredientsText?: string;
+  nutritionPer100g?: {
+    energyKj?: number;
+    energyKcal?: number;
+    carbs?: number;
+    sugars?: number;
+  };
+  nutritionPreparedPer100g?: {
+    energyKj?: number;
+    energyKcal?: number;
+    carbs?: number;
+    sugars?: number;
+  };
+  categories?: string[];
+}
+
+export const PRODUCT_OVERRIDES: ProductOverride[] = [
+  {
+    ean: '3560070894222',
+    productName: 'Sirop / Siroop Cerise / Kers',
+    brand: 'Carrefour Classic’',
+    quantity: '75 cl',
+    nutriScore: 'C',
+    ingredientsText:
+      'Sucre, sirop de glucose-fructose, jus de fruits à base de concentrés 26 % (cerise 12 %, citron, sureau), eau, arôme, acidifiant : acide citrique.',
+    nutritionPer100g: {
+      energyKj: 1332,
+      energyKcal: 313,
+      carbs: 77,
+      sugars: 73,
+    },
+    nutritionPreparedPer100g: {
+      energyKj: 103,
+      energyKcal: 24,
+      carbs: 6.0,
+      sugars: 5.6,
+    },
+    categories: ['Boissons', 'Sirops', 'Sirop de fruits'],
+  },
+];
+
+export function getProductOverrideByEan(ean: string): ProductOverride | null {
+  return PRODUCT_OVERRIDES.find((entry) => entry.ean === ean) ?? null;
+}

--- a/frontend/src/pages/ProductScanResult.tsx
+++ b/frontend/src/pages/ProductScanResult.tsx
@@ -1,14 +1,29 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
+import { TERRITORIES } from '../constants/territories';
 import { fetchOffProductDetails, type OffProductUiModel } from '../services/openFoodFacts';
+import { searchProductPrices } from '../services/priceSearch/priceSearch.service';
+import type { PriceSearchResult, TerritoryCode } from '../services/priceSearch/price.types';
 
 type LoadState = 'loading' | 'success' | 'notFound' | 'errorNetwork';
+
+const TERRITORY_CHOICES: TerritoryCode[] = ['gp', 'mq', 'fr'];
+
+function formatPrice(value: number): string {
+  if (!Number.isFinite(value)) {
+    return 'Prix non renseigné';
+  }
+  return `${value.toFixed(2)} €`;
+}
 
 export default function ProductScanResult() {
   const { barcode = '' } = useParams();
   const navigate = useNavigate();
   const [state, setState] = useState<LoadState>('loading');
   const [product, setProduct] = useState<OffProductUiModel | null>(null);
+  const [territory, setTerritory] = useState<TerritoryCode>('gp');
+  const [priceResult, setPriceResult] = useState<PriceSearchResult | null>(null);
+  const [priceLoading, setPriceLoading] = useState(false);
 
   const loadProduct = useCallback(async () => {
     setState('loading');
@@ -28,9 +43,52 @@ export default function ProductScanResult() {
     setState('errorNetwork');
   }, [barcode]);
 
+  const loadPrices = useCallback(async () => {
+    if (!barcode) {
+      setPriceResult(null);
+      return;
+    }
+
+    setPriceLoading(true);
+    try {
+      const result = await searchProductPrices({
+        barcode,
+        territory,
+      });
+      setPriceResult(result);
+    } finally {
+      setPriceLoading(false);
+    }
+  }, [barcode, territory]);
+
   useEffect(() => {
     void loadProduct();
   }, [loadProduct]);
+
+  useEffect(() => {
+    void loadPrices();
+  }, [loadPrices]);
+
+  const sortedPrices = useMemo(() => {
+    if (!priceResult) {
+      return [];
+    }
+
+    return [...priceResult.observations].sort((a, b) => {
+      const aValue = Number.isFinite(a.price) ? a.price : Number.POSITIVE_INFINITY;
+      const bValue = Number.isFinite(b.price) ? b.price : Number.POSITIVE_INFINITY;
+      return aValue - bValue;
+    });
+  }, [priceResult]);
+
+  const availablePrices = sortedPrices.filter((item) => Number.isFinite(item.price)).map((item) => item.price);
+
+  const minPrice = availablePrices.length > 0 ? Math.min(...availablePrices) : null;
+  const maxPrice = availablePrices.length > 0 ? Math.max(...availablePrices) : null;
+  const medianPrice =
+    availablePrices.length >= 3
+      ? availablePrices[Math.floor(availablePrices.length / 2)]
+      : null;
 
   return (
     <div className="min-h-screen bg-slate-950 p-4 pt-24 text-white">
@@ -72,7 +130,57 @@ export default function ProductScanResult() {
               {product.nutriScore && <span className="rounded-full bg-green-500/20 px-3 py-1">Nutri-Score {product.nutriScore}</span>}
               {product.nova && <span className="rounded-full bg-purple-500/20 px-3 py-1">NOVA {product.nova}</span>}
               {product.ecoScore && <span className="rounded-full bg-emerald-500/20 px-3 py-1">EcoScore {product.ecoScore}</span>}
+              {product.source === 'local_override' && <span className="rounded-full bg-slate-700 px-3 py-1">Source: Catalogue interne (produit)</span>}
             </div>
+
+            <section className="rounded-xl border border-slate-700 p-4">
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                <h3 className="text-lg font-semibold">Prix (territoire: {TERRITORIES[territory].label})</h3>
+                <label className="text-sm text-slate-300">
+                  Territoire{' '}
+                  <select
+                    className="ml-2 rounded border border-slate-600 bg-slate-800 px-2 py-1"
+                    value={territory}
+                    onChange={(event) => setTerritory(event.target.value as TerritoryCode)}
+                  >
+                    {TERRITORY_CHOICES.map((item) => (
+                      <option key={item} value={item}>
+                        {TERRITORIES[item].label} — {TERRITORIES[item].name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              {priceLoading && <p className="text-sm text-slate-300">Chargement des prix…</p>}
+
+              {!priceLoading && sortedPrices.length === 0 && (
+                <p className="text-sm text-slate-300">Aucun prix disponible pour ce territoire.</p>
+              )}
+
+              {!priceLoading && sortedPrices.length > 0 && (
+                <div className="space-y-3 text-sm text-slate-200">
+                  <ul className="space-y-2">
+                    {sortedPrices.map((entry, index) => (
+                      <li key={`${entry.metadata?.retailer ?? 'retailer'}-${index}`} className="flex items-center justify-between rounded-lg border border-slate-700 px-3 py-2">
+                        <span className="capitalize">{entry.metadata?.retailer ?? entry.metadata?.store ?? 'Enseigne'}</span>
+                        <span>{formatPrice(entry.price)}</span>
+                      </li>
+                    ))}
+                  </ul>
+
+                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                    <div>Min: {minPrice === null ? 'n/d' : formatPrice(minPrice)}</div>
+                    <div>Médiane: {medianPrice === null ? 'n/d' : formatPrice(medianPrice)}</div>
+                    <div>Max: {maxPrice === null ? 'n/d' : formatPrice(maxPrice)}</div>
+                  </div>
+
+                  {priceResult?.sourcesUsed.includes('local_override') && (
+                    <p className="text-xs text-slate-400">Source: Catalogue interne (prix)</p>
+                  )}
+                </div>
+              )}
+            </section>
 
             <section className="rounded-xl border border-slate-700 p-4">
               <h3 className="mb-3 text-lg font-semibold">Nutrition (pour 100g)</h3>

--- a/frontend/src/pages/ScannerHub.tsx
+++ b/frontend/src/pages/ScannerHub.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { BrowserMultiFormatReader } from '@zxing/browser';
+import { BrowserMultiFormatReader } from '@zxing/library';
 import { useNavigate } from 'react-router-dom';
 
 type ScanStatus =

--- a/frontend/src/services/openFoodFacts.ts
+++ b/frontend/src/services/openFoodFacts.ts
@@ -1,4 +1,5 @@
 import { getCachedWithTTL, setCachedJson } from './localStore';
+import { getProductOverrideByEan } from '../data/product_overrides';
 
 const OFF_DEFAULT_BASE_URL = 'https://world.openfoodfacts.org';
 const OFF_PRODUCT_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
@@ -40,6 +41,7 @@ type OffApiResponse = {
 };
 
 export type OffProductUiModel = {
+  source?: 'open_food_facts' | 'local_override';
   barcode: string;
   name?: string;
   brand?: string;
@@ -248,6 +250,7 @@ function mapToUiModel(barcode: string, product: OffApiProduct): OffProductUiMode
     : {};
 
   return {
+    source: 'open_food_facts',
     barcode,
     name: safeString(product.product_name),
     brand: safeString(product.brands),
@@ -264,6 +267,30 @@ function mapToUiModel(barcode: string, product: OffApiProduct): OffProductUiMode
     },
     ingredients: safeString(product.ingredients_text),
     allergens: safeString(product.allergens),
+  };
+}
+
+function mapOverrideToUiModel(barcode: string): OffProductUiModel | null {
+  const override = getProductOverrideByEan(barcode);
+
+  if (!override) {
+    return null;
+  }
+
+  return {
+    source: 'local_override',
+    barcode,
+    name: override.productName,
+    brand: override.brand,
+    quantity: override.quantity,
+    nutriScore: override.nutriScore,
+    nutriments: {
+      kcal: override.nutritionPer100g?.energyKcal,
+      sugars: override.nutritionPer100g?.sugars,
+      fat: undefined,
+      salt: undefined,
+    },
+    ingredients: override.ingredientsText,
   };
 }
 
@@ -289,6 +316,24 @@ export async function fetchOffProductDetails(
     );
 
     if (!response.ok) {
+      if (response.status === 404) {
+        const overrideUi = mapOverrideToUiModel(barcode);
+        if (overrideUi) {
+          const override = getProductOverrideByEan(barcode);
+          return {
+            status: 'OK',
+            barcode,
+            ui: overrideUi,
+            product: {
+              name: overrideUi.name,
+              brands: overrideUi.brand,
+              quantity: overrideUi.quantity,
+              categories: override?.categories,
+            },
+          };
+        }
+      }
+
       return {
         status: response.status === 404 ? 'NOT_FOUND' : 'ERROR',
         barcode,
@@ -302,6 +347,22 @@ export async function fetchOffProductDetails(
     const payload = (await response.json()) as OffApiResponse;
 
     if (payload.status === 0 || !payload.product) {
+      const overrideUi = mapOverrideToUiModel(barcode);
+      const override = getProductOverrideByEan(barcode);
+      if (overrideUi) {
+        return {
+          status: 'OK',
+          barcode,
+          ui: overrideUi,
+          product: {
+            name: overrideUi.name,
+            brands: overrideUi.brand,
+            quantity: overrideUi.quantity,
+            categories: override?.categories,
+          },
+        };
+      }
+
       return {
         status: 'NOT_FOUND',
         barcode,
@@ -331,6 +392,22 @@ export async function fetchOffProductDetails(
       },
     };
   } catch (error: unknown) {
+    const overrideUi = mapOverrideToUiModel(barcode);
+    const override = getProductOverrideByEan(barcode);
+    if (overrideUi) {
+      return {
+        status: 'OK',
+        barcode,
+        ui: overrideUi,
+        product: {
+          name: overrideUi.name,
+          brands: overrideUi.brand,
+          quantity: overrideUi.quantity,
+          categories: override?.categories,
+        },
+      };
+    }
+
     const errorName = error instanceof Error ? error.name : '';
     const isAbortError = errorName === 'AbortError';
     return {

--- a/frontend/src/services/priceSearch/price.types.ts
+++ b/frontend/src/services/priceSearch/price.types.ts
@@ -32,7 +32,8 @@ export type TerritoryCode =
 export type PriceSourceId =
   | 'open_food_facts'
   | 'open_prices'
-  | 'data_gouv';
+  | 'data_gouv'
+  | 'local_override';
 
 export type PriceSearchStatus =
   | 'OK'

--- a/frontend/src/services/priceSearch/priceSearch.service.ts
+++ b/frontend/src/services/priceSearch/priceSearch.service.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-undef */
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import { findLocalPriceOverrides, type RetailerId } from '../../data/price_overrides';
 import { computeMedian, normalizeObservation, normalizePriceValue } from './priceNormalizer';
 import { computePriceConfidence } from './priceConfidence';
 import { normalizeTerritoryCode } from './normalizeTerritoryCode';
@@ -8,6 +9,7 @@ import { buildCacheKey, getCache, purgeExpiredCache, setCache } from '../../prov
 import { trackSearchError, trackSearchResult, trackSearchStart } from './telemetry';
 import type {
   PriceInterval,
+  PriceObservation,
   PriceSearchInput,
   PriceSearchResult,
   PriceSearchStatus,
@@ -56,6 +58,77 @@ function areResultsDifferent(a: PriceSearchResult, b: PriceSearchResult): boolea
   return JSON.stringify(a) !== JSON.stringify(b);
 }
 
+function mapStoreToRetailerId(storeId?: string): RetailerId | undefined {
+  const normalized = (storeId ?? '').trim().toLowerCase();
+  switch (normalized) {
+    case 'carrefour':
+      return 'carrefour';
+    case 'leclerc':
+    case 'e.leclerc':
+    case 'e-leclerc':
+      return 'leclerc';
+    case 'intermarche':
+    case 'intermarché':
+      return 'intermarche';
+    case 'superu':
+    case 'super u':
+      return 'superu';
+    default:
+      return undefined;
+  }
+}
+
+function computeInterval(observations: ReturnType<typeof normalizeObservation>[]): PriceInterval {
+  const priceValues = observations.map((obs) => obs.price);
+  return {
+    min: priceValues.length > 0 ? normalizePriceValue(Math.min(...priceValues)) : null,
+    median: computeMedian(priceValues),
+    max: priceValues.length > 0 ? normalizePriceValue(Math.max(...priceValues)) : null,
+    currency: 'EUR',
+    priceCount: priceValues.length,
+  };
+}
+
+function buildLocalOverrideObservations(
+  input: PriceSearchInput,
+  territory: TerritoryCode
+): PriceObservation[] {
+  if (!input.barcode) {
+    return [];
+  }
+
+  const retailer = mapStoreToRetailerId(input.storeId);
+  const localEntries = findLocalPriceOverrides(input.barcode, territory, retailer);
+
+  return localEntries.map((entry) => {
+    const price = entry.price ?? Number.NaN;
+
+    return {
+      source: 'local_override',
+      barcode: entry.ean,
+      price,
+      currency: entry.currency,
+      unit: entry.unit,
+      observedAt: entry.observedAt,
+      territory,
+      metadata: {
+        retailer: entry.retailer,
+        territory,
+        note: entry.sourceNote ?? 'Catalogue interne (prix).',
+        priceStatus: entry.price === null ? 'missing' : 'available',
+      },
+    };
+  });
+}
+
+function shouldUseLocalOverride(
+  status: PriceSearchStatus,
+  observationsCount: number,
+  hasUnavailableProvider: boolean
+): boolean {
+  return observationsCount === 0 || status === 'NO_DATA' || status === 'UNAVAILABLE' || hasUnavailableProvider;
+}
+
 async function fetchLiveResult(
   normalizedInput: PriceSearchInput,
   territory: TerritoryCode,
@@ -68,7 +141,7 @@ async function fetchLiveResult(
     controller.signal
   );
 
-  const observations = providerResults
+  const providerObservations = providerResults
     .flatMap((result) => result.observations)
     .map(normalizeObservation);
 
@@ -82,20 +155,11 @@ async function fetchLiveResult(
     )
   );
 
-  const priceValues = observations.map((obs) => obs.price);
-  const interval: PriceInterval = {
-    min: priceValues.length > 0 ? normalizePriceValue(Math.min(...priceValues)) : null,
-    median: computeMedian(priceValues),
-    max: priceValues.length > 0 ? normalizePriceValue(Math.max(...priceValues)) : null,
-    currency: 'EUR',
-    priceCount: priceValues.length,
-  };
-
   const confidence = computePriceConfidence({
-    territoryMatch: observations.some(
+    territoryMatch: providerObservations.some(
       (obs) => normalizeTerritoryCode(obs.territory) === territory
     ),
-    observations,
+    observations: providerObservations,
   });
 
   const productName =
@@ -103,26 +167,48 @@ async function fetchLiveResult(
       .map((result) => result.productName)
       .find(Boolean) ?? undefined;
 
-  if (observations.length === 0) {
-    warnings.push('Données insuffisantes pour établir une fourchette de prix fiable.');
-  }
-
   const hasUnavailableProvider = providerResults.some((result) => result.status === 'UNAVAILABLE');
 
-  const status: PriceSearchStatus =
-    observations.length === 0
+  const providerStatus: PriceSearchStatus =
+    providerObservations.length === 0
       ? 'NO_DATA'
       : confidence < 50 || warnings.length > 0 || hasUnavailableProvider
         ? 'PARTIAL'
         : 'OK';
 
+  const useLocalOverride = shouldUseLocalOverride(providerStatus, providerObservations.length, hasUnavailableProvider);
+  const localOverrides = useLocalOverride ? buildLocalOverrideObservations(normalizedInput, territory) : [];
+  const normalizedLocalOverrides = localOverrides.map(normalizeObservation);
+
+  if (providerObservations.length === 0 && normalizedLocalOverrides.length === 0) {
+    warnings.push('Données insuffisantes pour établir une fourchette de prix fiable.');
+  }
+
+  const observations = providerObservations.length > 0 ? providerObservations : normalizedLocalOverrides;
+  const localOverrideFound = normalizedLocalOverrides.length > 0;
+  const status: PriceSearchStatus =
+    providerObservations.length > 0
+      ? providerStatus
+      : localOverrideFound
+        ? 'PARTIAL'
+        : 'NO_DATA';
+
+  const finalWarnings = [...warnings];
+  if (localOverrideFound) {
+    finalWarnings.push('Source: Catalogue interne (prix).');
+  }
+
+  const finalSourcesUsed = localOverrideFound
+    ? Array.from(new Set([...sourcesUsed, 'local_override']))
+    : sourcesUsed;
+
   return {
     status,
-    intervals: observations.length > 0 ? [interval] : [],
+    intervals: observations.length > 0 ? [computeInterval(observations)] : [],
     confidence,
     observations,
-    warnings,
-    sourcesUsed,
+    warnings: finalWarnings,
+    sourcesUsed: finalSourcesUsed,
     territory,
     productName,
     metadata: {
@@ -218,6 +304,36 @@ export async function searchProductPrices(input: PriceSearchInput): Promise<Pric
         cacheHit: true,
       });
       return cached.value;
+    }
+
+    const localOverrides = buildLocalOverrideObservations(normalizedInput, territory).map(normalizeObservation);
+    if (localOverrides.length > 0) {
+      const localResult: PriceSearchResult = {
+        status: 'PARTIAL',
+        intervals: [computeInterval(localOverrides)],
+        confidence: 20,
+        observations: localOverrides,
+        warnings: ['Service indisponible pour le moment.', 'Source: Catalogue interne (prix).'],
+        sourcesUsed: ['local_override'],
+        territory,
+        metadata: {
+          queriedAt: new Date().toISOString(),
+          queryUsed,
+          territoryMessage: territoryMessage(territory),
+        },
+      };
+
+      trackSearchError({ territory, cacheHit: false, reason: 'live_fetch_failed' });
+      trackSearchResult({
+        territory,
+        status: localResult.status,
+        confidence: localResult.confidence,
+        sourceCount: localResult.sourcesUsed.length,
+        warningCount: localResult.warnings.length,
+        cacheHit: false,
+      });
+
+      return localResult;
     }
 
     const unavailableResult: PriceSearchResult = {

--- a/frontend/src/test/alerts.serviceFallback.test.ts
+++ b/frontend/src/test/alerts.serviceFallback.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getAlerts } from '../services/alertsService';
 
 describe('alertsService fallback', () => {
@@ -14,5 +14,93 @@ describe('alertsService fallback', () => {
     expect(result.metadata.source).toBe('fallback');
     expect(result.alerts.length).toBeGreaterThan(0);
     expect(result.alerts.every((alert) => alert.territory === 'gp')).toBe(true);
+  });
+});
+
+describe('priceSearch local overrides fallback', () => {
+  const runPriceProvidersMock = vi.fn();
+
+  beforeEach(() => {
+    runPriceProvidersMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.doUnmock('../providers');
+    vi.doUnmock('../providers/cache');
+    vi.doUnmock('../services/priceSearch/telemetry');
+  });
+
+  async function loadSearchProductPrices() {
+    vi.doMock('../providers', () => ({
+      runPriceProviders: runPriceProvidersMock,
+    }));
+
+    vi.doMock('../providers/cache', () => ({
+      buildCacheKey: () => 'price-search-key',
+      getCache: () => null,
+      setCache: vi.fn(),
+      purgeExpiredCache: vi.fn(),
+    }));
+
+    vi.doMock('../services/priceSearch/telemetry', () => ({
+      trackSearchStart: vi.fn(),
+      trackSearchResult: vi.fn(),
+      trackSearchError: vi.fn(),
+    }));
+
+    const module = await import('../services/priceSearch/priceSearch.service');
+    return module.searchProductPrices;
+  }
+
+  it('returns local overrides when live providers return no data', async () => {
+    runPriceProvidersMock.mockResolvedValue([
+      { source: 'open_prices', status: 'NO_DATA', observations: [], warnings: [] },
+    ]);
+
+    const searchProductPrices = await loadSearchProductPrices();
+    const result = await searchProductPrices({
+      barcode: '3560070894222',
+      territory: 'gp',
+    });
+
+    expect(result.status).toBe('PARTIAL');
+    expect(result.sourcesUsed).toContain('local_override');
+    expect(result.observations).toHaveLength(4);
+    expect(result.observations.every((entry) => entry.source === 'local_override')).toBe(true);
+  });
+
+  it('keeps NO_DATA when no local override exists', async () => {
+    runPriceProvidersMock.mockResolvedValue([
+      { source: 'open_prices', status: 'NO_DATA', observations: [], warnings: [] },
+    ]);
+
+    const searchProductPrices = await loadSearchProductPrices();
+    const result = await searchProductPrices({
+      barcode: '0000000000000',
+      territory: 'gp',
+    });
+
+    expect(result.status).toBe('NO_DATA');
+    expect(result.sourcesUsed).not.toContain('local_override');
+    expect(result.observations).toHaveLength(0);
+  });
+
+  it('filters local overrides by territory and retailer', async () => {
+    runPriceProvidersMock.mockResolvedValue([
+      { source: 'open_prices', status: 'NO_DATA', observations: [], warnings: [] },
+    ]);
+
+    const searchProductPrices = await loadSearchProductPrices();
+    const result = await searchProductPrices({
+      barcode: '3560070894222',
+      territory: 'mq',
+      storeId: 'carrefour',
+    });
+
+    expect(result.observations).toHaveLength(1);
+    expect(result.observations[0]?.metadata?.retailer).toBe('carrefour');
+    expect(result.observations[0]?.territory).toBe('mq');
   });
 });


### PR DESCRIPTION
### Motivation
- Fournir un fallback local maintenable et multi-enseignes / multi-territoires pour les prix lorsque les sources externes sont vides ou indisponibles, sans scraper côté client et sans inventer de prix.
- Rendre la fiche produit robuste en affichant un produit local si OpenFoodFacts est indisponible ou ne contient pas le produit.

### Description
- Ajout d’un catalogue produit local `frontend/src/data/product_overrides.ts` contenant l’EAN `3560070894222` avec marque, nom, quantité, ingrédients FR, nutrition (sirop + dilué) et catégories, et helper `getProductOverrideByEan`.
- Nouveau fichier de données `frontend/src/data/price_overrides.ts` avec type `LocalPriceOverride` et entrées par couple `ean`/`territory`/`retailer` pour `carrefour|leclerc|intermarche|superu` × `fr|gp|mq`, en laissant `price: null` (placeholders explicites, pas de prix inventés) et fonction `findLocalPriceOverrides`.
- Extension des types prix (`PriceSourceId`) pour inclure `local_override` et adaptation du service de recherche prix (`frontend/src/services/priceSearch/priceSearch.service.ts`) pour : filtrer par EAN exact, territoire et retailer optionnel (mapping `storeId -> retailer`), injecter les observations locales quand les providers renvoient `NO_DATA`/`UNAVAILABLE`/aucune observation, et exposer `PARTIAL` quand seules les overrides locales sont utilisées, avec métadonnées (`retailer`, `note`, `priceStatus`, `territory`).
- Fallback produit côté OpenFoodFacts (`frontend/src/services/openFoodFacts.ts`) pour retourner la donnée locale (`local_override`) en cas de `status:0`, HTTP 404, ou erreur réseau.
- UI: mise à jour de la page fiche produit (`frontend/src/pages/ProductScanResult.tsx`) pour ajouter un sélecteur de territoire (`GP/MQ/FR`), afficher la liste multi-enseignes triée par prix, traiter `price: null` comme « Prix non renseigné », et calculer min/médiane/max tout en indiquant discrètement la source locale.
- Tests: ajout/extension des tests unitaires pour couvrir le fallback local (cas: providers renvoient vide → overrides locales; pas d’override → NO_DATA; filtrage territoire/enseigne).
- Build fix: remplacement de l’import `@zxing/browser` par `@zxing/library` dans `ScannerHub` pour corriger un blocage de build Vite/Cloudflare Pages.

### Testing
- Exécution des tests unitaires avec `npm -C frontend test` et `vitest` : suite passée (tests existants + nouveaux tests) — all tests green.
- Linting via `npm -C frontend run lint:ci` : OK (changed-files lint passed).
- Build via `npm -C frontend run build` : initialement échoué à cause de `@zxing/browser`, corrigé en remplaçant l’import et rebuild réussi ; artefact de build généré avec succès.
- Tests ajoutés/édités pertinents : fichiers de test mis à jour pour valider la logique de fallback local (voir `frontend/src/test/alerts.serviceFallback.test.ts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994fbf554fc83218abfa7c1210398eb)