### PR TITLE
Add free client-side receipt OCR ingestion flow

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,6 +54,7 @@ const LutteVieChere = lazyPage(() => import('./pages/LutteVieChereIndexPage'));
 // Scanner & OCR pages
 const ScannerHub = lazyPage(() => import('./pages/ScannerHub'));
 const OCRHub = lazyPage(() => import('./pages/ocr/OCRHub'));
+const ReceiptIngestPage = lazyPage(() => import('./pages/ReceiptIngestPage'));
 const ScanEAN = lazyPage(() => import('./pages/ScanEAN'));
 const ProductPhotoAnalysis = lazyPage(() => import('./pages/ProductPhotoAnalysis'));
 const ProductScanResult = lazyPage(() => import('./pages/ProductScanResult'));
@@ -221,6 +222,7 @@ export default function App() {
                       {/* Scanner & OCR routes */}
                       <Route path="scan" element={<ScannerHub />} />
                       <Route path="scanner" element={<ScannerHub />} />
+                      <Route path="receipt-ingest" element={<ReceiptIngestPage />} />
                       <Route path="scan-ean" element={<ScanEAN />} />
                       <Route path="analyse-photo-produit" element={<ProductPhotoAnalysis />} />
                       <Route path="product/:barcode" element={<ProductScanResult />} />

--- a/frontend/src/pages/ReceiptIngestPage.tsx
+++ b/frontend/src/pages/ReceiptIngestPage.tsx
@@ -1,0 +1,106 @@
+import { useMemo, useState } from 'react';
+import { mergeTexts, ocrFiles, parseReceipt, type NormalizedReceiptItem } from '../services/receiptOcrClient';
+import { getApiBaseUrl } from '../utils/apiBase';
+
+interface CompletePayload {
+  territory: 'fr' | 'gp' | 'mq';
+  retailer: string;
+  storeLabel?: string;
+  purchasedAt?: string;
+  currency: 'EUR';
+  confidence: number;
+  redactedText: string;
+  ocrText: string;
+  items: Array<NormalizedReceiptItem>;
+}
+
+export default function ReceiptIngestPage() {
+  const [files, setFiles] = useState<File[]>([]);
+  const [progress, setProgress] = useState(0);
+  const [payload, setPayload] = useState<CompletePayload | null>(null);
+  const [sending, setSending] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const canScan = files.length >= 1 && files.length <= 6;
+
+  const onScan = async () => {
+    setMessage(null);
+    const texts = await ocrFiles(files, setProgress);
+    const merged = mergeTexts(texts);
+    const parsed = parseReceipt(merged);
+    setPayload({ ...parsed, territory: 'gp' });
+  };
+
+  const updateItem = (index: number, key: 'label' | 'priceCents', value: string) => {
+    if (!payload) return;
+    const nextItems = [...payload.items];
+    if (key === 'priceCents') {
+      nextItems[index] = { ...nextItems[index], priceCents: Math.max(0, Math.round(Number.parseFloat(value || '0') * 100)) };
+    } else {
+      nextItems[index] = { ...nextItems[index], label: value };
+    }
+    setPayload({ ...payload, items: nextItems });
+  };
+
+  const onSend = async () => {
+    if (!payload) return;
+    setSending(true);
+    setMessage(null);
+    try {
+      const response = await fetch(`${getApiBaseUrl()}/v1/ingest/receipt/complete`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Envoi impossible (${response.status})`);
+      }
+      setMessage('Ticket envoyé avec succès.');
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Erreur d’envoi');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const summary = useMemo(() => {
+    if (!payload) return null;
+    const total = payload.items.reduce((sum, item) => sum + item.priceCents, 0) / 100;
+    return `${payload.items.length} lignes détectées · total estimé ${total.toFixed(2)} €`;
+  }, [payload]);
+
+  return (
+    <div className="mx-auto max-w-3xl p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">Ingestion ticket (OCR gratuit)</h1>
+      <input
+        type="file"
+        accept="image/*"
+        multiple
+        onChange={(event) => setFiles(Array.from(event.target.files ?? []).slice(0, 6))}
+      />
+      <p className="text-sm text-gray-600">Sélectionner 1 à 6 images.</p>
+      <button type="button" onClick={onScan} disabled={!canScan} className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50">
+        Lancer OCR
+      </button>
+      {progress > 0 ? <p>Progression OCR: {progress}%</p> : null}
+      {summary ? <p>{summary}</p> : null}
+
+      {payload?.items.map((item, index) => (
+        <div key={`${item.label}-${index}`} className="grid grid-cols-2 gap-2">
+          <input value={item.label} onChange={(e) => updateItem(index, 'label', e.target.value)} className="border rounded p-2" />
+          <input
+            value={(item.priceCents / 100).toFixed(2)}
+            onChange={(e) => updateItem(index, 'priceCents', e.target.value)}
+            className="border rounded p-2"
+          />
+        </div>
+      ))}
+
+      <button type="button" onClick={onSend} disabled={!payload || sending} className="rounded bg-green-600 px-4 py-2 text-white disabled:opacity-50">
+        Envoyer
+      </button>
+      {message ? <p>{message}</p> : null}
+    </div>
+  );
+}

--- a/frontend/src/services/receiptOcrClient.ts
+++ b/frontend/src/services/receiptOcrClient.ts
@@ -1,0 +1,201 @@
+import { runOCR } from './ocrService';
+
+export interface NormalizedReceiptItem {
+  label: string;
+  qty?: number;
+  unit?: string;
+  priceCents: number;
+  ean?: string;
+  confidence: number;
+}
+
+export interface NormalizedReceiptPayload {
+  retailer: string;
+  storeLabel?: string;
+  purchasedAt?: string;
+  territory: 'fr' | 'gp' | 'mq';
+  currency: 'EUR';
+  items: NormalizedReceiptItem[];
+  totals?: {
+    totalCents?: number;
+  };
+  confidence: number;
+  redactedText: string;
+  ocrText: string;
+}
+
+const PII_PATTERNS: RegExp[] = [
+  /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[A-Za-z]{2,}/g,
+  /\b(?:\+33|0)[1-9](?:[\s.-]?\d{2}){4}\b/g,
+  /\b(?:\d{4}[\s.-]?){3}\d{4}\b/g,
+  /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/gi,
+  /\b\d{1,4}\s+[A-Za-zÀ-ÿ'\-\s]{3,}(?:rue|avenue|av\.?|impasse|lotissement|boulevard|bd\.?|chemin)\b/gi,
+  /\b(?:carte\s+fid[ée]lit[ée]|fid[ée]lit[ée]|n[°o]\s*client)\s*[:#-]?\s*[A-Z0-9\-]{4,}\b/gi,
+];
+
+const RETAILER_PATTERNS: Array<{ pattern: RegExp; name: string }> = [
+  { pattern: /carrefour(?:\s+market|\s+express)?/i, name: 'carrefour' },
+  { pattern: /e?\.?\s*leclerc/i, name: 'leclerc' },
+  { pattern: /inter\s*march[ée]/i, name: 'intermarché' },
+  { pattern: /super\s*u|hyper\s*u/i, name: 'superu' },
+];
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+export function redactPII(text: string): string {
+  return PII_PATTERNS.reduce((acc, pattern) => acc.replace(pattern, '[REDACTED]'), text);
+}
+
+function parsePriceToCents(input: string): number | null {
+  const normalized = input.replace(/\s/g, '').replace(',', '.');
+  const parsed = Number.parseFloat(normalized);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return Math.round(parsed * 100);
+}
+
+function detectRetailer(lines: string[]): string {
+  const header = lines.slice(0, 12).join('\n');
+  for (const entry of RETAILER_PATTERNS) {
+    if (entry.pattern.test(header)) {
+      return entry.name;
+    }
+  }
+
+  return 'unknown';
+}
+
+function detectPurchasedAt(text: string): string | undefined {
+  const match = text.match(/(\d{2})[\/-](\d{2})[\/-](\d{4})(?:\s+(\d{2}):(\d{2}))?/);
+  if (!match) {
+    return undefined;
+  }
+
+  const date = `${match[3]}-${match[2]}-${match[1]}`;
+  if (!match[4] || !match[5]) {
+    return `${date}T00:00:00.000Z`;
+  }
+
+  return `${date}T${match[4]}:${match[5]}:00.000Z`;
+}
+
+function parseLineAsItem(line: string): NormalizedReceiptItem | null {
+  const cleaned = normalizeWhitespace(line);
+  if (cleaned.length < 4) {
+    return null;
+  }
+
+  if (/^(total|tva|cb|carte|paiement|rendu|a\s+r[eé]gler)/i.test(cleaned)) {
+    return null;
+  }
+
+  const priceMatch = cleaned.match(/(\d{1,4}(?:[\s.,]\d{2}))\s*(?:€|eur)?$/i);
+  if (!priceMatch) {
+    return null;
+  }
+
+  const priceCents = parsePriceToCents(priceMatch[1]);
+  if (!priceCents) {
+    return null;
+  }
+
+  const label = normalizeWhitespace(cleaned.slice(0, cleaned.length - priceMatch[0].length));
+  if (label.length < 2) {
+    return null;
+  }
+
+  const qtyMatch = label.match(/\b(\d+(?:[.,]\d+)?)\s*(kg|g|l|ml|x)\b/i);
+  const qty = qtyMatch ? Number.parseFloat(qtyMatch[1].replace(',', '.')) : undefined;
+  const unit = qtyMatch ? qtyMatch[2].toLowerCase() : undefined;
+
+  return {
+    label,
+    qty,
+    unit,
+    priceCents,
+    confidence: 0.75,
+  };
+}
+
+export function parseReceipt(text: string): Omit<NormalizedReceiptPayload, 'territory'> {
+  const lines = text.split('\n').map((line) => line.trim()).filter(Boolean);
+  const items = lines.map(parseLineAsItem).filter((item): item is NormalizedReceiptItem => Boolean(item));
+  const totalLine = lines.find((line) => /^total\s*(ttc)?/i.test(line));
+
+  return {
+    retailer: detectRetailer(lines),
+    storeLabel: lines[0],
+    purchasedAt: detectPurchasedAt(text),
+    currency: 'EUR',
+    items,
+    totals: {
+      totalCents: totalLine ? parsePriceToCents(totalLine.replace(/^total\s*(ttc)?/i, '')) ?? undefined : undefined,
+    },
+    confidence: items.length > 0 ? Math.min(1, items.reduce((s, i) => s + i.confidence, 0) / items.length) : 0,
+    redactedText: redactPII(text),
+    ocrText: text,
+  };
+}
+
+export async function preprocessImage(file: File, maxDimension = 2000): Promise<Blob> {
+  const bitmap = await createImageBitmap(file, { imageOrientation: 'from-image' } as ImageBitmapOptions);
+  const ratio = Math.min(1, maxDimension / Math.max(bitmap.width, bitmap.height));
+  const width = Math.round(bitmap.width * ratio);
+  const height = Math.round(bitmap.height * ratio);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Canvas 2D unavailable');
+  }
+
+  ctx.filter = 'grayscale(100%) contrast(115%)';
+  ctx.drawImage(bitmap, 0, 0, width, height);
+
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        reject(new Error('image preprocessing failed'));
+        return;
+      }
+      resolve(blob);
+    }, 'image/jpeg', 0.9);
+  });
+}
+
+export async function ocrFiles(files: File[], onProgress?: (value: number) => void): Promise<string[]> {
+  const outputs: string[] = [];
+  for (let i = 0; i < files.length; i += 1) {
+    const processed = await preprocessImage(files[i]);
+    const url = URL.createObjectURL(processed);
+    try {
+      const result = await runOCR(url, 'fra');
+      outputs.push(result.rawText ?? '');
+    } finally {
+      URL.revokeObjectURL(url);
+      onProgress?.(Math.round(((i + 1) / files.length) * 100));
+    }
+  }
+
+  return outputs;
+}
+
+export function mergeTexts(texts: string[]): string {
+  const seen = new Set<string>();
+  const merged: string[] = [];
+  for (const text of texts) {
+    for (const line of text.split('\n')) {
+      const normalized = normalizeWhitespace(line.toLowerCase());
+      if (!normalized || seen.has(normalized)) continue;
+      seen.add(normalized);
+      merged.push(line.trim());
+    }
+  }
+  return merged.join('\n');
+}

--- a/frontend/src/test/receiptOcrClient.test.ts
+++ b/frontend/src/test/receiptOcrClient.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { parseReceipt, redactPII } from '../services/receiptOcrClient';
+
+describe('receiptOcrClient', () => {
+  it('redacts common pii fields', () => {
+    const input = 'Email john@doe.com\nTel 0690 12 34 56\nCB 1234 5678 9012 3456';
+    const output = redactPII(input);
+
+    expect(output).not.toContain('john@doe.com');
+    expect(output).not.toContain('0690 12 34 56');
+    expect(output).not.toContain('1234 5678 9012 3456');
+    expect(output).toContain('[REDACTED]');
+  });
+
+  it('parses normalized receipt payload', () => {
+    const text = `CARREFOUR MARKET\n12/02/2026 14:33\nPOMME GOLDEN 2,99€\nTOTAL TTC 2,99€`;
+    const parsed = parseReceipt(text);
+
+    expect(parsed.retailer).toBe('carrefour');
+    expect(parsed.currency).toBe('EUR');
+    expect(parsed.items).toHaveLength(1);
+    expect(parsed.items[0].priceCents).toBe(299);
+    expect(parsed.purchasedAt).toContain('2026-02-12');
+  });
+});

--- a/frontend/src/utils/apiBase.ts
+++ b/frontend/src/utils/apiBase.ts
@@ -1,0 +1,7 @@
+export function getApiBaseUrl(): string {
+  const base = (import.meta.env.VITE_PRICE_API_BASE as string | undefined) ?? (import.meta.env.VITE_API_BASE_URL as string | undefined);
+  if (!base) {
+    throw new Error('API base URL is not configured (VITE_PRICE_API_BASE/VITE_API_BASE_URL).');
+  }
+  return base.replace(/\/$/, '');
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       'src/test/freemium.test.ts',
       'src/test/cloudflareRouting.test.ts',
       'src/test/serviceWorkerCacheStrategy.test.ts',
+      'src/test/receiptOcrClient.test.ts',
       'scripts/verify-pages-api.test.ts',
     ],
   },

--- a/price-api/README.md
+++ b/price-api/README.md
@@ -107,3 +107,47 @@ curl -s -X POST "http://127.0.0.1:8787/v1/admin/seed" \
 
 `POST /v1/admin/seed` insère le produit EAN `3560070894222` et des prix **placeholder** (`source=admin_seed`) pour démonstration.
 Ces valeurs ne sont pas des prix réels et doivent être remplacées via back-office / sources autorisées.
+
+## Receipt ingestion (free OCR)
+
+Flux recommandé “100% gratuit” : OCR côté client (Tesseract.js), redaction PII client + serveur, puis envoi d’un payload normalisé vers le Worker.
+
+Endpoints ingestion:
+
+- `POST /v1/ingest/receipt/init`
+- `POST /v1/ingest/receipt/complete`
+- `GET /v1/ingest/receipt/jobs/:jobId`
+- `POST /v1/ingest/receipt/confirm`
+
+Exemple payload `POST /v1/ingest/receipt/complete`:
+
+```json
+{
+  "territory": "gp",
+  "retailer": "carrefour",
+  "storeLabel": "CARREFOUR MARKET BAIE-MAHAULT",
+  "purchasedAt": "2026-02-12T14:33:00.000Z",
+  "currency": "EUR",
+  "confidence": 0.78,
+  "redactedText": "...texte OCR déjà redacted...",
+  "ocrText": "...texte OCR brut...",
+  "items": [
+    {
+      "label": "POMME GOLDEN",
+      "qty": 1,
+      "unit": "kg",
+      "priceCents": 299,
+      "confidence": 0.82,
+      "ean": "3560070894222"
+    }
+  ],
+  "totals": {
+    "totalCents": 299
+  }
+}
+```
+
+Notes RGPD:
+- Le Worker re-redacte les champs texte même si le client l’a déjà fait.
+- Aucune clé API externe requise.
+- Les observations de prix sont écrites avec `source=receipt_user` quand un EAN est présent.

--- a/price-api/migrations/0002_receipt_ingestion.sql
+++ b/price-api/migrations/0002_receipt_ingestion.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS receipt_jobs (
+  id TEXT PRIMARY KEY,
+  status TEXT NOT NULL CHECK (status IN ('pending','partial','success','failed','confirmed')),
+  territory TEXT NOT NULL CHECK (territory IN ('fr','gp','mq')),
+  failure_reason TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS receipt_items (
+  id TEXT PRIMARY KEY,
+  job_id TEXT NOT NULL,
+  ean TEXT,
+  label TEXT NOT NULL,
+  qty REAL,
+  unit TEXT,
+  price_cents INTEGER NOT NULL,
+  confidence REAL NOT NULL DEFAULT 0.5,
+  created_at TEXT DEFAULT (datetime('now')),
+  FOREIGN KEY (job_id) REFERENCES receipt_jobs(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_receipt_items_job_id ON receipt_items(job_id);

--- a/price-api/src/db.ts
+++ b/price-api/src/db.ts
@@ -322,3 +322,63 @@ export async function applySimpleRateLimit(
   await db.prepare('UPDATE rate_limits SET count = count + 1 WHERE key = ?').bind(key).run();
   return true;
 }
+
+export async function createReceiptJob(db: D1Database, territory: Territory): Promise<string> {
+  const id = crypto.randomUUID();
+  await db
+    .prepare(
+      `INSERT INTO receipt_jobs (id, status, territory, created_at, updated_at)
+       VALUES (?, 'pending', ?, datetime('now'), datetime('now'))`,
+    )
+    .bind(id, territory)
+    .run();
+  return id;
+}
+
+export async function getReceiptJob(db: D1Database, jobId: string): Promise<Record<string, unknown> | null> {
+  return db.prepare('SELECT * FROM receipt_jobs WHERE id = ?').bind(jobId).first<Record<string, unknown>>();
+}
+
+export async function updateReceiptJobStatus(
+  db: D1Database,
+  jobId: string,
+  status: 'pending' | 'partial' | 'success' | 'failed' | 'confirmed',
+  reason?: string,
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE receipt_jobs SET status = ?, failure_reason = ?, updated_at = datetime('now') WHERE id = ?`,
+    )
+    .bind(status, reason ?? null, jobId)
+    .run();
+}
+
+export async function insertReceiptItem(
+  db: D1Database,
+  input: {
+    jobId: string;
+    label: string;
+    qty?: number;
+    unit?: string;
+    priceCents: number;
+    confidence: number;
+    ean?: string;
+  },
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO receipt_items (id, job_id, label, qty, unit, price_cents, confidence, ean, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+    )
+    .bind(
+      crypto.randomUUID(),
+      input.jobId,
+      input.label,
+      input.qty ?? null,
+      input.unit ?? null,
+      input.priceCents,
+      input.confidence,
+      input.ean ?? null,
+    )
+    .run();
+}

--- a/price-api/src/router.ts
+++ b/price-api/src/router.ts
@@ -1,11 +1,15 @@
 import { buildEtag, shouldReturnNotModified, storeInCache } from './cache';
 import {
   applySimpleRateLimit,
+  createReceiptJob,
   getAggregateFingerprint,
   getPriceAggregates,
   getProduct,
+  getReceiptJob,
   getRecentObservations,
   insertObservationAndRefreshAggregate,
+  insertReceiptItem,
+  updateReceiptJobStatus,
   upsertProduct,
 } from './db';
 import { withCors } from './cors';
@@ -16,6 +20,7 @@ import {
   assertAdminToken,
   getPricesQuerySchema,
   getProductParamsSchema,
+  receiptCompleteSchema,
   validateRetailer,
 } from './validators';
 
@@ -62,6 +67,17 @@ function toObservationView(observation: PriceObservationRecord) {
     confidence: observation.confidence,
     metadata: observation.metadata_json ? (JSON.parse(observation.metadata_json) as Record<string, unknown>) : null,
   };
+}
+
+
+function redactServerText(text: string): string {
+  const piiPatterns = [
+    /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[A-Za-z]{2,}/g,
+    /\b(?:\+33|0)[1-9](?:[\s.-]?\d{2}){4}\b/g,
+    /\b(?:\d{4}[\s.-]?){3}\d{4}\b/g,
+    /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/gi,
+  ];
+  return piiPatterns.reduce((acc, pattern) => acc.replace(pattern, '[REDACTED]'), text);
 }
 
 function computeStatus(hasAggregates: boolean, hasProduct = false): PriceStatus {
@@ -159,6 +175,80 @@ export async function handleRequest(request: Request, env: Env): Promise<Respons
         json(response, 200, {
           'Cache-Control': 'public, max-age=120, s-maxage=300',
         }),
+        origin,
+        env,
+      );
+    }
+
+    if (request.method === 'POST' && url.pathname === '/v1/ingest/receipt/init') {
+      const body = (await request.json()) as { territory?: 'fr' | 'gp' | 'mq' };
+      const territory = body.territory ?? 'gp';
+      const jobId = await createReceiptJob(env.PRICE_DB, territory);
+      return withCors(json({ status: 'OK', jobId }, 201), origin, env);
+    }
+
+    if (request.method === 'GET' && url.pathname.startsWith('/v1/ingest/receipt/jobs/')) {
+      const jobId = decodeURIComponent(url.pathname.replace('/v1/ingest/receipt/jobs/', ''));
+      const job = await getReceiptJob(env.PRICE_DB, jobId);
+      if (!job) {
+        return withCors(json({ error: 'not_found' }, 404), origin, env);
+      }
+      return withCors(json({ status: 'OK', job }, 200), origin, env);
+    }
+
+    if (request.method === 'POST' && url.pathname === '/v1/ingest/receipt/confirm') {
+      const body = (await request.json()) as { jobId?: string };
+      if (!body.jobId) {
+        return withCors(json({ error: 'bad_request', message: 'jobId is required' }, 400), origin, env);
+      }
+      await updateReceiptJobStatus(env.PRICE_DB, body.jobId, 'confirmed');
+      return withCors(json({ status: 'OK', jobId: body.jobId }, 200), origin, env);
+    }
+
+    if (request.method === 'POST' && url.pathname === '/v1/ingest/receipt/complete') {
+      const body = receiptCompleteSchema.parse(await request.json());
+      const jobId = body.jobId ?? (await createReceiptJob(env.PRICE_DB, body.territory));
+      const redactedText = redactServerText(body.redactedText);
+      const observedAt = body.purchasedAt ?? new Date().toISOString();
+      let insertedObservations = 0;
+
+      for (const item of body.items) {
+        await insertReceiptItem(env.PRICE_DB, {
+          jobId,
+          label: redactServerText(item.label),
+          qty: item.qty,
+          unit: item.unit,
+          priceCents: item.priceCents,
+          confidence: item.confidence,
+          ean: item.ean,
+        });
+
+        if (item.ean) {
+          await insertObservationAndRefreshAggregate(env.PRICE_DB, {
+            ean: item.ean,
+            territory: body.territory,
+            retailer: validateRetailer(body.retailer),
+            price: item.priceCents / 100,
+            currency: body.currency,
+            unit: item.unit,
+            observedAt,
+            storeName: body.storeLabel ? redactServerText(body.storeLabel) : undefined,
+            source: 'receipt_user',
+            confidence: item.confidence,
+            metadata: {
+              jobId,
+              redactedTextPreview: redactedText.slice(0, 500),
+            },
+          });
+          insertedObservations += 1;
+        }
+      }
+
+      const status = insertedObservations === body.items.length ? 'success' : insertedObservations > 0 ? 'partial' : 'failed';
+      await updateReceiptJobStatus(env.PRICE_DB, jobId, status, insertedObservations === 0 ? 'No EAN in payload items' : undefined);
+
+      return withCors(
+        json({ status: 'OK', jobId, jobStatus: status, insertedItems: body.items.length, insertedObservations }, 201),
         origin,
         env,
       );

--- a/price-api/src/validators.ts
+++ b/price-api/src/validators.ts
@@ -46,9 +46,36 @@ export const adminObservationSchema = z.object({
   observedAt: isoDateSchema.optional(),
   storeId: z.string().min(1).max(128).optional(),
   storeName: z.string().min(1).max(255).optional(),
-  source: z.enum(['admin', 'admin_seed', 'partner', 'receipt']).default('admin'),
+  source: z.enum(['admin', 'admin_seed', 'partner', 'receipt', 'receipt_user']).default('admin'),
   confidence: z.number().min(0).max(1).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+const receiptItemSchema = z.object({
+  label: z.string().min(1).max(255),
+  qty: z.number().positive().max(9999).optional(),
+  unit: z.string().min(1).max(32).optional(),
+  priceCents: z.number().int().positive().max(1_000_000),
+  ean: z.string().regex(EAN_REGEX, 'ean must have 8-14 digits').optional(),
+  confidence: z.number().min(0).max(1).default(0.5),
+});
+
+export const receiptCompleteSchema = z.object({
+  jobId: z.string().uuid().optional(),
+  territory: territoryEnum,
+  retailer: retailerSchema,
+  storeLabel: z.string().min(1).max(255).optional(),
+  purchasedAt: isoDateSchema.optional(),
+  currency: currencyEnum.default('EUR'),
+  confidence: z.number().min(0).max(1).default(0.5),
+  redactedText: z.string().min(1).max(100_000),
+  ocrText: z.string().min(1).max(100_000),
+  items: z.array(receiptItemSchema).min(1).max(500),
+  totals: z
+    .object({
+      totalCents: z.number().int().positive().max(10_000_000).optional(),
+    })
+    .optional(),
 });
 
 export function assertAdminToken(request: Request, expectedToken: string): boolean {

--- a/price-api/tests/validators.test.ts
+++ b/price-api/tests/validators.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { adminObservationSchema, adminProductSchema, getPricesQuerySchema } from '../src/validators';
+import { adminObservationSchema, adminProductSchema, getPricesQuerySchema, receiptCompleteSchema } from '../src/validators';
 
 describe('validators', () => {
   it('validates public prices query', () => {
@@ -40,5 +40,20 @@ describe('validators', () => {
 
     expect(payload.retailer).toBe('leclerc');
     expect(payload.observedAt).toBe('2026-02-18T12:00:00.000Z');
+  });
+
+  it('validates receipt complete payload', () => {
+    const payload = receiptCompleteSchema.parse({
+      territory: 'gp',
+      retailer: 'Carrefour',
+      currency: 'EUR',
+      confidence: 0.7,
+      redactedText: 'TOTAL [REDACTED]',
+      ocrText: 'TOTAL 5,90',
+      items: [{ label: 'POMME GOLDEN', priceCents: 299, confidence: 0.8, ean: '3560070894222' }],
+    });
+
+    expect(payload.retailer).toBe('carrefour');
+    expect(payload.items[0].priceCents).toBe(299);
   });
 });


### PR DESCRIPTION
### Motivation
- Provide a 100% free OCR ingestion path by running OCR in the browser with Tesseract.js to avoid paid providers and heavy Worker-side WASM, while respecting GDPR by redacting PII before any server persistence. 
- Keep the existing ingestion pipeline semantics (job lifecycle / insert into D1 / price aggregates) while accepting pre-normalized, redacted payloads from the client.
- Target mobile-first constraints: sequential OCR, image preprocessing (resize ≤2000px, grayscale/contrast) and limited memory/CPU usage.
- Ensure server-side defense in depth: re-validate schema and re-redact all text fields before any write to D1.

### Description
- Frontend: added a new OCR client module `frontend/src/services/receiptOcrClient.ts` implementing image preprocessing, sequential OCR (`runOCR` integration), text merge, `redactPII`, and `parseReceipt` producing a normalized payload; added `frontend/src/pages/ReceiptIngestPage.tsx` (1..6 images, OCR progress, editable preview, submit to Worker); added `frontend/src/utils/apiBase.ts` helper and enabled the new frontend test in `frontend/vitest.config.ts`.
- Worker / price-api: added strict `receiptCompleteSchema` validator and extended `adminObservationSchema` to include `receipt_user`; added server-side `redactServerText` and new endpoints in `price-api/src/router.ts`: `POST /v1/ingest/receipt/init`, `POST /v1/ingest/receipt/complete`, `GET /v1/ingest/receipt/jobs/:jobId`, `POST /v1/ingest/receipt/confirm` that create jobs, insert `receipt_items`, and write to `price_observations` with `source = 'receipt_user'` when EANs are provided.
- DB / migrations: added D1 migration `price-api/migrations/0002_receipt_ingestion.sql` to create `receipt_jobs` and `receipt_items`; implemented helper DB functions in `price-api/src/db.ts` (`createReceiptJob`, `getReceiptJob`, `updateReceiptJobStatus`, `insertReceiptItem`).
- Docs & tests: updated `price-api/README.md` with a new "Receipt ingestion (free OCR)" section and payload example; added frontend unit tests `frontend/src/test/receiptOcrClient.test.ts` for parsing/redaction and added `price-api/tests/validators.test.ts` coverage for the new schema.

### Testing
- Frontend unit tests (targeted new suite): ran `cd frontend && npm run test -- src/test/receiptOcrClient.test.ts` and the new tests passed (2 tests passed).
- Worker tests: ran `cd price-api && npm test` and all validator tests passed (5 tests passed).
- Type checks: ran `cd price-api && npm run typecheck` and the price-api TypeScript check succeeded; ran `cd frontend && npx tsc --noEmit` which failed due to many pre-existing, repository-wide TypeScript issues unrelated to the changes in this PR (no frontend-type changes introduced that caused these errors).
- Smoke / manual render: started the frontend dev server and captured a screenshot of the new `/receipt-ingest` page to validate the UI flow (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995295d029c83219630d7c9c5fed0ad)