### PR TITLE
feat(price-api): add connector-based fetch jobs with admin endpoints and scheduled cron

### DIFF
--- a/price-api/README.md
+++ b/price-api/README.md
@@ -9,6 +9,8 @@ Micro-service TypeScript pour centraliser les prix (`GET` public) et administrer
 - Historique des observations avec `source`, `confidence`, `metadata_json` (extensible pour flux autorisés/back-office).
 - Endpoints `GET` cacheables (Cloudflare cache + ETag).
 - Endpoints `POST /v1/admin/*` protégés par `PRICE_ADMIN_TOKEN` + rate limit D1.
+- Architecture de connecteurs autorisés (`src/connectors/*`) pour ingestion asynchrone via jobs.
+- Traçabilité complète des runs dans D1 (`sources`, `fetch_jobs`, `fetch_job_items`).
 
 ## Setup
 
@@ -23,7 +25,7 @@ Créer la base D1 (remplacer le nom si besoin) :
 npx wrangler d1 create price-db
 ```
 
-Mettre à jour `wrangler.toml` avec le `database_id` retourné, puis appliquer la migration :
+Mettre à jour `wrangler.toml` avec le `database_id` retourné, puis appliquer les migrations :
 
 ```bash
 npx wrangler d1 migrations apply PRICE_DB --local
@@ -52,13 +54,41 @@ npm run dev
 - `GET /v1/prices?ean=...&territory=gp`
 - `GET /v1/products/:ean`
 
-### Admin (POST)
+### Admin
 
 Header requis : `Authorization: Bearer <PRICE_ADMIN_TOKEN>`
+
+#### POST
 
 - `POST /v1/admin/products`
 - `POST /v1/admin/observations`
 - `POST /v1/admin/seed`
+- `POST /v1/admin/fetch/run`
+  - Body: `{ "territory": "fr|gp|mq", "sourceId"?: "backoffice", "limit"?: 25 }`
+  - Crée un `fetch_job`, exécute le run immédiatement (MVP synchrone), écrit les `fetch_job_items`, insère les observations valides, puis recalcule les agrégats.
+
+#### GET
+
+- `GET /v1/admin/fetch/jobs?territory=&sourceId=&limit=`
+  - Retourne la liste des jobs récents avec compteurs `ok/no_data/error/invalid`.
+
+## Cron & scheduled jobs
+
+`wrangler.toml` configure un cron toutes les 6h:
+
+```toml
+[triggers]
+crons = ["0 */6 * * *"]
+```
+
+Le handler `scheduled()` exécute un job par territoire (`fr`, `gp`, `mq`) via un connecteur activé (fallback `backoffice`) en utilisant `ctx.waitUntil()`.
+
+## Ajouter un connecteur autorisé
+
+1. Créer un fichier dans `src/connectors/` qui implémente l’interface `Connector`.
+2. Ajouter le connecteur à `src/connectors/registry.ts`.
+3. Déclarer/mettre à jour la source dans `sources` (via `ensureDefaultSources` ou admin outillé).
+4. Implémenter `fetchPrices({ territory, eans })` en respectant les contraintes de sécurité (aucun secret dans les logs, payload brut limité et tracé via `raw_payload_json`).
 
 ## Exemples cURL
 
@@ -71,35 +101,14 @@ curl -s "http://127.0.0.1:8787/v1/products/3560070894222"
 ```
 
 ```bash
-curl -s -X POST "http://127.0.0.1:8787/v1/admin/products" \
+curl -s -X POST "http://127.0.0.1:8787/v1/admin/fetch/run" \
   -H "Authorization: Bearer $PRICE_ADMIN_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{
-    "ean":"3560070894222",
-    "productName":"Carrefour Classic’ Sirop de cerise / Cerise-Kers 75 cl",
-    "brand":"Carrefour Classic’",
-    "quantity":"75 cl"
-  }'
+  -d '{"territory":"fr","sourceId":"backoffice","limit":25}'
 ```
 
 ```bash
