### PR TITLE
feat(price-api): implement production-ready CSV import ingestion with R2 + D1 tracking

### DIFF
--- a/price-api/README.md
+++ b/price-api/README.md
@@ -107,3 +107,86 @@ curl -s -X POST "http://127.0.0.1:8787/v1/admin/seed" \
 
 `POST /v1/admin/seed` insère le produit EAN `3560070894222` et des prix **placeholder** (`source=admin_seed`) pour démonstration.
 Ces valeurs ne sont pas des prix réels et doivent être remplacées via back-office / sources autorisées.
+
+## CSV Import – Production ingestion flow
+
+### Endpoint sécurisé
+
+- `POST /v1/admin/import/csv`
+- Auth obligatoire: `Authorization: Bearer <PRICE_ADMIN_TOKEN>`
+- Rate limit admin D1 identique aux autres endpoints admin
+- Formats supportés:
+  - `multipart/form-data` avec champ `file` (ou `csv`) + champ `territory`
+  - `text/csv` avec query `?territory=gp` et optionnel header `x-filename`
+
+Le Worker:
+1. stocke le CSV brut dans R2 (`PRICE_IMPORTS`) via clé `imports/{jobId}/{filename}`;
+2. crée un `import_job` en base;
+3. démarre le traitement asynchrone avec `ctx.waitUntil()`.
+
+### Suivi des imports
+
+- `GET /v1/admin/import/jobs`
+- `GET /v1/admin/import/jobs/:id`
+
+Ces endpoints admin renvoient `Cache-Control: no-store`.
+
+### Format CSV attendu
+
+Colonnes obligatoires:
+
+`ean,territory,retailer,storeLabel,price_cents,currency,observedAt`
+
+Colonnes optionnelles:
+
+`unit,quantity,promoLabel,sourceRef,confidence`
+
+Exemple:
+
+```csv
+ean,territory,retailer,storeLabel,price_cents,currency,observedAt,unit,quantity,promoLabel,sourceRef,confidence
+3560070894222,gp,carrefour,Carrefour Destreland,349,EUR,2026-02-18T12:00:00Z,l,75 cl,PROMO MARS,flyer-gp-20260218,0.92
+3560070894222,mq,leclerc,Leclerc Dillon,375,EUR,2026-02-18T12:30:00Z,l,75 cl,,ticket-123,0.88
+```
+
+### Curl upload
+
+Multipart:
+
+```bash
+curl -X POST "http://127.0.0.1:8787/v1/admin/import/csv" \
+  -H "Authorization: Bearer $PRICE_ADMIN_TOKEN" \
+  -F "territory=gp" \
+  -F "file=@./prices.csv;type=text/csv"
+```
+
+Raw CSV:
+
+```bash
+curl -X POST "http://127.0.0.1:8787/v1/admin/import/csv?territory=gp" \
+  -H "Authorization: Bearer $PRICE_ADMIN_TOKEN" \
+  -H "Content-Type: text/csv" \
+  -H "x-filename: prices-gp.csv" \
+  --data-binary @./prices.csv
+```
+
+### Wrangler: D1 + R2
+
+Créer/configurer bucket R2:
+
+```bash
+npx wrangler r2 bucket create price-imports
+```
+
+Appliquer les migrations D1:
+
+```bash
+npx wrangler d1 migrations apply PRICE_DB --local
+npx wrangler d1 migrations apply PRICE_DB --remote
+```
+
+La migration `0003_imports.sql` ajoute:
+
+- `import_jobs`
+- `import_rows`
+- index `idx_import_job_status`, `idx_import_rows_job`, `idx_import_rows_ean`

