### PR TITLE
Add internal cashier storage and stable hashing primitives

### DIFF
--- a/price-api/migrations/0006_cashier_fields.sql
+++ b/price-api/migrations/0006_cashier_fields.sql
@@ -1,0 +1,5 @@
+ALTER TABLE receipt_jobs ADD COLUMN cashier_label_raw TEXT;
+ALTER TABLE receipt_jobs ADD COLUMN cashier_hash TEXT;
+ALTER TABLE receipt_jobs ADD COLUMN cashier_operator_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_receipt_jobs_cashier_hash ON receipt_jobs(cashier_hash);

--- a/price-api/src/db.ts
+++ b/price-api/src/db.ts
@@ -435,3 +435,18 @@ export async function applySimpleRateLimit(
   await db.prepare('UPDATE rate_limits SET count = count + 1 WHERE key = ?').bind(key).run();
   return true;
 }
+
+export async function updateReceiptJobCashier(
+  db: D1Database,
+  jobId: string,
+  fields: { cashierLabelRaw: string | null; cashierHash: string | null; cashierOperatorId: string | null },
+): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE receipt_jobs
+       SET cashier_label_raw = ?, cashier_hash = ?, cashier_operator_id = ?
+       WHERE id = ?`,
+    )
+    .bind(fields.cashierLabelRaw, fields.cashierHash, fields.cashierOperatorId, jobId)
+    .run();
+}

--- a/price-api/src/pii/hash.ts
+++ b/price-api/src/pii/hash.ts
@@ -1,0 +1,11 @@
+export async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export async function stableCashierHash(label: string, salt: string): Promise<string> {
+  return sha256Hex(`cashier:${label}::${salt}`);
+}

--- a/price-api/src/receipt/normalize.ts
+++ b/price-api/src/receipt/normalize.ts
@@ -1,0 +1,27 @@
+export interface ExtractedCashierLabel {
+  label: string | null;
+  operatorId: string | null;
+}
+
+export function extractCashierLabel(text: string): ExtractedCashierLabel {
+  const clean = text.replace(/\r/g, '\n');
+
+  const explicitMatch = clean.match(/(?:CAISSI(?:ER|ERE)|H[ÔO]TE(?:SSE)?)[\s:]*([A-Z][A-Z' -]{2,}(?:\s*\(\d+\))?)/);
+  if (explicitMatch?.[1]) {
+    const label = explicitMatch[1].trim();
+    const operatorId = label.match(/\((\d+)\)/)?.[1] ?? null;
+    return { label, operatorId };
+  }
+
+  const anchorIndex = clean.search(/Ticket\s*n|Caisse/i);
+  const ticketWindow = anchorIndex >= 0 ? clean.slice(anchorIndex, anchorIndex + 250) : clean.slice(0, 400);
+  const isolatedMatch = ticketWindow.match(/\n\s*([A-Z][A-Z' -]{2,})(?:\s*\((\d{1,4})\))\s*\n/);
+  if (isolatedMatch?.[1]) {
+    return {
+      label: `${isolatedMatch[1].trim()}${isolatedMatch[2] ? ` (${isolatedMatch[2]})` : ''}`,
+      operatorId: isolatedMatch[2] ?? null,
+    };
+  }
+
+  return { label: null, operatorId: null };
+}

--- a/price-api/src/types.ts
+++ b/price-api/src/types.ts
@@ -12,7 +12,20 @@ export interface Env {
   PRICE_DB: D1Database;
   PRICE_ADMIN_TOKEN: string;
   ALLOWED_ORIGINS?: string;
+  CASHIER_HASH_SALT?: string;
   PRICE_IMPORTS: R2Bucket;
+}
+
+export type ReceiptJobStatus = 'created' | 'processing' | 'completed' | 'failed';
+
+export interface ReceiptJobRecord {
+  id: string;
+  status: ReceiptJobStatus;
+  territory: string;
+  createdAt: string;
+  cashierLabelRaw?: string | null;
+  cashierHash?: string | null;
+  cashierOperatorId?: string | null;
 }
 
 export interface ProductRecord {

--- a/price-api/tests/receiptNormalize.test.ts
+++ b/price-api/tests/receiptNormalize.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { stableCashierHash } from '../src/pii/hash';
+import { extractCashierLabel } from '../src/receipt/normalize';
+
+describe('extractCashierLabel', () => {
+  it('extracts explicit cashier label and operator id', () => {
+    const text = 'MAGASIN XYZ\nCAISSIERE: DUPONT (12)\nTOTAL';
+    expect(extractCashierLabel(text)).toEqual({
+      label: 'DUPONT (12)',
+      operatorId: '12',
+    });
+  });
+
+  it('extracts isolated name around ticket anchor', () => {
+    const text = 'Ticket n° 991\n\nMARTIN (7)\nArticle A';
+    expect(extractCashierLabel(text)).toEqual({
+      label: 'MARTIN (7)',
+      operatorId: '7',
+    });
+  });
+
+  it('returns null when no cashier-like info is found', () => {
+    expect(extractCashierLabel('Aucun caissier ici')).toEqual({
+      label: null,
+      operatorId: null,
+    });
+  });
+});
+
+describe('stableCashierHash', () => {
+  it('returns stable hash for same label and salt', async () => {
+    const a = await stableCashierHash('DUPONT (12)', 'salt');
+    const b = await stableCashierHash('DUPONT (12)', 'salt');
+    const c = await stableCashierHash('DURAND (12)', 'salt');
+
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+    expect(a).toBe(b);
+    expect(c).not.toBe(a);
+  });
+});

--- a/price-api/wrangler.toml
+++ b/price-api/wrangler.toml
@@ -5,6 +5,7 @@ workers_dev = true
 
 [vars]
 ALLOWED_ORIGINS = "http://localhost:5173,http://127.0.0.1:5173"
+CASHIER_HASH_SALT = "CHANGE_ME_LONG_RANDOM"
 
 [[d1_databases]]
 binding = "PRICE_DB"


### PR DESCRIPTION
### Motivation
- Persist cashier information extracted from receipt OCR as internal-only fields to allow admin inspection and aggregated stats while avoiding public exposure. 
- Store a stable, salted hash of the cashier label to enable privacy-preserving filtering/aggregation and support future purge policies. 
- Provide parsing and hashing primitives so the OCR pipeline can capture cashier info before redaction and update `receipt_jobs` atomically.

### Description
- Add D1 migration `price-api/migrations/0006_cashier_fields.sql` to add `cashier_label_raw`, `cashier_hash`, and `cashier_operator_id` to `receipt_jobs` and create an index on `cashier_hash`. 
- Expose `CASHIER_HASH_SALT` in `price-api/wrangler.toml` vars for local/testing (should be stored as a secret in production). 
- Extend `Env` with `CASHIER_HASH_SALT` and introduce `ReceiptJobRecord` / `ReceiptJobStatus` types in `price-api/src/types.ts` for internal use only. 
- Add DB helper `updateReceiptJobCashier(...)` in `price-api/src/db.ts` to write the cashier-related fields to `receipt_jobs`. 
- Add stable hashing helpers in `price-api/src/pii/hash.ts` (`sha256Hex` and `stableCashierHash`) to compute a salted SHA-256 hex fingerprint. 
- Add cashier extraction logic `extractCashierLabel(...)` in `price-api/src/receipt/normalize.ts` with explicit and contextual patterns to extract label and operator id from OCR text. 
- Add unit tests `price-api/tests/receiptNormalize.test.ts` covering extraction and hash stability.

### Testing
- Ran unit tests with `npm --prefix price-api test`, all tests passed (`3 files, 12 tests`). 
- Ran TypeScript typecheck with `npm --prefix price-api run typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699532c20fcc8321ba948862a7bd50ad)