### PR TITLE
feat: add local product override fallback for missing EAN data

### DIFF
--- a/frontend/src/data/product_overrides.ts
+++ b/frontend/src/data/product_overrides.ts
@@ -1,0 +1,43 @@
+export type ProductOverride = {
+  productName: string;
+  brand: string;
+  quantity?: string;
+  ingredientsText?: string;
+  nutritionPer100g?: {
+    energyKj?: number;
+    energyKcal?: number;
+    fat?: number;
+    saturatedFat?: number;
+    carbs?: number;
+    sugars?: number;
+    fiber?: number;
+    protein?: number;
+    salt?: number;
+  };
+  categories?: string[];
+};
+
+export const productOverrides: Record<string, ProductOverride> = {
+  '3179142767304': {
+    productName: 'Levure du Boulanger – Levée rapide',
+    brand: 'Vahiné',
+    quantity: '27,6 g (6 sachets de 4,6 g)',
+    ingredientsText: 'Levure de boulangerie déshydratée, émulsifiant : E491, antioxydant : E300.',
+    nutritionPer100g: {
+      energyKj: 1489,
+      energyKcal: 355,
+      fat: 5.7,
+      saturatedFat: 0.9,
+      carbs: 19,
+      sugars: 14,
+      fiber: 27,
+      protein: 44,
+      salt: 0.3,
+    },
+    categories: ['boulangerie', 'levure', 'aide à la pâtisserie'],
+  },
+};
+
+export function getProductOverride(barcode: string): ProductOverride | null {
+  return productOverrides[barcode] ?? null;
+}