--- a/price-api/migrations/0003_imports.sql
+++ b/price-api/migrations/0003_imports.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS import_jobs (
+  id TEXT PRIMARY KEY,
+  filename TEXT NOT NULL,
+  r2_key TEXT NOT NULL,
+  territory TEXT NOT NULL CHECK (territory IN ('fr', 'gp', 'mq')),
+  status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'success', 'partial', 'failed')),
+  total_rows INTEGER NOT NULL DEFAULT 0,
+  success_rows INTEGER NOT NULL DEFAULT 0,
+  error_rows INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT DEFAULT (datetime('now')),
+  finished_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS import_rows (
+  id TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL,
+  row_number INTEGER NOT NULL,
+  ean TEXT,
+  retailer TEXT,
+  territory TEXT,
+  price_cents INTEGER,
+  status TEXT NOT NULL CHECK (status IN ('ok', 'invalid', 'error')),
+  error_message TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  FOREIGN KEY (job_id) REFERENCES import_jobs(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_import_job_status ON import_jobs(status, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_import_rows_job ON import_rows(job_id, row_number);
+CREATE INDEX IF NOT EXISTS idx_import_rows_ean ON import_rows(ean);

--- a/price-api/src/db.ts
+++ b/price-api/src/db.ts
@@ -1,4 +1,9 @@
 import type {
+  ImportJobRecord,
+  ImportJobStatus,
+  ImportRowRecord,
+  ImportRowStatus,
+  InsertObservationCentsInput,
   InsertObservationInput,
   PriceAggregateRecord,
   PriceObservationRecord,
@@ -96,6 +101,19 @@ export async function getProduct(db: D1Database, ean: string): Promise<ProductRe
   return db.prepare('SELECT * FROM products WHERE ean = ?').bind(ean).first<ProductRecord>();
 }
 
+export async function ensureProductExists(
+  db: D1Database,
+  input: {
+    ean: string;
+    quantity?: string;
+  },
+): Promise<void> {
+  await db
+    .prepare(`INSERT OR IGNORE INTO products (ean, product_name, quantity, updated_at) VALUES (?, NULL, ?, datetime('now'))`)
+    .bind(input.ean, input.quantity ?? null)
+    .run();
+}
+
 export async function upsertProduct(
   db: D1Database,
   input: {
@@ -131,7 +149,16 @@ export async function insertObservationAndRefreshAggregate(
   db: D1Database,
   input: InsertObservationInput,
 ): Promise<void> {
-  const priceCents = Math.round(input.price * 100);
+  await insertObservationCentsAndRefreshAggregate(db, {
+    ...input,
+    priceCents: Math.round(input.price * 100),
+  });
+}
+
+export async function insertObservationCentsAndRefreshAggregate(
+  db: D1Database,
+  input: InsertObservationCentsInput,
+): Promise<void> {
   const observedAt = input.observedAt ?? new Date().toISOString();
   const id = crypto.randomUUID();
 
@@ -149,7 +176,7 @@ export async function insertObservationAndRefreshAggregate(
       input.retailer,
       input.storeId ?? null,
       input.storeName ?? null,
-      priceCents,
+      input.priceCents,
       input.currency,
       input.unit ?? null,
       observedAt,
@@ -284,6 +311,92 @@ export async function refreshAggregate(
       stats.median_price_cents,
       stats.count_observations,
       stats.last_observed_at,
+    )
+    .run();
+}
+
+export async function createImportJob(
+  db: D1Database,
+  payload: { id: string; filename: string; r2Key: string; territory: Territory; status?: ImportJobStatus },
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO import_jobs (id, filename, r2_key, territory, status, total_rows, success_rows, error_rows)
+       VALUES (?, ?, ?, ?, ?, 0, 0, 0)`,
+    )
+    .bind(payload.id, payload.filename, payload.r2Key, payload.territory, payload.status ?? 'queued')
+    .run();
+}
+
+export async function updateImportJobProgress(
+  db: D1Database,
+  payload: {
+    id: string;
+    status: ImportJobStatus;
+    totalRows: number;
+    successRows: number;
+    errorRows: number;
+    finished: boolean;
+  },
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE import_jobs
+       SET status = ?, total_rows = ?, success_rows = ?, error_rows = ?, finished_at = CASE WHEN ? THEN datetime('now') ELSE NULL END
+       WHERE id = ?`,
+    )
+    .bind(payload.status, payload.totalRows, payload.successRows, payload.errorRows, payload.finished ? 1 : 0, payload.id)
+    .run();
+}
+
+export async function getImportJobs(db: D1Database, limit = 50): Promise<ImportJobRecord[]> {
+  const { results } = await db
+    .prepare('SELECT * FROM import_jobs ORDER BY created_at DESC LIMIT ?')
+    .bind(limit)
+    .all<ImportJobRecord>();
+  return results ?? [];
+}
+
+export async function getImportJobById(db: D1Database, jobId: string): Promise<ImportJobRecord | null> {
+  return db.prepare('SELECT * FROM import_jobs WHERE id = ?').bind(jobId).first<ImportJobRecord>();
+}
+
+export async function getImportRowsByJobId(db: D1Database, jobId: string, limit = 200): Promise<ImportRowRecord[]> {
+  const { results } = await db
+    .prepare('SELECT * FROM import_rows WHERE job_id = ? ORDER BY row_number ASC LIMIT ?')
+    .bind(jobId, limit)
+    .all<ImportRowRecord>();
+  return results ?? [];
+}
+
+export async function insertImportRow(
+  db: D1Database,
+  payload: {
+    jobId: string;
+    rowNumber: number;
+    ean?: string | null;
+    retailer?: string | null;
+    territory?: string | null;
+    priceCents?: number | null;
+    status: ImportRowStatus;
+    errorMessage?: string | null;
+  },
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO import_rows (id, job_id, row_number, ean, retailer, territory, price_cents, status, error_message)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      crypto.randomUUID(),
+      payload.jobId,
+      payload.rowNumber,
+      payload.ean ?? null,
+      payload.retailer ?? null,
+      payload.territory ?? null,
+      payload.priceCents ?? null,
+      payload.status,
+      payload.errorMessage ?? null,
     )
     .run();
 }

--- a/price-api/src/importCsv.ts
+++ b/price-api/src/importCsv.ts
@@ -1,0 +1,398 @@
+import {
+  createImportJob,
+  ensureProductExists,
+  insertImportRow,
+  insertObservationCentsAndRefreshAggregate,
+  updateImportJobProgress,
+} from './db';
+import type { Env, Territory } from './types';
+import { TERRITORIES } from './types';
+import { validateRetailer } from './validators';
+
+const REQUIRED_HEADERS = ['ean', 'territory', 'retailer', 'storeLabel', 'price_cents', 'currency', 'observedAt'] as const;
+const ALLOWED_TERRITORIES = new Set<Territory>(TERRITORIES);
+const EAN_REGEX = /^\d{8,14}$/;
+
+interface UploadPayload {
+  filename: string;
+  stream: ReadableStream;
+  territory: Territory;
+  contentType: string;
+}
+
+export interface ImportJobResult {
+  jobId: string;
+  filename: string;
+  r2Key: string;
+}
+
+interface CsvRow {
+  ean: string;
+  territory: Territory;
+  retailer: string;
+  storeLabel: string;
+  priceCents: number;
+  currency: 'EUR';
+  observedAt: string;
+  unit?: string;
+  quantity?: string;
+  promoLabel?: string;
+  sourceRef?: string;
+  confidence?: number;
+}
+
+export async function queueCsvImport(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<ImportJobResult> {
+  const upload = await extractUploadPayload(request);
+  const jobId = crypto.randomUUID();
+  const safeFilename = sanitizeFilename(upload.filename);
+  const r2Key = `imports/${jobId}/${safeFilename}`;
+
+  await env.PRICE_IMPORTS.put(r2Key, upload.stream, {
+    httpMetadata: {
+      contentType: upload.contentType,
+    },
+  });
+
+  await createImportJob(env.PRICE_DB, {
+    id: jobId,
+    filename: safeFilename,
+    r2Key,
+    territory: upload.territory,
+    status: 'queued',
+  });
+
+  ctx.waitUntil(processCsvImportJob(env, jobId, r2Key));
+
+  return {
+    jobId,
+    filename: safeFilename,
+    r2Key,
+  };
+}
+
+export async function processCsvImportJob(env: Env, jobId: string, r2Key: string): Promise<void> {
+  let totalRows = 0;
+  let successRows = 0;
+  let errorRows = 0;
+
+  await updateImportJobProgress(env.PRICE_DB, {
+    id: jobId,
+    status: 'running',
+    totalRows,
+    successRows,
+    errorRows,
+    finished: false,
+  });
+
+  try {
+    const obj = await env.PRICE_IMPORTS.get(r2Key);
+    if (!obj?.body) {
+      throw new Error('csv_not_found_in_r2');
+    }
+
+    const parsed = parseCsvRows(obj.body);
+    const first = await parsed.next();
+    if (first.done || !first.value.headers) {
+      throw new Error('missing_csv_header');
+    }
+
+    const headers = first.value.headers;
+    for (const header of REQUIRED_HEADERS) {
+      if (!headers.includes(header)) {
+        throw new Error(`missing_required_column:${header}`);
+      }
+    }
+
+    for await (const item of parsed) {
+      if (!item.row) {
+        continue;
+      }
+
+      totalRows += 1;
+      const rowNumber = item.rowNumber;
+      try {
+        const validatedRow = validateCsvRow(item.row);
+
+        await ensureProductExists(env.PRICE_DB, {
+          ean: validatedRow.ean,
+          quantity: validatedRow.quantity,
+        });
+
+        await insertObservationCentsAndRefreshAggregate(env.PRICE_DB, {
+          ean: validatedRow.ean,
+          territory: validatedRow.territory,
+          retailer: validatedRow.retailer,
+          priceCents: validatedRow.priceCents,
+          currency: validatedRow.currency,
+          observedAt: validatedRow.observedAt,
+          unit: validatedRow.unit,
+          storeName: validatedRow.storeLabel,
+          source: 'partner',
+          confidence: validatedRow.confidence ?? 1,
+          metadata: {
+            promoLabel: validatedRow.promoLabel,
+            sourceRef: validatedRow.sourceRef,
+          },
+        });
+
+        await insertImportRow(env.PRICE_DB, {
+          jobId,
+          rowNumber,
+          ean: validatedRow.ean,
+          retailer: validatedRow.retailer,
+          territory: validatedRow.territory,
+          priceCents: validatedRow.priceCents,
+          status: 'ok',
+        });
+
+        successRows += 1;
+      } catch (error) {
+        errorRows += 1;
+        const message = error instanceof Error ? error.message : 'unexpected_row_error';
+        await insertImportRow(env.PRICE_DB, {
+          jobId,
+          rowNumber,
+          ean: item.row.ean ?? null,
+          retailer: item.row.retailer ?? null,
+          territory: item.row.territory ?? null,
+          priceCents: item.row.price_cents ? Number(item.row.price_cents) : null,
+          status: message.startsWith('invalid_') ? 'invalid' : 'error',
+          errorMessage: message,
+        });
+      }
+    }
+
+    const status = errorRows > 0 ? (successRows > 0 ? 'partial' : 'failed') : 'success';
+    await updateImportJobProgress(env.PRICE_DB, {
+      id: jobId,
+      status,
+      totalRows,
+      successRows,
+      errorRows,
+      finished: true,
+    });
+  } catch {
+    await updateImportJobProgress(env.PRICE_DB, {
+      id: jobId,
+      status: 'failed',
+      totalRows,
+      successRows,
+      errorRows: Math.max(errorRows, 1),
+      finished: true,
+    });
+  }
+}
+
+async function extractUploadPayload(request: Request): Promise<UploadPayload> {
+  const contentType = request.headers.get('content-type')?.toLowerCase() ?? '';
+
+  if (contentType.includes('multipart/form-data')) {
+    const form = await request.formData();
+    const file = form.get('file') ?? form.get('csv');
+    if (!file || typeof file !== 'object' || !('stream' in file) || !('name' in file)) {
+      throw new Error('invalid_multipart_payload');
+    }
+    const csvFile = file as { name: string; stream: () => ReadableStream; type?: string };
+
+    const territoryValue = String(form.get('territory') ?? '').trim().toLowerCase();
+    if (!ALLOWED_TERRITORIES.has(territoryValue as Territory)) {
+      throw new Error('invalid_territory');
+    }
+
+    return {
+      filename: String(csvFile.name || 'import.csv'),
+      stream: csvFile.stream(),
+      territory: territoryValue as Territory,
+      contentType: String(csvFile.type || 'text/csv'),
+    };
+  }
+
+  if (!contentType.includes('text/csv') && !contentType.includes('application/csv')) {
+    throw new Error('unsupported_content_type');
+  }
+
+  if (!request.body) {
+    throw new Error('empty_csv_payload');
+  }
+
+  const territoryValue = new URL(request.url).searchParams.get('territory')?.trim().toLowerCase();
+  if (!territoryValue || !ALLOWED_TERRITORIES.has(territoryValue as Territory)) {
+    throw new Error('invalid_territory');
+  }
+
+  const filename = request.headers.get('x-filename') ?? 'import.csv';
+  return {
+    filename,
+    stream: request.body,
+    territory: territoryValue as Territory,
+    contentType: 'text/csv',
+  };
+}
+
+function sanitizeFilename(filename: string): string {
+  const safe = filename.trim().replace(/[^a-zA-Z0-9._-]/g, '_');
+  return safe.length > 0 ? safe : 'import.csv';
+}
+
+function validateCsvRow(row: Record<string, string>): CsvRow {
+  const ean = (row.ean ?? '').trim();
+  if (!EAN_REGEX.test(ean)) {
+    throw new Error('invalid_ean');
+  }
+
+  const territoryValue = (row.territory ?? '').trim().toLowerCase() as Territory;
+  if (!ALLOWED_TERRITORIES.has(territoryValue)) {
+    throw new Error('invalid_territory');
+  }
+
+  const retailer = validateRetailer((row.retailer ?? '').trim().toLowerCase());
+  if (!retailer || !['carrefour','leclerc','intermarche','superu','auchan','match','autre'].includes(retailer)) {
+    throw new Error('invalid_retailer');
+  }
+
+  const priceCents = Number((row.price_cents ?? '').trim());
+  if (!Number.isInteger(priceCents) || priceCents <= 0) {
+    throw new Error('invalid_price_cents');
+  }
+
+  const currency = (row.currency ?? '').trim();
+  if (currency !== 'EUR') {
+    throw new Error('invalid_currency');
+  }
+
+  const observedAt = (row.observedAt ?? '').trim();
+  if (!Number.isFinite(Date.parse(observedAt))) {
+    throw new Error('invalid_observedAt');
+  }
+
+  const storeLabel = (row.storeLabel ?? '').trim();
+  if (!storeLabel) {
+    throw new Error('invalid_storeLabel');
+  }
+
+  const confidenceRaw = (row.confidence ?? '').trim();
+  let confidence: number | undefined;
+  if (confidenceRaw) {
+    confidence = Number(confidenceRaw);
+    if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+      throw new Error('invalid_confidence');
+    }
+  }
+
+  return {
+    ean,
+    territory: territoryValue,
+    retailer,
+    storeLabel,
+    priceCents,
+    currency: 'EUR',
+    observedAt: new Date(observedAt).toISOString(),
+    unit: (row.unit ?? '').trim() || undefined,
+    quantity: (row.quantity ?? '').trim() || undefined,
+    promoLabel: (row.promoLabel ?? '').trim() || undefined,
+    sourceRef: (row.sourceRef ?? '').trim() || undefined,
+    confidence,
+  };
+}
+
+async function* parseCsvRows(
+  stream: ReadableStream,
+): AsyncGenerator<{ headers?: string[]; rowNumber: number; row?: Record<string, string> }> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let inQuotes = false;
+  let field = '';
+  let row: string[] = [];
+  let headers: string[] | null = null;
+  let rowNumber = 0;
+
+  const emitRow = async () => {
+    if (row.length === 1 && row[0] === '' && field === '') {
+      row = [];
+      return null;
+    }
+
+    row.push(field);
+    field = '';
+
+    if (!headers) {
+      headers = row.map((col) => col.trim());
+      row = [];
+      return { headers, rowNumber: 0 };
+    }
+
+    rowNumber += 1;
+    const mapped: Record<string, string> = {};
+    headers.forEach((header, idx) => {
+      mapped[header] = (row[idx] ?? '').trim();
+    });
+    row = [];
+    return { rowNumber, row: mapped };
+  };
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+
+    buffer += typeof value === 'string' ? value : decoder.decode(value, { stream: true });
+
+    let i = 0;
+    while (i < buffer.length) {
+      const char = buffer[i];
+
+      if (char === '"') {
+        const next = buffer[i + 1];
+        if (inQuotes && next === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+
+        inQuotes = !inQuotes;
+        i += 1;
+        continue;
+      }
+
+      if (!inQuotes && char === ',') {
+        row.push(field);
+        field = '';
+        i += 1;
+        continue;
+      }
+
+      if (!inQuotes && (char === '\n' || char === '\r')) {
+        if (char === '\r' && buffer[i + 1] === '\n') {
+          i += 1;
+        }
+
+        const emitted = await emitRow();
+        if (emitted) {
+          yield emitted;
+        }
+        i += 1;
+        continue;
+      }
+
+      field += char;
+      i += 1;
+    }
+
+    buffer = '';
+  }
+
+  buffer += decoder.decode();
+
+  if (field.length > 0 || row.length > 0) {
+    const emitted = await emitRow();
+    if (emitted) {
+      yield emitted;
+    }
+  }
+}

--- a/price-api/src/index.ts
+++ b/price-api/src/index.ts
@@ -2,7 +2,7 @@ import { handleRequest } from './router';
 import type { Env } from './types';
 
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    return handleRequest(request, env);
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    return handleRequest(request, env, ctx);
   },
 };

--- a/price-api/src/router.ts
+++ b/price-api/src/router.ts
@@ -2,6 +2,9 @@ import { buildEtag, shouldReturnNotModified, storeInCache } from './cache';
 import {
   applySimpleRateLimit,
   getAggregateFingerprint,
+  getImportJobById,
+  getImportJobs,
+  getImportRowsByJobId,
   getPriceAggregates,
   getProduct,
   getRecentObservations,
@@ -9,6 +12,7 @@ import {
   upsertProduct,
 } from './db';
 import { withCors } from './cors';
+import { queueCsvImport } from './importCsv';
 import type { Env, PriceAggregateRecord, PriceObservationRecord, PriceStatus, PricesResponse, ProductResponse } from './types';
 import {
   adminObservationSchema,
@@ -27,6 +31,10 @@ function json(data: unknown, status = 200, headers?: HeadersInit): Response {
       ...headers,
     },
   });
+}
+
+function adminJson(data: unknown, status = 200): Response {
+  return json(data, status, { 'Cache-Control': 'no-store' });
 }
 
 function toAggregateView(aggregate: PriceAggregateRecord) {
@@ -74,7 +82,7 @@ function computeStatus(hasAggregates: boolean, hasProduct = false): PriceStatus 
   return 'NO_DATA';
 }
 