-curl -s -X POST "http://127.0.0.1:8787/v1/admin/observations" \
-  -H "Authorization: Bearer $PRICE_ADMIN_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "ean":"3560070894222",
-    "territory":"gp",
-    "retailer":"carrefour",
-    "price":3.49,
-    "currency":"EUR",
-    "unit":"l",
-    "source":"admin",
-    "confidence":0.9
-  }'
-```
-
-```bash
-curl -s -X POST "http://127.0.0.1:8787/v1/admin/seed" \
+curl -s "http://127.0.0.1:8787/v1/admin/fetch/jobs?territory=fr&limit=20" \
   -H "Authorization: Bearer $PRICE_ADMIN_TOKEN"
 ```
 

--- a/price-api/migrations/0002_fetch_jobs.sql
+++ b/price-api/migrations/0002_fetch_jobs.sql
@@ -1,0 +1,44 @@
+CREATE TABLE IF NOT EXISTS sources (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  type TEXT NOT NULL,
+  base_url TEXT,
+  auth_type TEXT NOT NULL,
+  enabled INTEGER NOT NULL DEFAULT 1,
+  territory_scope TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS fetch_jobs (
+  id TEXT PRIMARY KEY,
+  source_id TEXT NOT NULL REFERENCES sources(id),
+  territory TEXT NOT NULL,
+  status TEXT NOT NULL,
+  started_at TEXT,
+  finished_at TEXT,
+  error TEXT
+);
+
+CREATE TABLE IF NOT EXISTS fetch_job_items (
+  id TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL REFERENCES fetch_jobs(id),
+  ean TEXT NOT NULL,
+  retailer TEXT,
+  status TEXT NOT NULL,
+  raw_ref TEXT,
+  raw_payload_json TEXT,
+  observed_price_cents INTEGER,
+  currency TEXT,
+  unit TEXT,
+  observed_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_source_territory_time
+  ON fetch_jobs (source_id, territory, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_items_job
+  ON fetch_job_items (job_id);
+
+CREATE INDEX IF NOT EXISTS idx_items_ean
+  ON fetch_job_items (ean);

--- a/price-api/src/connectors/backoffice.ts
+++ b/price-api/src/connectors/backoffice.ts
@@ -1,0 +1,12 @@
+import type { Connector } from './types';
+
+export const backofficeConnector: Connector = {
+  id: 'backoffice',
+  name: 'Backoffice Placeholder Connector',
+  type: 'backoffice',
+  enabledByDefault: true,
+  supportsTerritory: () => true,
+  async fetchPrices() {
+    return [];
+  },
+};

--- a/price-api/src/connectors/open_data_dummy.ts
+++ b/price-api/src/connectors/open_data_dummy.ts
@@ -1,0 +1,13 @@
+import type { Connector } from './types';
+
+export const openDataDummyConnector: Connector = {
+  id: 'open_data_dummy',
+  name: 'Open Data Dummy Connector',
+  type: 'open_data',
+  enabledByDefault: true,
+  supportsTerritory: () => true,
+  async fetchPrices() {
+    // TODO: implement authorized open-data source integration.
+    return [];
+  },
+};

--- a/price-api/src/connectors/registry.ts
+++ b/price-api/src/connectors/registry.ts
@@ -1,0 +1,18 @@
+import type { Territory } from '../types';
+import { backofficeConnector } from './backoffice';
+import { openDataDummyConnector } from './open_data_dummy';
+import type { Connector } from './types';
+
+const connectors: Connector[] = [backofficeConnector, openDataDummyConnector];
+
+export function getConnectorById(id: string): Connector | null {
+  return connectors.find((connector) => connector.id === id) ?? null;
+}
+
+export function getEnabledConnectorsForTerritory(territory: Territory): Connector[] {
+  return connectors.filter((connector) => connector.enabledByDefault && connector.supportsTerritory(territory));
+}
+
+export function listConnectors(): Connector[] {
+  return connectors;
+}

--- a/price-api/src/connectors/types.ts
+++ b/price-api/src/connectors/types.ts
@@ -1,0 +1,31 @@
+import type { Territory } from '../types';
+
+export type ConnectorType = 'partner_api' | 'open_data' | 'backoffice';
+
+export interface ConnectorPrice {
+  ean: string;
+  retailer: string;
+  priceCents: number;
+  currency: 'EUR';
+  unit?: string;
+  observedAt?: string;
+  rawRef?: string;
+  rawPayload?: Record<string, unknown>;
+}
+
+export interface FetchContext {
+  territory: Territory;
+  eans: string[];
+  env: {
+    PRICE_DB: D1Database;
+  };
+}
+
+export interface Connector {
+  id: string;
+  name: string;
+  type: ConnectorType;
+  enabledByDefault: boolean;
+  supportsTerritory(territory: Territory): boolean;
+  fetchPrices(context: FetchContext): Promise<ConnectorPrice[]>;
+}

--- a/price-api/src/db.ts
+++ b/price-api/src/db.ts
@@ -1,8 +1,12 @@
 import type {
+  FetchJobListRecord,
+  FetchJobRecord,
+  FetchJobStatus,
   InsertObservationInput,
   PriceAggregateRecord,
   PriceObservationRecord,
   ProductRecord,
+  SourceRecord,
   Territory,
 } from './types';
 
@@ -127,10 +131,7 @@ export async function upsertProduct(
     .run();
 }
 
-export async function insertObservationAndRefreshAggregate(
-  db: D1Database,
-  input: InsertObservationInput,
-): Promise<void> {
+export async function insertObservationAndRefreshAggregate(db: D1Database, input: InsertObservationInput): Promise<void> {
   const priceCents = Math.round(input.price * 100);
   const observedAt = input.observedAt ?? new Date().toISOString();
   const id = crypto.randomUUID();
@@ -288,12 +289,7 @@ export async function refreshAggregate(
     .run();
 }
 
-export async function applySimpleRateLimit(
-  db: D1Database,
-  key: string,
-  limit = 60,
-  windowSeconds = 60,
-): Promise<boolean> {
+export async function applySimpleRateLimit(db: D1Database, key: string, limit = 60, windowSeconds = 60): Promise<boolean> {
   const now = new Date();
   const currentWindow = new Date(Math.floor(now.getTime() / (windowSeconds * 1000)) * windowSeconds * 1000).toISOString();
 
@@ -321,4 +317,163 @@ export async function applySimpleRateLimit(
 
   await db.prepare('UPDATE rate_limits SET count = count + 1 WHERE key = ?').bind(key).run();
   return true;
+}
+
+export async function upsertSource(db: D1Database, source: Omit<SourceRecord, 'created_at'>): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO sources (id, name, type, base_url, auth_type, enabled, territory_scope, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+       ON CONFLICT(id) DO UPDATE SET
+         name = excluded.name,
+         type = excluded.type,
+         base_url = excluded.base_url,
+         auth_type = excluded.auth_type,
+         enabled = excluded.enabled,
+         territory_scope = excluded.territory_scope`,
+    )
+    .bind(source.id, source.name, source.type, source.base_url, source.auth_type, source.enabled, source.territory_scope)
+    .run();
+}
+
+export async function ensureDefaultSources(db: D1Database): Promise<void> {
+  const defaults: Omit<SourceRecord, 'created_at'>[] = [
+    {
+      id: 'backoffice',
+      name: 'Backoffice Placeholder',
+      type: 'backoffice',
+      base_url: null,
+      auth_type: 'none',
+      enabled: 1,
+      territory_scope: 'fr,gp,mq',
+    },
+    {
+      id: 'open_data_dummy',
+      name: 'Open Data Dummy',
+      type: 'open_data',
+      base_url: null,
+      auth_type: 'none',
+      enabled: 1,
+      territory_scope: 'fr,gp,mq',
+    },
+  ];
+
+  for (const source of defaults) {
+    await upsertSource(db, source);
+  }
+}
+
+export async function createFetchJob(db: D1Database, sourceId: string, territory: Territory): Promise<string> {
+  const id = crypto.randomUUID();
+  await db.prepare('INSERT INTO fetch_jobs (id, source_id, territory, status) VALUES (?, ?, ?, ?)').bind(id, sourceId, territory, 'queued').run();
+  return id;
+}
+
+export async function getFetchJob(db: D1Database, jobId: string): Promise<FetchJobRecord | null> {
+  return db.prepare('SELECT * FROM fetch_jobs WHERE id = ?').bind(jobId).first<FetchJobRecord>();
+}
+
+export async function updateFetchJobStatus(
+  db: D1Database,
+  jobId: string,
+  status: FetchJobStatus,
+  patch?: { startedAt?: string; finishedAt?: string; error?: string | null },
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE fetch_jobs
+       SET status = ?,
+           started_at = COALESCE(?, started_at),
+           finished_at = COALESCE(?, finished_at),
+           error = ?
+       WHERE id = ?`,
+    )
+    .bind(status, patch?.startedAt ?? null, patch?.finishedAt ?? null, patch?.error ?? null, jobId)
+    .run();
+}
+
+export async function insertFetchJobItem(
+  db: D1Database,
+  input: {
+    jobId: string;
+    ean: string;
+    retailer?: string;
+    status: 'ok' | 'no_data' | 'invalid' | 'error';
+    rawRef?: string;
+    rawPayloadJson?: string;
+    observedPriceCents?: number;
+    currency?: string;
+    unit?: string;
+    observedAt?: string;
+  },
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO fetch_job_items (
+        id, job_id, ean, retailer, status, raw_ref, raw_payload_json,
+        observed_price_cents, currency, unit, observed_at, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+    )
+    .bind(
+      crypto.randomUUID(),
+      input.jobId,
+      input.ean,
+      input.retailer ?? null,
+      input.status,
+      input.rawRef ?? null,
+      input.rawPayloadJson ?? null,
+      input.observedPriceCents ?? null,
+      input.currency ?? null,
+      input.unit ?? null,
+      input.observedAt ?? null,
+    )
+    .run();
+}
+
+export async function listFetchJobs(
+  db: D1Database,
+  filters: { territory?: Territory; sourceId?: string; limit?: number },
+): Promise<FetchJobListRecord[]> {
+  let sql = `
+    SELECT
+      j.*,
+      SUM(CASE WHEN i.status = 'ok' THEN 1 ELSE 0 END) AS ok_count,
+      SUM(CASE WHEN i.status = 'no_data' THEN 1 ELSE 0 END) AS no_data_count,
+      SUM(CASE WHEN i.status = 'error' THEN 1 ELSE 0 END) AS error_count,
+      SUM(CASE WHEN i.status = 'invalid' THEN 1 ELSE 0 END) AS invalid_count
+    FROM fetch_jobs j
+    LEFT JOIN fetch_job_items i ON i.job_id = j.id
+    WHERE 1=1
+  `;
+  const binds: (string | number)[] = [];
+
+  if (filters.territory) {
+    sql += ' AND j.territory = ?';
+    binds.push(filters.territory);
+  }
+
+  if (filters.sourceId) {
+    sql += ' AND j.source_id = ?';
+    binds.push(filters.sourceId);
+  }
+
+  sql += ' GROUP BY j.id ORDER BY COALESCE(j.started_at, j.finished_at) DESC, j.id DESC LIMIT ?';
+  binds.push(filters.limit ?? 20);
+
+  const { results } = await db.prepare(sql).bind(...binds).all<FetchJobListRecord>();
+  return (results ?? []).map((item) => ({
+    ...item,
+    ok_count: Number(item.ok_count ?? 0),
+    no_data_count: Number(item.no_data_count ?? 0),
+    error_count: Number(item.error_count ?? 0),
+    invalid_count: Number(item.invalid_count ?? 0),
+  }));
+}
+
+export async function selectKnownEans(db: D1Database, limit: number): Promise<string[]> {
+  const { results } = await db
+    .prepare('SELECT ean FROM products ORDER BY updated_at DESC LIMIT ?')
+    .bind(limit)
+    .all<{ ean: string }>();
+  return (results ?? []).map((item) => item.ean);
 }

--- a/price-api/src/fetch/runner.ts
+++ b/price-api/src/fetch/runner.ts
@@ -1,0 +1,125 @@
+import {
+  createFetchJob,
+  ensureDefaultSources,
+  getFetchJob,
+  insertFetchJobItem,
+  insertObservationAndRefreshAggregate,
+  updateFetchJobStatus,
+} from '../db';
+import { getConnectorById } from '../connectors/registry';
+import { eanListSchema } from '../validators';
+import type { Env, Territory } from '../types';
+import { computeFetchJobStatus } from './status';
+
+export interface RunJobResult {
+  jobId: string;
+  status: 'success' | 'partial' | 'failed';
+  counts: {
+    ok: number;
+    noData: number;
+    error: number;
+    invalid: number;
+  };
+}
+
+export async function createJob(env: Env, sourceId: string, territory: Territory): Promise<string> {
+  await ensureDefaultSources(env.PRICE_DB);
+  return createFetchJob(env.PRICE_DB, sourceId, territory);
+}
+
+export async function runJob(
+  env: Env,
+  jobId: string,
+  input: { eans: string[] },
+): Promise<RunJobResult> {
+  const job = await getFetchJob(env.PRICE_DB, jobId);
+  if (!job) {
+    throw new Error('job_not_found');
+  }
+
+  const connector = getConnectorById(job.source_id);
+  if (!connector) {
+    throw new Error('connector_not_found');
+  }
+
+  const eans = eanListSchema.parse(input.eans);
+  const startedAt = new Date().toISOString();
+  await updateFetchJobStatus(env.PRICE_DB, jobId, 'running', { startedAt, error: null });
+
+  const counts = { ok: 0, noData: 0, error: 0, invalid: 0 };
+
+  try {
+    const rows = await connector.fetchPrices({ territory: job.territory, eans, env: { PRICE_DB: env.PRICE_DB } });
+    const byEan = new Map(rows.map((row) => [row.ean, row]));
+
+    for (const ean of eans) {
+      const row = byEan.get(ean);
+      if (!row) {
+        counts.noData += 1;
+        await insertFetchJobItem(env.PRICE_DB, { jobId, ean, status: 'no_data' });
+        continue;
+      }
+
+      if (!row.retailer || !Number.isInteger(row.priceCents) || row.priceCents <= 0) {
+        counts.invalid += 1;
+        await insertFetchJobItem(env.PRICE_DB, {
+          jobId,
+          ean,
+          retailer: row.retailer,
+          status: 'invalid',
+          rawRef: row.rawRef,
+          rawPayloadJson: row.rawPayload ? JSON.stringify(row.rawPayload) : undefined,
+        });
+        continue;
+      }
+
+      await insertObservationAndRefreshAggregate(env.PRICE_DB, {
+        ean,
+        territory: job.territory,
+        retailer: row.retailer,
+        price: row.priceCents / 100,
+        currency: row.currency,
+        unit: row.unit,
+        observedAt: row.observedAt,
+        source: `connector:${connector.id}`,
+        confidence: 0.8,
+        metadata: row.rawPayload,
+      });
+
+      counts.ok += 1;
+      await insertFetchJobItem(env.PRICE_DB, {
+        jobId,
+        ean,
+        retailer: row.retailer,
+        status: 'ok',
+        rawRef: row.rawRef,
+        rawPayloadJson: row.rawPayload ? JSON.stringify(row.rawPayload) : undefined,
+        observedPriceCents: row.priceCents,
+        currency: row.currency,
+        unit: row.unit,
+        observedAt: row.observedAt ?? new Date().toISOString(),
+      });
+    }
+  } catch (error) {
+    counts.error += 1;
+    const safeError = error instanceof Error ? error.message.slice(0, 300) : 'connector_error';
+    await updateFetchJobStatus(env.PRICE_DB, jobId, 'failed', {
+      finishedAt: new Date().toISOString(),
+      error: safeError,
+    });
+
+    return {
+      jobId,
+      status: 'failed',
+      counts,
+    };
+  }
+
+  const finalStatus = computeFetchJobStatus({ ok: counts.ok, error: counts.error + counts.invalid });
+  await updateFetchJobStatus(env.PRICE_DB, jobId, finalStatus, {
+    finishedAt: new Date().toISOString(),
+    error: null,
+  });
+
+  return { jobId, status: finalStatus as 'success' | 'partial' | 'failed', counts };
+}

--- a/price-api/src/fetch/selectors.ts
+++ b/price-api/src/fetch/selectors.ts
@@ -1,0 +1,12 @@
+import { selectKnownEans } from '../db';
+
+const FALLBACK_EANS = ['3560070894222', '3017620422003', '3270190202002'];
+
+export async function selectEansToRefresh(db: D1Database, limit = 50): Promise<string[]> {
+  const known = await selectKnownEans(db, limit);
+  if (known.length > 0) {
+    return known;
+  }
+
+  return FALLBACK_EANS.slice(0, Math.max(1, Math.min(limit, FALLBACK_EANS.length)));
+}

--- a/price-api/src/fetch/status.ts
+++ b/price-api/src/fetch/status.ts
@@ -1,0 +1,12 @@
+export function computeFetchJobStatus(counts: { ok: number; error: number }): 'success' | 'partial' | 'failed' {
+  if (counts.ok > 0 && counts.error === 0) {
+    return 'success';
+  }
+  if (counts.ok > 0 && counts.error > 0) {
+    return 'partial';
+  }
+  if (counts.ok === 0 && counts.error > 0) {
+    return 'failed';
+  }
+  return 'success';
+}

--- a/price-api/src/index.ts
+++ b/price-api/src/index.ts
@@ -1,8 +1,27 @@
+import { ensureDefaultSources } from './db';
+import { getEnabledConnectorsForTerritory } from './connectors/registry';
+import { selectEansToRefresh } from './fetch/selectors';
+import { createJob, runJob } from './fetch/runner';
 import { handleRequest } from './router';
-import type { Env } from './types';
+import type { Env, Territory } from './types';
+
+async function runScheduledFetch(env: Env, territory: Territory): Promise<void> {
+  await ensureDefaultSources(env.PRICE_DB);
+  const sourceId = getEnabledConnectorsForTerritory(territory)[0]?.id ?? 'backoffice';
+  const eans = await selectEansToRefresh(env.PRICE_DB, 50);
+  const jobId = await createJob(env, sourceId, territory);
+  await runJob(env, jobId, { eans });
+}
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     return handleRequest(request, env);
+  },
+
+  async scheduled(_event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
+    const territories: Territory[] = ['fr', 'gp', 'mq'];
+    for (const territory of territories) {
+      ctx.waitUntil(runScheduledFetch(env, territory));
+    }
   },
 };

--- a/price-api/src/router.ts
+++ b/price-api/src/router.ts
@@ -1,16 +1,23 @@
 import { buildEtag, shouldReturnNotModified, storeInCache } from './cache';
 import {
   applySimpleRateLimit,
+  ensureDefaultSources,
   getAggregateFingerprint,
   getPriceAggregates,
   getProduct,
   getRecentObservations,
   insertObservationAndRefreshAggregate,
+  listFetchJobs,
   upsertProduct,
 } from './db';
 import { withCors } from './cors';
+import { getEnabledConnectorsForTerritory } from './connectors/registry';
+import { createJob, runJob } from './fetch/runner';
+import { selectEansToRefresh } from './fetch/selectors';
 import type { Env, PriceAggregateRecord, PriceObservationRecord, PriceStatus, PricesResponse, ProductResponse } from './types';
 import {
+  adminFetchJobsQuerySchema,
+  adminFetchRunSchema,
   adminObservationSchema,
   adminProductSchema,
   assertAdminToken,
@@ -164,6 +171,21 @@ export async function handleRequest(request: Request, env: Env): Promise<Respons
       );
     }
 
+    if (request.method === 'GET' && url.pathname === '/v1/admin/fetch/jobs') {
+      if (!assertAdminToken(request, env.PRICE_ADMIN_TOKEN)) {
+        return withCors(json({ error: 'unauthorized' }, 401), origin, env);
+      }
+
+      const parsed = adminFetchJobsQuerySchema.parse(Object.fromEntries(url.searchParams.entries()));
+      const jobs = await listFetchJobs(env.PRICE_DB, {
+        territory: parsed.territory,
+        sourceId: parsed.sourceId,
+        limit: parsed.limit,
+      });
+
+      return withCors(json({ status: 'OK', jobs }, 200), origin, env);
+    }
+
     if (request.method === 'POST' && url.pathname.startsWith('/v1/admin/')) {
       if (!assertAdminToken(request, env.PRICE_ADMIN_TOKEN)) {
         return withCors(json({ error: 'unauthorized' }, 401), origin, env);
@@ -199,6 +221,21 @@ export async function handleRequest(request: Request, env: Env): Promise<Respons
         });
 
         return withCors(json({ status: 'OK', ean: body.ean }, 201), origin, env);
+      }
+
+      if (url.pathname === '/v1/admin/fetch/run') {
+        const body = adminFetchRunSchema.parse(await request.json());
+        await ensureDefaultSources(env.PRICE_DB);
+        const sourceId = body.sourceId ?? getEnabledConnectorsForTerritory(body.territory)[0]?.id ?? 'backoffice';
+        const eans = await selectEansToRefresh(env.PRICE_DB, body.limit ?? 25);
+        const jobId = await createJob(env, sourceId, body.territory);
+        const result = await runJob(env, jobId, { eans });
+
+        return withCors(
+          json({ status: 'OK', jobId, sourceId, territory: body.territory, selectedEans: eans.length, result }, 200),
+          origin,
+          env,
+        );
       }
 
       if (url.pathname === '/v1/admin/seed') {

--- a/price-api/src/types.ts
+++ b/price-api/src/types.ts
@@ -5,6 +5,8 @@ export type Territory = (typeof TERRITORIES)[number];
 export type Retailer = (typeof RETAILERS)[number] | string;
 export type Currency = 'EUR';
 export type PriceStatus = 'OK' | 'NO_DATA' | 'PARTIAL' | 'UNAVAILABLE';
+export type FetchJobStatus = 'queued' | 'running' | 'success' | 'partial' | 'failed';
+export type FetchJobItemStatus = 'ok' | 'no_data' | 'invalid' | 'error';
 
 export interface Env {
   PRICE_DB: D1Database;
@@ -52,6 +54,34 @@ export interface PriceObservationRecord {
   confidence: number;
   metadata_json: string | null;
   created_at: string;
+}
+
+export interface SourceRecord {
+  id: string;
+  name: string;
+  type: 'partner_api' | 'open_data' | 'backoffice';
+  base_url: string | null;
+  auth_type: 'none' | 'bearer' | 'api_key';
+  enabled: number;
+  territory_scope: string;
+  created_at: string;
+}
+
+export interface FetchJobRecord {
+  id: string;
+  source_id: string;
+  territory: Territory;
+  status: FetchJobStatus;
+  started_at: string | null;
+  finished_at: string | null;
+  error: string | null;
+}
+
+export interface FetchJobListRecord extends FetchJobRecord {
+  ok_count: number;
+  no_data_count: number;
+  error_count: number;
+  invalid_count: number;
 }
 
 export interface ApiResponseBase {

--- a/price-api/src/validators.ts
+++ b/price-api/src/validators.ts
@@ -18,6 +18,11 @@ const isoDateSchema = z
   .or(z.string().datetime())
   .transform((value) => new Date(value).toISOString());
 
+const positiveIntegerFromUnknown = z
+  .union([z.number(), z.string()])
+  .transform((value) => Number(value))
+  .pipe(z.number().int().positive());
+
 export const getPricesQuerySchema = z.object({
   ean: z.string().regex(EAN_REGEX, 'ean must have 8-14 digits'),
   territory: territoryEnum.optional(),
@@ -50,6 +55,20 @@ export const adminObservationSchema = z.object({
   confidence: z.number().min(0).max(1).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
+
+export const adminFetchRunSchema = z.object({
+  territory: territoryEnum,
+  sourceId: z.string().min(2).max(100).optional(),
+  limit: positiveIntegerFromUnknown.refine((value) => value <= 500, "limit must be <= 500").optional(),
+});
+
+export const adminFetchJobsQuerySchema = z.object({
+  territory: territoryEnum.optional(),
+  sourceId: z.string().min(2).max(100).optional(),
+  limit: positiveIntegerFromUnknown.refine((value) => value <= 200, "limit must be <= 200").optional(),
+});
+
+export const eanListSchema = z.array(z.string().regex(EAN_REGEX, 'ean must have 8-14 digits')).min(1).max(500);
 
 export function assertAdminToken(request: Request, expectedToken: string): boolean {
   const authHeader = request.headers.get('Authorization');

--- a/price-api/tests/fetch-status.test.ts
+++ b/price-api/tests/fetch-status.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { computeFetchJobStatus } from '../src/fetch/status';
+
+describe('computeFetchJobStatus', () => {
+  it('returns success when there are successful items and no errors', () => {
+    expect(computeFetchJobStatus({ ok: 2, error: 0 })).toBe('success');
+  });
+
+  it('returns partial when there are successes and errors', () => {
+    expect(computeFetchJobStatus({ ok: 1, error: 1 })).toBe('partial');
+  });
+
+  it('returns failed when all items failed', () => {
+    expect(computeFetchJobStatus({ ok: 0, error: 2 })).toBe('failed');
+  });
+
+  it('returns success when all items are no_data', () => {
+    expect(computeFetchJobStatus({ ok: 0, error: 0 })).toBe('success');
+  });
+});

--- a/price-api/tests/validators.test.ts
+++ b/price-api/tests/validators.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { adminObservationSchema, adminProductSchema, getPricesQuerySchema } from '../src/validators';
+import {
+  adminFetchJobsQuerySchema,
+  adminFetchRunSchema,
+  adminObservationSchema,
+  adminProductSchema,
+  eanListSchema,
+  getPricesQuerySchema,
+} from '../src/validators';
 
 describe('validators', () => {
   it('validates public prices query', () => {
@@ -40,5 +47,29 @@ describe('validators', () => {
 
     expect(payload.retailer).toBe('leclerc');
     expect(payload.observedAt).toBe('2026-02-18T12:00:00.000Z');
+  });
+
+  it('validates admin fetch run payload', () => {
+    const payload = adminFetchRunSchema.parse({
+      territory: 'fr',
+      sourceId: 'backoffice',
+      limit: '25',
+    });
+
+    expect(payload.limit).toBe(25);
+  });
+
+  it('validates admin fetch jobs query payload', () => {
+    const payload = adminFetchJobsQuerySchema.parse({
+      territory: 'gp',
+      limit: '10',
+    });
+
+    expect(payload.limit).toBe(10);
+  });
+
+  it('validates ean lists for connector jobs', () => {
+    const list = eanListSchema.parse(['3560070894222', '3017620422003']);
+    expect(list).toHaveLength(2);
   });
 });

--- a/price-api/wrangler.toml
+++ b/price-api/wrangler.toml
@@ -11,3 +11,6 @@ binding = "PRICE_DB"
 database_name = "price-db"
 database_id = "REPLACE_WITH_D1_DATABASE_ID"
 migrations_dir = "migrations"
+
+[triggers]
+crons = ["0 */6 * * *"]


### PR DESCRIPTION
### Motivation

- Prepare a safe, extensible ingestion architecture for authorized connectors to import price data asynchronously instead of ad-hoc scraping. 
- Ensure full traceability of fetch runs, per-EAN items and raw payloads in D1 for auditing and debugging. 
- Provide admin control to trigger and inspect fetch jobs and to normalize observations into existing aggregates so the public GET API remains stable.

### Description

- Add D1 migration `migrations/0002_fetch_jobs.sql` to create `sources`, `fetch_jobs`, `fetch_job_items` and indexes for job/item traceability. 
- Introduce connector architecture under `src/connectors/` with `types.ts`, a registry and two initial connectors (`backoffice` placeholder and `open_data_dummy`) to illustrate the pattern. 
- Implement job runner and helpers in `src/fetch/` (`runner.ts`, `selectors.ts`, `status.ts`) and extend `src/db.ts` with functions to upsert sources, create/update fetch jobs, insert fetch job items and list jobs with per-status counters. 
- Extend admin router in `src/router.ts` with `POST /v1/admin/fetch/run` to create+run a job (MVP synchronous) and `GET /v1/admin/fetch/jobs` to list recent jobs, add `scheduled()` to `src/index.ts` and add a Wrangler cron (`wrangler.toml`) to run jobs periodically. 
- Add strict validators for fetch payloads and EAN lists in `src/validators.ts`, add tests in `price-api/tests/` and update `price-api/README.md` with usage and connector guidance.

### Testing

- Ran TypeScript checks with `npm -C price-api run typecheck` which succeeded. 
- Ran unit tests with `npm -C price-api run test` and all new and existing tests passed (`vitest`: 11 tests, 11 passed). 
- Built the frontend with `npm -C frontend run build` to verify the change did not break the frontend and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995155281cc832189ae274e435c60ee)