### PR TITLE
feat(import): lock official CSV format v1 with strict validation and template endpoint

### DIFF
--- a/price-api/README.md
+++ b/price-api/README.md
@@ -52,13 +52,15 @@ npm run dev
 - `GET /v1/prices?ean=...&territory=gp`
 - `GET /v1/products/:ean`
 
-### Admin (POST)
+### Admin (Bearer requis)
 
 Header requis : `Authorization: Bearer <PRICE_ADMIN_TOKEN>`
 
+- `GET /v1/admin/import/template`
 - `POST /v1/admin/products`
 - `POST /v1/admin/observations`
 - `POST /v1/admin/seed`
+- `POST /v1/admin/import/csv`
 
 ## Exemples cURL
 
@@ -107,3 +109,67 @@ curl -s -X POST "http://127.0.0.1:8787/v1/admin/seed" \
 
 `POST /v1/admin/seed` insère le produit EAN `3560070894222` et des prix **placeholder** (`source=admin_seed`) pour démonstration.
 Ces valeurs ne sont pas des prix réels et doivent être remplacées via back-office / sources autorisées.
+
+## CSV Import – Official Production Format v1
+
+Le format CSV d'import est verrouillé et strictement validé.
+
+### Colonnes obligatoires (ordre strict)
+
+```csv
+ean,product_name,brand,territory,retailer,store_name,price_eur,observed_at,currency
+```
+
+### Contraintes
+
+- `ean` : regex stricte `^[0-9]{8,14}$`
+- `product_name` : chaîne non vide
+- `brand` : chaîne non vide
+- `territory` : `fr` | `gp` | `mq`
+- `retailer` : chaîne normalisée (`trim` + collapse des espaces + mapping canonique)
+- `store_name` : chaîne non vide
+- `price_eur` : décimal strict `> 0` avec max 2 décimales
+- `observed_at` : ISO 8601 UTC strict (suffixe `Z`)
+- `currency` : doit être exactement `EUR`
+
+Validation stricte du header :
+
+- Colonne manquante -> `400`
+- Colonne supplémentaire -> `400`
+- Ordre incorrect -> `400`
+
+### Exemple valide
+
+```csv
+ean,product_name,brand,territory,retailer,store_name,price_eur,observed_at,currency
+3560070894222,Sirop Cerise 75cl,Carrefour,gp,Carrefour,Carrefour Jarry,4.10,2026-02-17T18:35:00Z,EUR
+```
+
+### Télécharger le template officiel
+
+```bash
+curl -sS "http://127.0.0.1:8787/v1/admin/import/template" \
+  -H "Authorization: Bearer $PRICE_ADMIN_TOKEN" \
+  -o price_import_template_v1.csv
+```
+
+### Upload CSV
+
+```bash
+curl -sS -X POST "http://127.0.0.1:8787/v1/admin/import/csv" \
+  -H "Authorization: Bearer $PRICE_ADMIN_TOKEN" \
+  -H "Content-Type: text/csv" \
+  --data-binary @price_import_template_v1.csv
+```
+
+### Statuts d'import
+
+- `success` : 0 erreur
+- `partial` : au moins 1 ligne rejetée
+- `failed` : 0 ligne valide
+
+Le worker :
+
+- insère systématiquement les observations en centimes
+- recalcule les agrégats après chaque insertion
+- normalise les retailers (`E.Leclerc`, `Carrefour`, `Super U`, `Intermarché`)