--- a/frontend/src/pages/ProductScanResult.tsx
+++ b/frontend/src/pages/ProductScanResult.tsx
@@ -9,6 +9,7 @@ export default function ProductScanResult() {
   const navigate = useNavigate();
   const [state, setState] = useState<LoadState>('loading');
   const [product, setProduct] = useState<OffProductUiModel | null>(null);
+  const [productSource, setProductSource] = useState<'openfoodfacts' | 'local_override' | null>(null);
 
   const loadProduct = useCallback(async () => {
     setState('loading');
@@ -16,6 +17,7 @@ export default function ProductScanResult() {
 
     if (result.status === 'OK' && result.ui) {
       setProduct(result.ui);
+      setProductSource(result.source ?? result.ui.source ?? null);
       setState('success');
       return;
     }
@@ -64,6 +66,9 @@ export default function ProductScanResult() {
             <header>
               <h2 className="text-2xl font-semibold">{product.name ?? 'Produit sans nom'}</h2>
               <p className="text-slate-300">{product.brand ?? 'Marque non renseignée'}{product.quantity ? ` · ${product.quantity}` : ''}</p>
+              {productSource === 'local_override' && (
+                <p className="mt-1 text-xs text-slate-400">Source: Catalogue interne</p>
+              )}
             </header>
 
             {product.image && <img src={product.image} alt={product.name ?? 'Produit'} className="max-h-64 w-full rounded-xl object-contain bg-white p-2" />}
@@ -78,8 +83,13 @@ export default function ProductScanResult() {
               <h3 className="mb-3 text-lg font-semibold">Nutrition (pour 100g)</h3>
               <div className="grid grid-cols-2 gap-2 text-sm text-slate-200">
                 <div>kcal: {product.nutriments.kcal ?? 'n/d'}</div>
+                <div>Énergie: {product.nutritionPer100g?.energyKj ?? 'n/d'} kJ</div>
                 <div>Sucres: {product.nutriments.sugars ?? 'n/d'} g</div>
                 <div>Matières grasses: {product.nutriments.fat ?? 'n/d'} g</div>
+                <div>Acides gras saturés: {product.nutritionPer100g?.saturatedFat ?? 'n/d'} g</div>
+                <div>Glucides: {product.nutritionPer100g?.carbs ?? 'n/d'} g</div>
+                <div>Fibres: {product.nutritionPer100g?.fiber ?? 'n/d'} g</div>
+                <div>Protéines: {product.nutritionPer100g?.protein ?? 'n/d'} g</div>
                 <div>Sel: {product.nutriments.salt ?? 'n/d'} g</div>
               </div>
             </section>

--- a/frontend/src/services/openFoodFacts.test.ts
+++ b/frontend/src/services/openFoodFacts.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { fetchOffProductByBarcode, validateBarcode, __offInternals } from './openFoodFacts';
+import { fetchOffProductByBarcode, fetchOffProductDetails, validateBarcode, __offInternals } from './openFoodFacts';
 import { getCachedWithTTL, setCachedJson } from './localStore';
 
 describe('openFoodFacts barcode validation', () => {
@@ -86,6 +86,22 @@ describe('openFoodFacts response mapping', () => {
 
     const result = await fetchOffProductByBarcode('12345678');
     expect(result.status).toBe('NOT_FOUND');
+  });
+
+
+  it('uses local override when OFF returns empty for seeded barcode', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, status: 200, json: async () => ({ status: 0 }) } as unknown as globalThis.Response))
+    );
+
+    const result = await fetchOffProductDetails('3179142767304');
+    expect(result.status).toBe('OK');
+    expect(result.source).toBe('local_override');
+    expect(result.message).toBe('données internes');
+    expect(result.ui?.name).toBe('Levure du Boulanger – Levée rapide');
+    expect(result.ui?.brand).toBe('Vahiné');
+    expect(result.ui?.nutritionPer100g?.protein).toBe(44);
   });
 
   it('returns error for network failure', async () => {

--- a/frontend/src/services/openFoodFacts.ts
+++ b/frontend/src/services/openFoodFacts.ts
@@ -1,13 +1,17 @@
 import { getCachedWithTTL, setCachedJson } from './localStore';
+import { getProductOverride } from '../data/product_overrides';
 
 const OFF_DEFAULT_BASE_URL = 'https://world.openfoodfacts.org';
 const OFF_PRODUCT_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const OFF_TIMEOUT_MS = 8000;
 
 type OffStatus = 'OK' | 'NOT_FOUND' | 'INVALID' | 'ERROR';
+type OffSource = 'openfoodfacts' | 'local_override';
 
 export type OffProductResult = {
   status: OffStatus;
+  source?: OffSource;
+  message?: string;
   barcode: string;
   product?: {
     name?: string;
@@ -56,6 +60,20 @@ export type OffProductUiModel = {
   };
   ingredients?: string;
   allergens?: string;
+  categories?: string[];
+  nutritionPer100g?: {
+    energyKj?: number;
+    energyKcal?: number;
+    fat?: number;
+    saturatedFat?: number;
+    carbs?: number;
+    sugars?: number;
+    fiber?: number;
+    protein?: number;
+    salt?: number;
+  };
+  source?: OffSource;
+  sourceMessage?: string;
 };
 
 function getOffBaseUrl(): string {
@@ -118,9 +136,30 @@ function mapApiResponse(barcode: string, payload: OffApiResponse): OffProductRes
 
   return {
     status: 'OK',
+    source: 'openfoodfacts',
     barcode,
     product: normalizedProduct,
     ...(import.meta.env.DEV ? { raw: payload } : {}),
+  };
+}
+
+function getLocalOverrideResult(barcode: string): OffProductResult | null {
+  const override = getProductOverride(barcode);
+  if (!override) {
+    return null;
+  }
+
+  return {
+    status: 'OK',
+    source: 'local_override',
+    message: 'données internes',
+    barcode,
+    product: {
+      name: override.productName,
+      brands: override.brand,
+      quantity: override.quantity,
+      categories: override.categories,
+    },
   };
 }
 
@@ -174,6 +213,12 @@ export async function fetchOffProductByBarcode(
     );
 
     if (!response.ok) {
+      if (response.status === 404) {
+        const local = getLocalOverrideResult(barcode);
+        if (local) {
+          return local;
+        }
+      }
       return {
         status: 'ERROR',
         barcode,
@@ -186,6 +231,13 @@ export async function fetchOffProductByBarcode(
 
     const payload = (await response.json()) as OffApiResponse;
     const mapped = mapApiResponse(barcode, payload);
+
+    if (mapped.status === 'NOT_FOUND') {
+      const local = getLocalOverrideResult(barcode);
+      if (local) {
+        return local;
+      }
+    }
 
     if (mapped.status === 'OK' || mapped.status === 'NOT_FOUND') {
       setCachedJson(cacheKey(barcode), {
@@ -264,6 +316,32 @@ function mapToUiModel(barcode: string, product: OffApiProduct): OffProductUiMode
     },
     ingredients: safeString(product.ingredients_text),
     allergens: safeString(product.allergens),
+    source: 'openfoodfacts',
+  };
+}
+
+function mapOverrideToUiModel(barcode: string): OffProductUiModel | null {
+  const override = getProductOverride(barcode);
+  if (!override) {
+    return null;
+  }
+
+  return {
+    barcode,
+    name: override.productName,
+    brand: override.brand,
+    quantity: override.quantity,
+    nutriments: {
+      kcal: override.nutritionPer100g?.energyKcal,
+      sugars: override.nutritionPer100g?.sugars,
+      fat: override.nutritionPer100g?.fat,
+      salt: override.nutritionPer100g?.salt,
+    },
+    ingredients: override.ingredientsText,
+    categories: override.categories,
+    nutritionPer100g: override.nutritionPer100g,
+    source: 'local_override',
+    sourceMessage: 'données internes',
   };
 }
 
@@ -289,6 +367,24 @@ export async function fetchOffProductDetails(
     );
 
     if (!response.ok) {
+      if (response.status === 404) {
+        const localUi = mapOverrideToUiModel(barcode);
+        if (localUi) {
+          return {
+            status: 'OK',
+            source: 'local_override',
+            message: 'données internes',
+            barcode,
+            ui: localUi,
+            product: {
+              name: localUi.name,
+              brands: localUi.brand,
+              quantity: localUi.quantity,
+              categories: localUi.categories,
+            },
+          };
+        }
+      }
       return {
         status: response.status === 404 ? 'NOT_FOUND' : 'ERROR',
         barcode,
@@ -302,6 +398,22 @@ export async function fetchOffProductDetails(
     const payload = (await response.json()) as OffApiResponse;
 
     if (payload.status === 0 || !payload.product) {
+      const localUi = mapOverrideToUiModel(barcode);
+      if (localUi) {
+        return {
+          status: 'OK',
+          source: 'local_override',
+          message: 'données internes',
+          barcode,
+          ui: localUi,
+          product: {
+            name: localUi.name,
+            brands: localUi.brand,
+            quantity: localUi.quantity,
+            categories: localUi.categories,
+          },
+        };
+      }
       return {
         status: 'NOT_FOUND',
         barcode,
@@ -321,6 +433,7 @@ export async function fetchOffProductDetails(
 
     return {
       status: 'OK',
+      source: 'openfoodfacts',
       barcode,
       ui: mapToUiModel(barcode, payload.product),
       product: {


### PR DESCRIPTION
### Motivation
- Ensure products missing from public sources (OpenFoodFacts) can still be resolved using an internal catalog so the app finds EAN 3179142767304.
- Provide a lightweight, runtime override mechanism (EAN -> product fiche) while preserving source traceability.
- Surface the internal source in the product UI so users know data originates from the internal catalogue.

### Description
- Add a runtime local override catalog at `frontend/src/data/product_overrides.ts` and seed it with EAN `3179142767304` (Vahiné Levure du Boulanger – Levée rapide) including `productName`, `brand`, `quantity`, `ingredientsText`, `nutritionPer100g`, and `categories`.
- Update OpenFoodFacts service (`frontend/src/services/openFoodFacts.ts`) to consult the local catalog when the OFF API returns `404` or an empty product (`status: 0`) and return a result with `status: 'OK'`, `source: 'local_override'` and `message: 'données internes'` when an override is found.
- Extend the OFF UI model to carry nutrition, categories and source metadata and add mapping helpers (`mapOverrideToUiModel`) so the product details page can render override data uniformly.
- Update product details UI (`frontend/src/pages/ProductScanResult.tsx`) to show a subtle `Source: Catalogue interne` label when an override is used and to display the extended nutrition fields.
- Add a unit test in `frontend/src/services/openFoodFacts.test.ts` that verifies the seeded EAN returns the local override when OFF responds empty.

### Testing
- Ran unit tests: `npm -C frontend run test -- src/services/openFoodFacts.test.ts` — test file passed (7 tests) ✅
- Linting: `npm -C frontend run lint:ci` — lint succeeded for changed files ✅
- Build: `npm -C frontend run build` — build failed due to a pre-existing unresolved dependency (`@zxing/browser` imported by `frontend/src/pages/ScannerHub.tsx`), unrelated to these changes ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994f5d9bb3c8321bb753a23195d919d)