-export async function handleRequest(request: Request, env: Env): Promise<Response> {
+export async function handleRequest(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
   const url = new URL(request.url);
   const origin = request.headers.get('Origin');
 
@@ -164,24 +172,49 @@ export async function handleRequest(request: Request, env: Env): Promise<Respons
       );
     }
 
-    if (request.method === 'POST' && url.pathname.startsWith('/v1/admin/')) {
+    if (
+      (request.method === 'POST' && url.pathname.startsWith('/v1/admin/')) ||
+      (request.method === 'GET' && url.pathname.startsWith('/v1/admin/import/'))
+    ) {
       if (!assertAdminToken(request, env.PRICE_ADMIN_TOKEN)) {
-        return withCors(json({ error: 'unauthorized' }, 401), origin, env);
+        return withCors(adminJson({ error: 'unauthorized' }, 401), origin, env);
       }
 
       const ipKey = request.headers.get('CF-Connecting-IP') ?? 'unknown';
       const allowed = await applySimpleRateLimit(env.PRICE_DB, `admin:${ipKey}`, 120, 60);
       if (!allowed) {
-        return withCors(json({ error: 'rate_limited' }, 429), origin, env);
+        return withCors(adminJson({ error: 'rate_limited' }, 429), origin, env);
       }
 
-      if (url.pathname === '/v1/admin/products') {
+      if (request.method === 'POST' && url.pathname === '/v1/admin/import/csv') {
+        const queued = await queueCsvImport(request, env, ctx);
+        return withCors(adminJson({ status: 'queued', jobId: queued.jobId, filename: queued.filename }, 202), origin, env);
+      }
+
+      if (request.method === 'GET' && url.pathname === '/v1/admin/import/jobs') {
+        const limit = Number(url.searchParams.get('limit') ?? '50');
+        const jobs = await getImportJobs(env.PRICE_DB, Number.isFinite(limit) ? Math.min(Math.max(limit, 1), 200) : 50);
+        return withCors(adminJson({ status: 'OK', jobs }, 200), origin, env);
+      }
+
+      if (request.method === 'GET' && /^\/v1\/admin\/import\/jobs\/[^/]+$/.test(url.pathname)) {
+        const jobId = decodeURIComponent(url.pathname.replace('/v1/admin/import/jobs/', ''));
+        const [job, rows] = await Promise.all([getImportJobById(env.PRICE_DB, jobId), getImportRowsByJobId(env.PRICE_DB, jobId, 500)]);
+
+        if (!job) {
+          return withCors(adminJson({ error: 'not_found' }, 404), origin, env);
+        }
+
+        return withCors(adminJson({ status: 'OK', job, rows }, 200), origin, env);
+      }
+
+      if (request.method === 'POST' && url.pathname === '/v1/admin/products') {
         const body = adminProductSchema.parse(await request.json());
         await upsertProduct(env.PRICE_DB, body);
-        return withCors(json({ status: 'OK', ean: body.ean }, 200), origin, env);
+        return withCors(adminJson({ status: 'OK', ean: body.ean }, 200), origin, env);
       }
 
-      if (url.pathname === '/v1/admin/observations') {
+      if (request.method === 'POST' && url.pathname === '/v1/admin/observations') {
         const body = adminObservationSchema.parse(await request.json());
         await insertObservationAndRefreshAggregate(env.PRICE_DB, {
           ean: body.ean,
@@ -198,10 +231,10 @@ export async function handleRequest(request: Request, env: Env): Promise<Respons
           metadata: body.metadata,
         });
 
-        return withCors(json({ status: 'OK', ean: body.ean }, 201), origin, env);
+        return withCors(adminJson({ status: 'OK', ean: body.ean }, 201), origin, env);
       }
 
-      if (url.pathname === '/v1/admin/seed') {
+      if (request.method === 'POST' && url.pathname === '/v1/admin/seed') {
         const ean = '3560070894222';
         await upsertProduct(env.PRICE_DB, {
           ean,
@@ -237,16 +270,16 @@ export async function handleRequest(request: Request, env: Env): Promise<Respons
           });
         }
 
-        return withCors(json({ status: 'OK', ean, inserted: seedPayloads.length }, 201), origin, env);
+        return withCors(adminJson({ status: 'OK', ean, inserted: seedPayloads.length }, 201), origin, env);
       }
     }
 
     return withCors(json({ error: 'not_found' }, 404), origin, env);
   } catch (error) {
     if (error instanceof Error) {
-      return withCors(json({ error: 'bad_request', message: error.message }, 400), origin, env);
+      return withCors(adminJson({ error: 'bad_request', message: error.message }, 400), origin, env);
     }
 
-    return withCors(json({ error: 'unavailable' }, 503), origin, env);
+    return withCors(adminJson({ error: 'unavailable' }, 503), origin, env);
   }
 }

--- a/price-api/src/types.ts
+++ b/price-api/src/types.ts
@@ -1,15 +1,18 @@
 export const TERRITORIES = ['fr', 'gp', 'mq'] as const;
-export const RETAILERS = ['carrefour', 'leclerc', 'intermarché', 'superu'] as const;
+export const RETAILERS = ['carrefour', 'leclerc', 'intermarché', 'intermarche', 'superu', 'auchan', 'match', 'autre'] as const;
 
 export type Territory = (typeof TERRITORIES)[number];
 export type Retailer = (typeof RETAILERS)[number] | string;
 export type Currency = 'EUR';
 export type PriceStatus = 'OK' | 'NO_DATA' | 'PARTIAL' | 'UNAVAILABLE';
+export type ImportJobStatus = 'queued' | 'running' | 'success' | 'partial' | 'failed';
+export type ImportRowStatus = 'ok' | 'invalid' | 'error';
 
 export interface Env {
   PRICE_DB: D1Database;
   PRICE_ADMIN_TOKEN: string;
   ALLOWED_ORIGINS?: string;
+  PRICE_IMPORTS: R2Bucket;
 }
 
 export interface ProductRecord {
@@ -51,6 +54,32 @@ export interface PriceObservationRecord {
   source: string;
   confidence: number;
   metadata_json: string | null;
+  created_at: string;
+}
+
+export interface ImportJobRecord {
+  id: string;
+  filename: string;
+  r2_key: string;
+  territory: Territory;
+  status: ImportJobStatus;
+  total_rows: number;
+  success_rows: number;
+  error_rows: number;
+  created_at: string;
+  finished_at: string | null;
+}
+
+export interface ImportRowRecord {
+  id: string;
+  job_id: string;
+  row_number: number;
+  ean: string | null;
+  retailer: string | null;
+  territory: string | null;
+  price_cents: number | null;
+  status: ImportRowStatus;
+  error_message: string | null;
   created_at: string;
 }
 
@@ -122,6 +151,21 @@ export interface InsertObservationInput {
   storeId?: string;
   storeName?: string;
   price: number;
+  currency: Currency;
+  unit?: string;
+  observedAt?: string;
+  source: string;
+  confidence?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface InsertObservationCentsInput {
+  ean: string;
+  territory: Territory;
+  retailer: string;
+  storeId?: string;
+  storeName?: string;
+  priceCents: number;
   currency: Currency;
   unit?: string;
   observedAt?: string;

--- a/price-api/src/validators.ts
+++ b/price-api/src/validators.ts
@@ -61,7 +61,7 @@ export function assertAdminToken(request: Request, expectedToken: string): boole
 }
 
 export function validateRetailer(retailer: string): string {
-  const normalized = retailer.trim().toLowerCase();
+  const normalized = retailer.trim().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
   if (RETAILERS.includes(normalized as (typeof RETAILERS)[number])) {
     return normalized;
   }

--- a/price-api/tests/importCsv.test.ts
+++ b/price-api/tests/importCsv.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMock = vi.hoisted(() => ({
+  createImportJob: vi.fn(),
+  ensureProductExists: vi.fn(),
+  insertImportRow: vi.fn(),
+  insertObservationCentsAndRefreshAggregate: vi.fn(),
+  updateImportJobProgress: vi.fn(),
+}));
+
+vi.mock('../src/db', () => dbMock);
+
+import { processCsvImportJob } from '../src/importCsv';
+
+describe('CSV import pipeline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function createEnv(csv: string) {
+    return {
+      PRICE_DB: {} as D1Database,
+      PRICE_ADMIN_TOKEN: 'token',
+      PRICE_IMPORTS: {
+        get: vi.fn().mockResolvedValue({ body: new ReadableStream({ start(controller) { controller.enqueue(new TextEncoder().encode(csv)); controller.close(); } }) }),
+      } as unknown as R2Bucket,
+    };
+  }
+
+  it('processes valid CSV row and marks job success', async () => {
+    const env = createEnv(
+      'ean,territory,retailer,storeLabel,price_cents,currency,observedAt\n3560070894222,gp,carrefour,Store GP,349,EUR,2026-02-18T12:00:00Z\n',
+    );
+
+    await processCsvImportJob(env as never, 'job-1', 'imports/job-1/test.csv');
+
+    expect(dbMock.insertObservationCentsAndRefreshAggregate).toHaveBeenCalledTimes(1);
+    expect(dbMock.insertObservationCentsAndRefreshAggregate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ ean: '3560070894222', priceCents: 349 }),
+    );
+    expect(dbMock.updateImportJobProgress).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: 'success', totalRows: 1, successRows: 1, errorRows: 0, finished: true }),
+    );
+  });
+
+  it('marks invalid row and fails job when all rows invalid', async () => {
+    const env = createEnv(
+      'ean,territory,retailer,storeLabel,price_cents,currency,observedAt\nINVALID,gp,carrefour,Store GP,349,EUR,2026-02-18T12:00:00Z\n',
+    );
+
+    await processCsvImportJob(env as never, 'job-2', 'imports/job-2/test.csv');
+
+    expect(dbMock.insertObservationCentsAndRefreshAggregate).not.toHaveBeenCalled();
+    expect(dbMock.insertImportRow).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: 'invalid', errorMessage: 'invalid_ean' }),
+    );
+    expect(dbMock.updateImportJobProgress).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: 'failed', totalRows: 1, successRows: 0, errorRows: 1, finished: true }),
+    );
+  });
+
+  it('marks job partial when CSV has mixed valid and invalid rows', async () => {
+    const env = createEnv(
+      [
+        'ean,territory,retailer,storeLabel,price_cents,currency,observedAt',
+        '3560070894222,gp,carrefour,Store GP,349,EUR,2026-02-18T12:00:00Z',
+        '3560070894222,gp,carrefour,Store GP,-10,EUR,2026-02-18T12:00:00Z',
+      ].join('\n'),
+    );
+
+    await processCsvImportJob(env as never, 'job-3', 'imports/job-3/test.csv');
+
+    expect(dbMock.insertObservationCentsAndRefreshAggregate).toHaveBeenCalledTimes(1);
+    expect(dbMock.updateImportJobProgress).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: 'partial', totalRows: 2, successRows: 1, errorRows: 1, finished: true }),
+    );
+  });
+
+  it('fails job on missing required column', async () => {
+    const env = createEnv('ean,territory,retailer,storeLabel,price_cents,currency\n3560070894222,gp,carrefour,Store GP,349,EUR\n');
+
+    await processCsvImportJob(env as never, 'job-4', 'imports/job-4/test.csv');
+
+    expect(dbMock.updateImportJobProgress).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ status: 'failed', finished: true }),
+    );
+  });
+});