--- a/price-api/src/importCsv.ts
+++ b/price-api/src/importCsv.ts
@@ -1,0 +1,293 @@
+import { insertObservationAndRefreshAggregate, upsertProduct } from './db';
+import type { Env, Territory } from './types';
+
+export const CSV_IMPORT_HEADERS = [
+  'ean',
+  'product_name',
+  'brand',
+  'territory',
+  'retailer',
+  'store_name',
+  'price_eur',
+  'observed_at',
+  'currency',
+] as const;
+
+const EAN_REGEX = /^[0-9]{8,14}$/;
+const UTC_ISO_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const PRICE_REGEX = /^(?:0|[1-9]\d*)(?:\.\d{1,2})?$/;
+
+export interface CsvImportRowError {
+  line: number;
+  reason: string;
+}
+
+export interface CsvImportResult {
+  status: 'success' | 'partial' | 'failed';
+  processedRows: number;
+  insertedRows: number;
+  errors: CsvImportRowError[];
+}
+
+interface ParsedCsvRow {
+  ean: string;
+  productName: string;
+  brand: string;
+  territory: Territory;
+  retailer: string;
+  storeName: string;
+  price: number;
+  observedAt: string;
+  currency: 'EUR';
+}
+
+function collapseWhitespace(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+export function normalizeRetailer(value: string): string {
+  const collapsed = collapseWhitespace(value);
+  const normalized = collapsed.toLowerCase();
+
+  if (normalized === 'carrefour') return 'carrefour';
+  if (normalized === 'e.leclerc' || normalized === 'e leclerc' || normalized === 'leclerc') return 'leclerc';
+  if (normalized === 'super u' || normalized === 'super-u' || normalized === 'superu') return 'superu';
+  if (normalized === 'intermarche' || normalized === 'intermarché') return 'intermarché';
+
+  return normalized;
+}
+
+function parseCsvLine(line: string): string[] {
+  const cells: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (char === ',' && !inQuotes) {
+      cells.push(current);
+      current = '';
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (inQuotes) {
+    throw new Error('unclosed quoted field');
+  }
+
+  cells.push(current);
+  return cells;
+}
+
+function parseHeader(line: string): void {
+  const headers = parseCsvLine(line).map((header) => header.trim());
+
+  if (headers.length !== CSV_IMPORT_HEADERS.length) {
+    throw new Error('invalid CSV header: missing or extra column');
+  }
+
+  for (let i = 0; i < CSV_IMPORT_HEADERS.length; i += 1) {
+    if (headers[i] !== CSV_IMPORT_HEADERS[i]) {
+      throw new Error(`invalid CSV header order at column ${i + 1}: expected ${CSV_IMPORT_HEADERS[i]}`);
+    }
+  }
+}
+
+function parseTerritory(rawValue: string): Territory | null {
+  if (rawValue === 'fr' || rawValue === 'gp' || rawValue === 'mq') {
+    return rawValue;
+  }
+
+  return null;
+}
+
+function parsePrice(rawValue: string): number | null {
+  if (!PRICE_REGEX.test(rawValue)) {
+    return null;
+  }
+
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+}
+
+function parseObservedAt(rawValue: string): string | null {
+  if (!UTC_ISO_REGEX.test(rawValue)) {
+    return null;
+  }
+
+  const date = new Date(rawValue);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toISOString();
+}
+
+function parseDataRow(line: string, lineNumber: number): { row?: ParsedCsvRow; error?: CsvImportRowError } {
+  let cells: string[];
+
+  try {
+    cells = parseCsvLine(line);
+  } catch (error) {
+    return {
+      error: {
+        line: lineNumber,
+        reason: error instanceof Error ? error.message : 'invalid csv row',
+      },
+    };
+  }
+
+  if (cells.length !== CSV_IMPORT_HEADERS.length) {
+    return {
+      error: {
+        line: lineNumber,
+        reason: `invalid column count: expected ${CSV_IMPORT_HEADERS.length}, got ${cells.length}`,
+      },
+    };
+  }
+
+  const [eanRaw, productNameRaw, brandRaw, territoryRaw, retailerRaw, storeNameRaw, priceRaw, observedAtRaw, currencyRaw] =
+    cells.map((cell) => cell.trim());
+
+  if (!EAN_REGEX.test(eanRaw)) {
+    return { error: { line: lineNumber, reason: 'ean must match ^[0-9]{8,14}$' } };
+  }
+
+  const productName = collapseWhitespace(productNameRaw);
+  if (!productName) {
+    return { error: { line: lineNumber, reason: 'product_name is required' } };
+  }
+
+  const brand = collapseWhitespace(brandRaw);
+  if (!brand) {
+    return { error: { line: lineNumber, reason: 'brand is required' } };
+  }
+
+  const territory = parseTerritory(territoryRaw);
+  if (!territory) {
+    return { error: { line: lineNumber, reason: "territory must be one of 'fr', 'gp', 'mq'" } };
+  }
+
+  const retailerCollapsed = collapseWhitespace(retailerRaw);
+  if (!retailerCollapsed) {
+    return { error: { line: lineNumber, reason: 'retailer is required' } };
+  }
+
+  const storeName = collapseWhitespace(storeNameRaw);
+  if (!storeName) {
+    return { error: { line: lineNumber, reason: 'store_name is required' } };
+  }
+
+  const price = parsePrice(priceRaw);
+  if (price === null) {
+    return { error: { line: lineNumber, reason: 'price_eur must be a decimal > 0 with up to 2 decimals' } };
+  }
+
+  const observedAt = parseObservedAt(observedAtRaw);
+  if (!observedAt) {
+    return { error: { line: lineNumber, reason: 'observed_at must be a strict ISO 8601 UTC datetime' } };
+  }
+
+  if (currencyRaw !== 'EUR') {
+    return { error: { line: lineNumber, reason: 'currency must be EUR' } };
+  }
+
+  return {
+    row: {
+      ean: eanRaw,
+      productName,
+      brand,
+      territory,
+      retailer: normalizeRetailer(retailerCollapsed),
+      storeName,
+      price,
+      observedAt,
+      currency: 'EUR',
+    },
+  };
+}
+
+export async function importCsvContent(csvContent: string, env: Env): Promise<CsvImportResult> {
+  const lines = csvContent
+    .replace(/^\uFEFF/, '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    throw new Error('empty CSV payload');
+  }
+
+  parseHeader(lines[0]);
+
+  const errors: CsvImportRowError[] = [];
+  let insertedRows = 0;
+  let processedRows = 0;
+
+  for (let i = 1; i < lines.length; i += 1) {
+    const lineNumber = i + 1;
+    const parsed = parseDataRow(lines[i], lineNumber);
+    processedRows += 1;
+
+    if (!parsed.row) {
+      errors.push(parsed.error ?? { line: lineNumber, reason: 'invalid row' });
+      continue;
+    }
+
+    await upsertProduct(env.PRICE_DB, {
+      ean: parsed.row.ean,
+      productName: parsed.row.productName,
+      brand: parsed.row.brand,
+    });
+
+    await insertObservationAndRefreshAggregate(env.PRICE_DB, {
+      ean: parsed.row.ean,
+      territory: parsed.row.territory,
+      retailer: parsed.row.retailer,
+      price: parsed.row.price,
+      currency: parsed.row.currency,
+      observedAt: parsed.row.observedAt,
+      storeName: parsed.row.storeName,
+      source: 'admin',
+      confidence: 1,
+      metadata: {
+        import: 'csv_v1',
+      },
+    });
+
+    insertedRows += 1;
+  }
+
+  let status: CsvImportResult['status'] = 'success';
+  if (insertedRows === 0) {
+    status = 'failed';
+  } else if (errors.length > 0) {
+    status = 'partial';
+  }
+
+  return {
+    status,
+    processedRows,
+    insertedRows,
+    errors,
+  };
+}
+
+export const PRICE_IMPORT_TEMPLATE_V1 = `${CSV_IMPORT_HEADERS.join(',')}\n3560070894222,Sirop Cerise 75cl,Carrefour,gp,Carrefour,Carrefour Jarry,4.10,2026-02-17T18:35:00Z,EUR\n`;

--- a/price-api/src/router.ts
+++ b/price-api/src/router.ts
@@ -9,6 +9,7 @@ import {
   upsertProduct,
 } from './db';
 import { withCors } from './cors';
+import { importCsvContent, PRICE_IMPORT_TEMPLATE_V1 } from './importCsv';
 import type { Env, PriceAggregateRecord, PriceObservationRecord, PriceStatus, PricesResponse, ProductResponse } from './types';
 import {
   adminObservationSchema,
@@ -164,9 +165,28 @@ export async function handleRequest(request: Request, env: Env): Promise<Respons
       );
     }
 
-    if (request.method === 'POST' && url.pathname.startsWith('/v1/admin/')) {
+    if (url.pathname.startsWith('/v1/admin/')) {
       if (!assertAdminToken(request, env.PRICE_ADMIN_TOKEN)) {
         return withCors(json({ error: 'unauthorized' }, 401), origin, env);
+      }
+
+      if (request.method === 'GET' && url.pathname === '/v1/admin/import/template') {
+        return withCors(
+          new Response(PRICE_IMPORT_TEMPLATE_V1, {
+            status: 200,
+            headers: {
+              'Content-Type': 'text/csv; charset=utf-8',
+              'Content-Disposition': 'attachment; filename="price_import_template_v1.csv"',
+              'Cache-Control': 'no-store',
+            },
+          }),
+          origin,
+          env,
+        );
+      }
+
+      if (request.method !== 'POST') {
+        return withCors(json({ error: 'not_found' }, 404), origin, env);
       }
 
       const ipKey = request.headers.get('CF-Connecting-IP') ?? 'unknown';
@@ -238,6 +258,12 @@ export async function handleRequest(request: Request, env: Env): Promise<Respons
         }
 
         return withCors(json({ status: 'OK', ean, inserted: seedPayloads.length }, 201), origin, env);
+      }
+
+      if (url.pathname === '/v1/admin/import/csv') {
+        const csvContent = await request.text();
+        const result = await importCsvContent(csvContent, env);
+        return withCors(json(result, 200), origin, env);
       }
     }
 