--- a/price-api/wrangler.toml
+++ b/price-api/wrangler.toml
@@ -11,3 +11,7 @@ binding = "PRICE_DB"
 database_name = "price-db"
 database_id = "REPLACE_WITH_D1_DATABASE_ID"
 migrations_dir = "migrations"
+
+[[r2_buckets]]
+binding = "PRICE_IMPORTS"
+bucket_name = "price-imports"


### PR DESCRIPTION
### Motivation

- Ajouter un flux d'ingestion CSV sécurisé, traçable et scalable pour alimenter les observations de prix en production sans casser les endpoints existants.
- Garantir validation stricte, stockage brut des fichiers et suivi opérationnel des imports pour audits et relances.

### Description

- Ajout d'une migration D1 `migrations/0003_imports.sql` qui crée les tables `import_jobs` et `import_rows` et les index demandés pour le suivi opérationnel.
- Implémentation d'un pipeline d'import streaming dans `src/importCsv.ts` qui accepte `multipart/form-data` ou `text/csv`, stocke le fichier brut en R2 sous la clé `imports/{jobId}/{filename}`, crée un `import_job`, et lance le traitement asynchrone via `ctx.waitUntil()`.
- Extension de la couche DB (`src/db.ts`) avec helpers pour créer/mettre à jour les jobs, insérer les lignes d'import, et une insertion d'observation en cents (`insertObservationCentsAndRefreshAggregate`) pour préserver la précision et recalculer les agrégats.
- Nouveaux endpoints admin dans le router sans modifier les endpoints publics: `POST /v1/admin/import/csv`, `GET /v1/admin/import/jobs`, `GET /v1/admin/import/jobs/:id`; l'auth Bearer et le rate-limit admin existants sont réutilisés et les réponses admin renvoient `Cache-Control: no-store`.
- Mise à jour des types et bindings (`src/types.ts`, `price-api/wrangler.toml`) pour inclure le binding R2 `PRICE_IMPORTS`, nouveaux statuts et schémas d'import; normalisation retailer améliorée et validations strictes appliquées côté parsing.
- Ajout de tests unitaires ciblés `price-api/tests/importCsv.test.ts` et documentation ajoutée à `price-api/README.md` (section "CSV Import – Production ingestion flow") avec exemples curl, format CSV attendu, et instructions wrangler/D1+R2.

### Testing

- Exécution du contrôle de types avec `npm run typecheck` dans `price-api`, qui a abouti sans erreurs après ajustements.
- Exécution de la suite de tests `npm test` (Vitest) dans `price-api`, incluant les nouveaux tests `tests/importCsv.test.ts` et les validations existantes, avec résultat: tous les tests passent (8/8).
- Tests automatisés couvrent: import CSV valide, gestion de ligne invalide, statut de job (success/partial/failed) et déclenchement du recalcul d'agrégats via l'insertion d'observation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69951b31674c8321a3373104c337e676)