--- a/price-api/src/validators.ts
+++ b/price-api/src/validators.ts
@@ -61,7 +61,20 @@ export function assertAdminToken(request: Request, expectedToken: string): boole
 }
 
 export function validateRetailer(retailer: string): string {
-  const normalized = retailer.trim().toLowerCase();
+  const normalized = retailer.trim().replace(/\s+/g, ' ').toLowerCase();
+
+  if (normalized === 'e.leclerc' || normalized === 'e leclerc' || normalized === 'leclerc') {
+    return 'leclerc';
+  }
+
+  if (normalized === 'super u' || normalized === 'super-u' || normalized === 'superu') {
+    return 'superu';
+  }
+
+  if (normalized === 'intermarche' || normalized === 'intermarché') {
+    return 'intermarché';
+  }
+
   if (RETAILERS.includes(normalized as (typeof RETAILERS)[number])) {
     return normalized;
   }

--- a/price-api/templates/price_import_template_v1.csv
+++ b/price-api/templates/price_import_template_v1.csv
@@ -1,0 +1,2 @@
+ean,product_name,brand,territory,retailer,store_name,price_eur,observed_at,currency
+3560070894222,Sirop Cerise 75cl,Carrefour,gp,Carrefour,Carrefour Jarry,4.10,2026-02-17T18:35:00Z,EUR

--- a/price-api/tests/importCsv.test.ts
+++ b/price-api/tests/importCsv.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/db', () => ({
+  insertObservationAndRefreshAggregate: vi.fn(async () => undefined),
+  upsertProduct: vi.fn(async () => undefined),
+}));
+
+import { insertObservationAndRefreshAggregate, upsertProduct } from '../src/db';
+import { CSV_IMPORT_HEADERS, importCsvContent } from '../src/importCsv';
+import type { Env } from '../src/types';
+
+const baseRow = '3560070894222,Sirop Cerise 75cl,Carrefour,gp,Carrefour,Carrefour Jarry,4.10,2026-02-17T18:35:00Z,EUR';
+
+function makeEnv(): Env {
+  return {
+    PRICE_DB: {} as D1Database,
+    PRICE_ADMIN_TOKEN: 'token',
+  };
+}
+
+describe('importCsvContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects invalid header', async () => {
+    const csv = `bad,header\n${baseRow}`;
+
+    await expect(importCsvContent(csv, makeEnv())).rejects.toThrow(/invalid CSV header/);
+  });
+
+  it('rejects missing column in header', async () => {
+    const invalidHeader = CSV_IMPORT_HEADERS.slice(0, CSV_IMPORT_HEADERS.length - 1).join(',');
+    const csv = `${invalidHeader}\n${baseRow}`;
+
+    await expect(importCsvContent(csv, makeEnv())).rejects.toThrow(/missing or extra column/);
+  });
+
+  it('rejects invalid territory row', async () => {
+    const csv = `${CSV_IMPORT_HEADERS.join(',')}\n3560070894222,Sirop Cerise 75cl,Carrefour,re,Carrefour,Carrefour Jarry,4.10,2026-02-17T18:35:00Z,EUR`;
+    const result = await importCsvContent(csv, makeEnv());
+
+    expect(result.status).toBe('failed');
+    expect(result.errors[0]?.reason).toMatch(/territory/);
+    expect(upsertProduct).not.toHaveBeenCalled();
+    expect(insertObservationAndRefreshAggregate).not.toHaveBeenCalled();
+  });
+
+  it('rejects negative price row', async () => {
+    const csv = `${CSV_IMPORT_HEADERS.join(',')}\n3560070894222,Sirop Cerise 75cl,Carrefour,gp,Carrefour,Carrefour Jarry,-4.10,2026-02-17T18:35:00Z,EUR`;
+    const result = await importCsvContent(csv, makeEnv());
+
+    expect(result.status).toBe('failed');
+    expect(result.errors[0]?.reason).toMatch(/price_eur/);
+  });
+
+  it('rejects non-EUR currency row', async () => {
+    const csv = `${CSV_IMPORT_HEADERS.join(',')}\n3560070894222,Sirop Cerise 75cl,Carrefour,gp,Carrefour,Carrefour Jarry,4.10,2026-02-17T18:35:00Z,USD`;
+    const result = await importCsvContent(csv, makeEnv());
+
+    expect(result.status).toBe('failed');
+    expect(result.errors[0]?.reason).toBe('currency must be EUR');
+  });
+
+  it('accepts valid full row', async () => {
+    const csv = `${CSV_IMPORT_HEADERS.join(',')}\n${baseRow}`;
+    const result = await importCsvContent(csv, makeEnv());
+
+    expect(result.status).toBe('success');
+    expect(result.insertedRows).toBe(1);
+    expect(result.errors).toHaveLength(0);
+    expect(upsertProduct).toHaveBeenCalledTimes(1);
+    expect(insertObservationAndRefreshAggregate).toHaveBeenCalledTimes(1);
+    expect(insertObservationAndRefreshAggregate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        retailer: 'carrefour',
+        price: 4.1,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation

- Standardiser définitivement le format CSV d'import prix pour le micro-service `price-api` et empêcher toute ingestion non conforme.
- Fournir un template officiel téléchargeable et une validation stricte côté Worker pour garantir traçabilité et cohérence des données. 
- Normaliser les retailers et s'assurer que les insertions utilisent des centimes et déclenchent le recalcul des agrégats.

### Description

- Ajout d'un moteur d'import strict dans `price-api/src/importCsv.ts` qui impose le header exact et l'ordre, valide chaque ligne (EAN, product_name, brand, territory, retailer, store_name, price_eur, observed_at, currency), normalise le retailer et retourne un `status` `success`/`partial`/`failed` avec erreurs ligne par ligne. 
- Exposition d'un endpoint admin `GET /v1/admin/import/template` (Bearer requis) qui renvoie le template CSV (`Cache-Control: no-store`) et d'un endpoint `POST /v1/admin/import/csv` qui ingère le CSV via `importCsvContent`. 
- Ajout du template de production `price-api/templates/price_import_template_v1.csv` et mise à jour de la documentation `price-api/README.md` (section "CSV Import – Official Production Format v1" avec colonnes, contraintes, exemples et exemples cURL). 
- Renforcement de la normalisation des retailers dans `price-api/src/validators.ts` et ajout de tests unitaires `price-api/tests/importCsv.test.ts` couvrant header invalide, colonne manquante, territoire invalide, prix négatif, currency ≠ EUR et ligne valide complète.

### Testing

- Exécution des tests unitaires avec `npm -C price-api run test`, tous les tests passent (`2 files, 10 tests, 10 passed`).
- Vérification du typage avec `npm -C price-api run typecheck`, la commande `tsc --noEmit` s'est exécutée sans erreurs.
- Les nouveaux tests d'import CSV ont validé les scénarios demandés (header invalide, colonne manquante, territoire invalide, prix négatif, currency ≠ EUR, ligne valide).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69952176f13c83218f90b26ac9587e9e)