### PR TITLE
feat(scanner): continuous scan for dev scanner + shared hook

### DIFF
--- a/frontend/src/hooks/useContinuousBarcodeScanner.ts
+++ b/frontend/src/hooks/useContinuousBarcodeScanner.ts
@@ -1,0 +1,414 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { lookupProductByEan } from '../services/eanProductService';
+import { toProductViewModel } from '../services/productViewModelService';
+import type { DataSource, Territoire } from '../types/ean';
+import { useTiPanier } from './useTiPanier';
+
+export type ScanStatus = 'loading' | 'ok' | 'not_found' | 'error';
+
+export type ResolvedProduct = {
+  name: string;
+  brand?: string;
+  imageUrl?: string;
+  price?: number;
+};
+
+export type ScanResultItem = {
+  id: string;
+  barcode: string;
+  status: ScanStatus;
+  detectedAt: string;
+  product?: ResolvedProduct;
+  errorMessage?: string;
+};
+
+type BarcodeDetectorFormat = 'ean_13' | 'ean_8' | 'upc_a' | 'upc_e';
+
+type BarcodeDetectorLike = {
+  detect: (source: HTMLVideoElement) => Promise<Array<{ rawValue?: string }>>;
+};
+
+type BarcodeDetectorConstructor = new (options?: { formats?: BarcodeDetectorFormat[] }) => BarcodeDetectorLike;
+
+const SUPPORTED_FORMATS: BarcodeDetectorFormat[] = ['ean_13', 'ean_8', 'upc_a', 'upc_e'];
+const DEFAULT_LOOKUP_TERRITORY: Territoire = 'martinique';
+const RESULT_LIMIT = 50;
+
+declare global {
+  interface Window {
+    BarcodeDetector?: BarcodeDetectorConstructor;
+  }
+}
+
+function uid() {
+  return Math.random().toString(16).slice(2) + Date.now().toString(16);
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function parseDisplayPrice(displayPrice?: string) {
+  if (!displayPrice) return undefined;
+  const normalized = displayPrice.replace(',', '.').match(/\d+(?:\.\d+)?/);
+  if (!normalized) return undefined;
+  const value = Number.parseFloat(normalized[0]);
+  return Number.isFinite(value) ? value : undefined;
+}
+
+export async function resolveBarcode(
+  barcode: string,
+  territoire: Territoire = DEFAULT_LOOKUP_TERRITORY,
+  source: DataSource = 'scan_utilisateur',
+): Promise<ResolvedProduct | null> {
+  if (!barcode) return null;
+
+  const result = await lookupProductByEan(barcode, {
+    territoire,
+    source,
+  });
+
+  if (!result.success || !result.product || result.product.status === 'non_référencé') {
+    return null;
+  }
+
+  const viewModel = toProductViewModel(result.product);
+
+  return {
+    name: viewModel.nom,
+    brand: viewModel.marque !== 'Non spécifiée' ? viewModel.marque : undefined,
+    imageUrl: viewModel.imageUrl,
+    price: parseDisplayPrice(viewModel.prix),
+  };
+}
+
+type UseContinuousBarcodeScannerOptions = {
+  territoire?: Territoire;
+  source?: DataSource;
+  debug?: boolean;
+  stabilityThreshold?: number;
+  cooldownMs?: number;
+  sameCodeLockMs?: number;
+};
+
+export type ContinuousScannerDebugInfo = {
+  status: 'idle' | 'starting' | 'scanning' | 'paused' | 'error';
+  lastCode: string | null;
+  stableCounter: number;
+  secondsSinceLastDetection: number | null;
+};
+
+export function useContinuousBarcodeScanner(options: UseContinuousBarcodeScannerOptions = {}) {
+  const {
+    territoire = DEFAULT_LOOKUP_TERRITORY,
+    source = 'scan_utilisateur',
+    debug = false,
+    stabilityThreshold = 1,
+    cooldownMs = 900,
+    sameCodeLockMs = 2500,
+  } = options;
+
+  const { addItem } = useTiPanier();
+
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  const lastAcceptedRef = useRef<{ code: string; at: number }>({ code: '', at: 0 });
+  const lastRawCodeRef = useRef<string | null>(null);
+  const stableCountRef = useRef(0);
+  const lastDetectedAtRef = useRef<number | null>(null);
+
+  const [cameraError, setCameraError] = useState<string | null>(null);
+  const [barcodeSupport, setBarcodeSupport] = useState<boolean>(true);
+  const [scanActive, setScanActive] = useState(true);
+  const [results, setResults] = useState<ScanResultItem[]>([]);
+  const [autoAddToCart, setAutoAddToCart] = useState(false);
+  const [scannerStatus, setScannerStatus] = useState<ContinuousScannerDebugInfo['status']>('idle');
+  const [debugLastCode, setDebugLastCode] = useState<string | null>(null);
+  const [debugStableCounter, setDebugStableCounter] = useState(0);
+  const [secondsSinceLastDetection, setSecondsSinceLastDetection] = useState<number | null>(null);
+
+  const clear = useCallback(() => setResults([]), []);
+
+  const removeItem = useCallback((id: string) => {
+    setResults((prev) => prev.filter((item) => item.id !== id));
+  }, []);
+
+  const addToCart = useCallback((product: ResolvedProduct, barcode: string) => {
+    addItem({
+      id: barcode,
+      quantity: 1,
+      meta: {
+        name: product.name,
+        brand: product.brand,
+        price: product.price,
+        barcode,
+      },
+    });
+  }, [addItem]);
+
+  const okItems = useMemo(
+    () => results.filter((item) => item.status === 'ok' && item.product),
+    [results],
+  );
+
+  const addAllOk = useCallback(() => {
+    okItems.forEach((item) => {
+      if (item.product) {
+        addToCart(item.product, item.barcode);
+      }
+    });
+  }, [addToCart, okItems]);
+
+  const addItemToCart = useCallback((id: string) => {
+    const target = results.find((item) => item.id === id);
+    if (target?.product) {
+      addToCart(target.product, target.barcode);
+    }
+  }, [addToCart, results]);
+
+  useEffect(() => {
+    setBarcodeSupport(typeof window !== 'undefined' && typeof window.BarcodeDetector === 'function');
+  }, []);
+
+  useEffect(() => {
+    if (!debug) return;
+
+    const timer = window.setInterval(() => {
+      if (lastDetectedAtRef.current === null) {
+        setSecondsSinceLastDetection(null);
+        return;
+      }
+
+      const delta = Math.max(0, Math.floor((Date.now() - lastDetectedAtRef.current) / 1000));
+      setSecondsSinceLastDetection(delta);
+    }, 500);
+
+    return () => window.clearInterval(timer);
+  }, [debug]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const stop = () => {
+      if (rafRef.current !== null) {
+        window.cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+
+      if (streamRef.current) {
+        streamRef.current.getTracks().forEach((track) => track.stop());
+        streamRef.current = null;
+      }
+
+      if (videoRef.current) {
+        videoRef.current.pause();
+        videoRef.current.srcObject = null;
+      }
+
+      setScannerStatus(scanActive ? 'idle' : 'paused');
+    };
+
+    if (!scanActive) {
+      stop();
+      return stop;
+    }
+
+    const onDetected = async (rawCode: string) => {
+      const barcode = rawCode.replace(/\D/g, '').trim();
+      if (!/^\d{8,14}$/.test(barcode)) return;
+
+      if (barcode === lastRawCodeRef.current) {
+        stableCountRef.current += 1;
+      } else {
+        lastRawCodeRef.current = barcode;
+        stableCountRef.current = 1;
+      }
+
+      if (debug) {
+        setDebugLastCode(barcode);
+        setDebugStableCounter(stableCountRef.current);
+      }
+
+      if (stableCountRef.current < Math.max(1, stabilityThreshold)) {
+        return;
+      }
+
+      const now = Date.now();
+      const lastAccepted = lastAcceptedRef.current;
+      if (now - lastAccepted.at < cooldownMs) return;
+      if (lastAccepted.code === barcode && now - lastAccepted.at < sameCodeLockMs) return;
+
+      lastAcceptedRef.current = { code: barcode, at: now };
+      lastDetectedAtRef.current = now;
+
+      const id = uid();
+      setResults((prev) => [
+        {
+          id,
+          barcode,
+          status: 'loading',
+          detectedAt: nowIso(),
+        },
+        ...prev,
+      ].slice(0, RESULT_LIMIT));
+
+      try {
+        const product = await resolveBarcode(barcode, territoire, source);
+        setResults((prev) => prev.map((item) => {
+          if (item.id !== id) return item;
+          if (!product) {
+            return { ...item, status: 'not_found' };
+          }
+          return { ...item, status: 'ok', product };
+        }));
+
+        if (product && autoAddToCart) {
+          addToCart(product, barcode);
+        }
+      } catch (error) {
+        setResults((prev) => prev.map((item) => (
+          item.id === id
+            ? {
+                ...item,
+                status: 'error',
+                errorMessage: error instanceof Error ? error.message : 'Erreur inconnue',
+              }
+            : item
+        )));
+      }
+    };
+
+    const start = async () => {
+      setCameraError(null);
+      setScannerStatus('starting');
+
+      if (!navigator.mediaDevices?.getUserMedia) {
+        setCameraError('Caméra non supportée sur cet appareil.');
+        setScannerStatus('error');
+        return;
+      }
+
+      if (!window.BarcodeDetector) {
+        setCameraError('BarcodeDetector indisponible: essayez Chrome/Edge sur mobile récent.');
+        setBarcodeSupport(false);
+        setScannerStatus('error');
+        return;
+      }
+
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: {
+            facingMode: { ideal: 'environment' },
+            width: { ideal: 1280 },
+            height: { ideal: 720 },
+          },
+          audio: false,
+        });
+
+        if (cancelled) {
+          stream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+
+        streamRef.current = stream;
+
+        if (!videoRef.current) return;
+        videoRef.current.srcObject = stream;
+        videoRef.current.muted = true;
+        videoRef.current.autoplay = true;
+        videoRef.current.setAttribute('playsinline', 'true');
+
+        await videoRef.current.play();
+
+        const detector = new window.BarcodeDetector({ formats: SUPPORTED_FORMATS });
+        setScannerStatus('scanning');
+
+        const loop = async () => {
+          if (cancelled || !videoRef.current) {
+            return;
+          }
+
+          try {
+            const matches = await detector.detect(videoRef.current);
+            const rawValue = matches[0]?.rawValue?.trim();
+            if (rawValue) {
+              void onDetected(rawValue);
+            }
+          } catch {
+            // Frame-level detect errors are non-blocking.
+          }
+
+          rafRef.current = window.requestAnimationFrame(loop);
+        };
+
+        rafRef.current = window.requestAnimationFrame(loop);
+      } catch (error) {
+        setCameraError(error instanceof Error ? error.message : 'Impossible d’ouvrir la caméra.');
+        setScannerStatus('error');
+      }
+    };
+
+    void start();
+
+    return () => {
+      cancelled = true;
+      stop();
+    };
+  }, [
+    addToCart,
+    autoAddToCart,
+    cooldownMs,
+    debug,
+    sameCodeLockMs,
+    scanActive,
+    source,
+    stabilityThreshold,
+    territoire,
+  ]);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        setScanActive(false);
+      }
+    };
+
+    const handlePageHide = () => {
+      setScanActive(false);
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('pagehide', handlePageHide);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('pagehide', handlePageHide);
+    };
+  }, []);
+
+  return {
+    videoRef,
+    cameraError,
+    barcodeSupport,
+    scanActive,
+    setScanActive,
+    results,
+    clear,
+    removeItem,
+    addAllOk,
+    addItemToCart,
+    okItems,
+    autoAddToCart,
+    setAutoAddToCart,
+    debugInfo: {
+      status: scannerStatus,
+      lastCode: debugLastCode,
+      stableCounter: debugStableCounter,
+      secondsSinceLastDetection,
+    } as ContinuousScannerDebugInfo,
+  };
+}
+
+export { DEFAULT_LOOKUP_TERRITORY };

--- a/frontend/src/pages/ScannerHub.tsx
+++ b/frontend/src/pages/ScannerHub.tsx
@@ -1,301 +1,139 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { BrowserMultiFormatReader } from '@zxing/browser';
-import { useNavigate } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
+import {
+  DEFAULT_LOOKUP_TERRITORY,
+  useContinuousBarcodeScanner,
+  type ScanStatus,
+} from '../hooks/useContinuousBarcodeScanner';
+import type { Territoire } from '../types/ean';
 
-type ScanStatus =
-  | 'idle'
-  | 'permissionDenied'
-  | 'cameraNotFound'
-  | 'scanning'
-  | 'notDetectedTimeout'
-  | 'success'
-  | 'errorNetwork'
-  | 'notFound';
+const TERRITORIES: Territoire[] = [
+  'guadeloupe',
+  'martinique',
+  'guyane',
+  'reunion',
+  'mayotte',
+  'polynesie',
+  'nouvelle_caledonie',
+  'wallis_et_futuna',
+  'saint_martin',
+  'saint_barthelemy',
+  'saint_pierre_et_miquelon',
+];
 
-type ScannerControls = {
-  stop: () => void;
-  switchTorch?: (on: boolean) => Promise<void>;
-};
+function getTerritoire(value: string | null): Territoire {
+  if (value && TERRITORIES.includes(value as Territoire)) {
+    return value as Territoire;
+  }
 
-const EAN_REGEX = /^[0-9]{8,14}$/;
-const SCAN_TIMEOUT_MS = 10_000;
-const SUCCESS_LOCK_MS = 1_500;
-const UI_COOLDOWN_MS = 1_500;
+  return DEFAULT_LOOKUP_TERRITORY;
+}
+
+function StatusBadge({ status }: { status: ScanStatus }) {
+  const tone =
+    status === 'ok'
+      ? 'bg-emerald-500/20 border-emerald-400/50 text-emerald-200'
+      : status === 'loading'
+        ? 'bg-blue-500/20 border-blue-400/50 text-blue-200'
+        : status === 'not_found'
+          ? 'bg-amber-500/20 border-amber-400/50 text-amber-200'
+          : 'bg-rose-500/20 border-rose-400/50 text-rose-200';
+
+  const label = status === 'loading' ? '…' : status === 'ok' ? 'OK' : status === 'not_found' ? 'VIDE' : 'ERR';
+
+  return (
+    <span className={`inline-flex h-6 min-w-11 items-center justify-center rounded-full border px-2 text-xs font-semibold ${tone}`}>
+      {label}
+    </span>
+  );
+}
 
 export default function ScannerHub() {
-  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const debugEnabled = searchParams.get('debug') === '1';
 
-  const videoRef = useRef<HTMLVideoElement | null>(null);
-  const readerRef = useRef<BrowserMultiFormatReader | null>(null);
-  const controlsRef = useRef<ScannerControls | null>(null);
-  const streamRef = useRef<MediaStream | null>(null);
-  const timeoutRef = useRef<number | null>(null);
-  const successLockRef = useRef<number | null>(null);
-  const startingRef = useRef(false);
-  const lastUiEmitRef = useRef<{ code: string; at: number } | null>(null);
-
-  const [status, setStatus] = useState<ScanStatus>('idle');
-  const [lastDetectedCode, setLastDetectedCode] = useState<string | null>(null);
-  const [stableCounter, setStableCounter] = useState(0);
-  const [manualInputVisible, setManualInputVisible] = useState(false);
-  const [manualEAN, setManualEAN] = useState('');
-  const [manualError, setManualError] = useState<string | null>(null);
-  const [torchSupported, setTorchSupported] = useState(false);
-  const [torchEnabled, setTorchEnabled] = useState(false);
-  const [successOverlayVisible, setSuccessOverlayVisible] = useState(false);
-  const [isScanning, setIsScanning] = useState(false);
-  const [isStarting, setIsStarting] = useState(false);
-
-  const stopCamera = useCallback(() => {
-    controlsRef.current?.stop();
-    controlsRef.current = null;
-
-    if (timeoutRef.current !== null) {
-      window.clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
-    }
-
-    const stream = streamRef.current ?? (videoRef.current?.srcObject instanceof MediaStream ? videoRef.current.srcObject : null);
-    if (stream) {
-      stream.getTracks().forEach((track) => track.stop());
-      streamRef.current = null;
-    }
-
-    if (videoRef.current) {
-      videoRef.current.srcObject = null;
-    }
-
-    setIsScanning(false);
-    setTorchEnabled(false);
-    setTorchSupported(false);
-  }, []);
-
-  const canFinalize = () => successLockRef.current === null;
-
-  const finalizeScan = useCallback(
-    (rawCode: string) => {
-      if (!canFinalize()) {
-        return;
-      }
-
-      const code = rawCode.replace(/\D/g, '');
-      if (!EAN_REGEX.test(code)) {
-        setStatus('notFound');
-        return;
-      }
-
-      successLockRef.current = window.setTimeout(() => {
-        successLockRef.current = null;
-      }, SUCCESS_LOCK_MS);
-
-      if (typeof navigator !== 'undefined' && 'vibrate' in navigator) {
-        navigator.vibrate(200);
-      }
-
-      setStatus('success');
-      setSuccessOverlayVisible(true);
-      stopCamera();
-
-      window.setTimeout(() => {
-        navigate(`/product/${code}`);
-      }, SUCCESS_LOCK_MS);
-    },
-    [navigate, stopCamera]
+  const territoire = useMemo(
+    () => getTerritoire(searchParams.get('territoire')),
+    [searchParams],
   );
 
-  const detectTorchSupport = useCallback(() => {
-    const stream = streamRef.current;
-    if (!stream) {
-      setTorchSupported(false);
-      return;
-    }
-
-    const [track] = stream.getVideoTracks();
-    if (!track || typeof track.getCapabilities !== 'function') {
-      setTorchSupported(false);
-      return;
-    }
-
-    const capabilities = track.getCapabilities() as { torch?: boolean };
-    setTorchSupported(Boolean(capabilities.torch));
-  }, []);
-
-  const resetForNewScan = useCallback(() => {
-    setLastDetectedCode(null);
-    setStableCounter(0);
-    setManualError(null);
-    setSuccessOverlayVisible(false);
-    if (status !== 'permissionDenied' && status !== 'cameraNotFound') {
-      setStatus('idle');
-    }
-  }, [status]);
-
-  const startCamera = useCallback(async () => {
-    if (startingRef.current || isScanning) {
-      return;
-    }
-
-    startingRef.current = true;
-    setIsStarting(true);
-
-    stopCamera();
-    resetForNewScan();
-    setManualInputVisible(false);
-
-    if (!videoRef.current || !navigator.mediaDevices?.getUserMedia) {
-      setStatus('cameraNotFound');
-      startingRef.current = false;
-      setIsStarting(false);
-      return;
-    }
-
-    try {
-      if (!readerRef.current) {
-        readerRef.current = new BrowserMultiFormatReader();
-      }
-
-      setStatus('scanning');
-      setIsScanning(true);
-
-      const controls = await readerRef.current.decodeFromConstraints(
-        {
-          video: { facingMode: { ideal: 'environment' } },
-          audio: false,
-        },
-        videoRef.current,
-        (result) => {
-          const text = result?.getText()?.trim();
-          if (!text) {
-            return;
-          }
-
-          const code = text.replace(/\D/g, '');
-          if (!EAN_REGEX.test(code)) {
-            return;
-          }
-
-          const now = Date.now();
-          const lastUiEmit = lastUiEmitRef.current;
-          if (lastUiEmit && lastUiEmit.code === code && now - lastUiEmit.at < UI_COOLDOWN_MS) {
-            return;
-          }
-
-          lastUiEmitRef.current = { code, at: now };
-
-          setLastDetectedCode((previousCode) => {
-            if (previousCode === code) {
-              setStableCounter((previousCounter) => {
-                return previousCounter + 1;
-              });
-              return previousCode;
-            }
-
-            setStableCounter(1);
-            return code;
-          });
-
-          setStatus('scanning');
-        }
-      );
-
-      controlsRef.current = controls as ScannerControls;
-
-      const media = videoRef.current.srcObject;
-      if (media instanceof MediaStream) {
-        streamRef.current = media;
-        detectTorchSupport();
-      }
-
-      timeoutRef.current = window.setTimeout(() => {
-        if (canFinalize()) {
-          setStatus('notDetectedTimeout');
-          setManualInputVisible(true);
-        }
-      }, SCAN_TIMEOUT_MS);
-    } catch (error) {
-      stopCamera();
-      const message = error instanceof Error ? error.message : '';
-
-      if (/permission|denied|notallowed/i.test(message)) {
-        setStatus('permissionDenied');
-        setManualInputVisible(true);
-        return;
-      }
-
-      if (/notfound|overconstrained|devices/i.test(message)) {
-        setStatus('cameraNotFound');
-        setManualInputVisible(true);
-        return;
-      }
-
-      setStatus('errorNetwork');
-      setManualInputVisible(true);
-    } finally {
-      startingRef.current = false;
-      setIsStarting(false);
-    }
-  }, [detectTorchSupport, isScanning, resetForNewScan, stopCamera]);
-
-  const handleManualSearch = useCallback(() => {
-    const normalized = manualEAN.replace(/\D/g, '');
-
-    if (!EAN_REGEX.test(normalized)) {
-      setManualError('Code EAN invalide. Entrez 8 à 14 chiffres.');
-      return;
-    }
-
-    setManualError(null);
-    finalizeScan(normalized);
-  }, [finalizeScan, manualEAN]);
-
-  const toggleTorch = useCallback(async () => {
-    const controls = controlsRef.current;
-    if (!controls || typeof controls.switchTorch !== 'function' || !torchSupported) {
-      return;
-    }
-
-    const nextState = !torchEnabled;
-    await controls.switchTorch(nextState);
-    setTorchEnabled(nextState);
-  }, [torchEnabled, torchSupported]);
-
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.hidden) {
-        stopCamera();
-      }
-    };
-
-    const handlePageHide = () => {
-      stopCamera();
-    };
-
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-    window.addEventListener('pagehide', handlePageHide);
-
-    return () => {
-      stopCamera();
-
-      if (successLockRef.current !== null) {
-        window.clearTimeout(successLockRef.current);
-        successLockRef.current = null;
-      }
-
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-      window.removeEventListener('pagehide', handlePageHide);
-    };
-  }, [stopCamera]);
+  const {
+    videoRef,
+    cameraError,
+    barcodeSupport,
+    scanActive,
+    setScanActive,
+    results,
+    clear,
+    removeItem,
+    addAllOk,
+    addItemToCart,
+    okItems,
+    autoAddToCart,
+    setAutoAddToCart,
+    debugInfo,
+  } = useContinuousBarcodeScanner({
+    territoire,
+    debug: debugEnabled,
+    stabilityThreshold: 2,
+  });
 
   return (
     <>
       <Helmet>
         <title>Scanner - A KI PRI SA YÉ</title>
+        <meta name="description" content="Scanner continu: code-barres avec historique et ajout rapide au panier" />
       </Helmet>
 
       <main className="min-h-screen bg-slate-950 p-4 pt-24 text-white">
-        <section className="mx-auto w-full max-w-2xl rounded-2xl border border-slate-800 bg-slate-900 p-4">
+        <section className="mx-auto w-full max-w-4xl rounded-2xl border border-slate-800 bg-slate-900 p-4">
           <h1 className="mb-3 text-2xl font-semibold">Scanner un code-barres</h1>
+          <p className="mb-4 text-sm text-slate-300">
+            Scan continu actif: caméra en boucle, anti-doublon et ajout rapide au panier.
+          </p>
+
+          <div className="mb-4 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => setScanActive((value) => !value)}
+              className="rounded-lg bg-blue-600 px-5 py-3 text-base font-semibold text-white hover:bg-blue-700"
+              aria-pressed={scanActive}
+              aria-label={scanActive ? 'Mettre le scan en pause' : 'Démarrer le scan'}
+            >
+              {scanActive ? 'Pause scan' : 'Start scan'}
+            </button>
+
+            <label className="inline-flex items-center gap-2 rounded-lg border border-slate-500 px-4 py-3 text-sm font-semibold">
+              <input
+                type="checkbox"
+                checked={autoAddToCart}
+                onChange={(event) => setAutoAddToCart(event.target.checked)}
+                aria-label="Activer l’ajout automatique au panier pour les résultats OK"
+              />
+              Ajout auto au panier (OK)
+            </label>
+
+            <button
+              type="button"
+              onClick={addAllOk}
+              disabled={okItems.length === 0}
+              className="rounded-lg border border-emerald-500/60 px-4 py-3 text-sm font-semibold text-emerald-200 disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label={`Ajouter tous les produits valides au panier (${okItems.length})`}
+            >
+              Ajouter tous les OK ({okItems.length})
+            </button>
+
+            <button
+              type="button"
+              onClick={clear}
+              disabled={results.length === 0}
+              className="rounded-lg border border-rose-500/60 px-4 py-3 text-sm font-semibold text-rose-200 disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label={`Vider la liste des résultats (${results.length})`}
+            >
+              Vider ({results.length})
+            </button>
+          </div>
 
           <div className="relative overflow-hidden rounded-xl border border-slate-700 bg-black">
             <video
@@ -303,115 +141,96 @@ export default function ScannerHub() {
               playsInline
               muted
               autoPlay
-              className="aspect-video w-full"
+              className="aspect-video w-full object-cover"
               aria-label="Caméra de scan"
             />
-
-            {successOverlayVisible && (
-              <div className="absolute inset-0 flex items-center justify-center bg-emerald-600/80 text-xl font-semibold">
-                Succès
-              </div>
-            )}
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+              <div className="h-[45%] w-[70%] rounded-xl border-2 border-white/60" />
+            </div>
+            <div className="absolute left-3 top-3 rounded-full bg-black/50 px-3 py-1 text-xs text-white">
+              Caméra: {scanActive ? 'ACTIVE' : 'PAUSE'}
+            </div>
           </div>
 
-          <div className="mt-4 flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={() => void startCamera()}
-              disabled={isScanning || isStarting}
-              className={`rounded-lg px-5 py-3 text-base font-semibold text-white ${isScanning || isStarting ? 'bg-slate-600' : 'bg-blue-600 hover:bg-blue-700'}`}
-            >
-              Activer la caméra
-            </button>
-
-            <button
-              type="button"
-              onClick={stopCamera}
-              className="rounded-lg border border-red-500 px-5 py-3 text-base font-semibold text-red-100"
-            >
-              Stop caméra
-            </button>
-
-            <button
-              type="button"
-              onClick={() => {
-                stopCamera();
-                setManualInputVisible(true);
-              }}
-              className="rounded-lg border border-slate-500 px-5 py-3 text-base font-semibold"
-            >
-              Saisir manuellement
-            </button>
-
-            {torchSupported && isScanning && (
-              <button
-                type="button"
-                onClick={() => void toggleTorch()}
-                className="rounded-lg border border-amber-400 px-5 py-3 text-base font-semibold text-amber-100"
-              >
-                {torchEnabled ? 'Lampe: ON' : 'Lampe'}
-              </button>
-            )}
+          <div className="mt-3 text-sm text-slate-300">
+            {!barcodeSupport && 'BarcodeDetector non disponible sur ce navigateur.'}
+            {cameraError && <div className="text-rose-300">{cameraError}</div>}
+            {!cameraError && barcodeSupport && 'Astuce: gardez le code au centre 1-2 secondes pour stabiliser la détection.'}
           </div>
 
-          <div className="mt-4 space-y-1 text-sm text-slate-300">
-            <p>État: {status}</p>
-            <p>Dernier code: {lastDetectedCode ?? '—'}</p>
-            <p>Validation stable: {stableCounter}/2</p>
-          </div>
-
-          {status === 'permissionDenied' && (
-            <p className="mt-3 rounded-lg border border-red-700 bg-red-500/10 p-3 text-sm text-red-200">
-              Permission caméra refusée. Utilisez la saisie manuelle.
-            </p>
-          )}
-
-          {status === 'cameraNotFound' && (
-            <p className="mt-3 rounded-lg border border-red-700 bg-red-500/10 p-3 text-sm text-red-200">
-              Caméra introuvable ou indisponible.
-            </p>
-          )}
-
-          {status === 'notDetectedTimeout' && (
-            <p className="mt-3 rounded-lg border border-amber-700 bg-amber-500/10 p-3 text-sm text-amber-200">
-              Aucun code détecté après 10 secondes. Vous pouvez saisir le code EAN.
-            </p>
-          )}
-
-          {(status === 'errorNetwork' || status === 'notFound') && (
-            <p className="mt-3 rounded-lg border border-red-700 bg-red-500/10 p-3 text-sm text-red-200">
-              Erreur pendant le scan. Passez par la saisie manuelle.
-            </p>
-          )}
-
-          {manualInputVisible && (
-            <div className="mt-4 rounded-xl border border-slate-700 p-3">
-              <label htmlFor="manual-ean" className="mb-2 block text-sm font-medium">
-                Code EAN (8 à 14 chiffres)
-              </label>
-              <div className="flex flex-col gap-2 sm:flex-row">
-                <input
-                  id="manual-ean"
-                  value={manualEAN}
-                  onChange={(event) => {
-                    setManualEAN(event.target.value.replace(/\D/g, ''));
-                    setManualError(null);
-                  }}
-                  inputMode="numeric"
-                  className="flex-1 rounded-lg border border-slate-600 bg-slate-950 px-3 py-3"
-                  placeholder="3017620422003"
-                />
-                <button
-                  type="button"
-                  onClick={handleManualSearch}
-                  className="rounded-lg bg-emerald-600 px-5 py-3 text-base font-semibold hover:bg-emerald-700"
-                >
-                  Rechercher
-                </button>
-              </div>
-              {manualError && <p className="mt-2 text-sm text-red-300">{manualError}</p>}
+          {debugEnabled && (
+            <div className="mt-4 rounded-xl border border-amber-500/50 bg-amber-500/10 p-3 text-sm text-amber-100">
+              <p><strong>Mode debug</strong> (debug=1)</p>
+              <p>État: {debugInfo.status}</p>
+              <p>Dernier code: {debugInfo.lastCode ?? '—'}</p>
+              <p>Validation stable: {debugInfo.stableCounter}/2</p>
+              <p>
+                Aucun code détecté depuis:{' '}
+                {debugInfo.secondsSinceLastDetection === null
+                  ? '—'
+                  : `${debugInfo.secondsSinceLastDetection} s`}
+              </p>
             </div>
           )}
+
+          <div className="mt-6">
+            <div className="mb-3 text-lg font-semibold text-white">Résultats (scan continu)</div>
+
+            {results.length === 0 ? (
+              <div className="rounded-xl border border-slate-800 bg-slate-900/50 p-4 text-sm text-gray-400">
+                Aucun scan pour l'instant.
+              </div>
+            ) : (
+              <div className="grid gap-3">
+                {results.map((item) => (
+                  <div
+                    key={item.id}
+                    className="flex flex-col justify-between gap-3 rounded-xl border border-slate-800 bg-slate-900/50 p-4 md:flex-row md:items-center"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-mono text-sm text-white">{item.barcode}</span>
+                        <StatusBadge status={item.status} />
+                        <span className="text-xs text-gray-500">{new Date(item.detectedAt).toLocaleString()}</span>
+                      </div>
+                      <div className="mt-2 text-sm text-gray-300">
+                        {item.status === 'loading' && 'Recherche…'}
+                        {item.status === 'not_found' && 'Produit non référencé.'}
+                        {item.status === 'error' && (item.errorMessage || 'Erreur inconnue.')}
+                        {item.status === 'ok' && item.product && (
+                          <>
+                            <span className="font-semibold text-white">{item.product.name}</span>
+                            {item.product.brand ? <span> — {item.product.brand}</span> : null}
+                          </>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="flex shrink-0 gap-2">
+                      <button
+                        type="button"
+                        onClick={() => addItemToCart(item.id)}
+                        disabled={item.status !== 'ok' || !item.product}
+                        className="rounded-lg border border-emerald-500/60 px-3 py-2 text-sm font-semibold text-emerald-200 disabled:cursor-not-allowed disabled:opacity-50"
+                        aria-label={`Ajouter ${item.barcode} au panier`}
+                      >
+                        Ajouter au panier
+                      </button>
+
+                      <button
+                        type="button"
+                        onClick={() => removeItem(item.id)}
+                        className="rounded-lg border border-slate-600 px-3 py-2 text-sm font-semibold text-slate-200"
+                        aria-label={`Supprimer la ligne ${item.barcode}`}
+                      >
+                        Supprimer
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </section>
       </main>
     </>

--- a/frontend/src/types/ean.ts
+++ b/frontend/src/types/ean.ts
@@ -35,7 +35,8 @@ export type DataSource =
   | 'base_officielle'         // Official government data
   | 'partenaire_enseigne'     // Retail partner data
   | 'open_food_facts'         // Open Food Facts API
-  | 'manuel';                 // Manual entry
+  | 'manuel'                 // Manual entry
+  | 'scan_utilisateur';      // User barcode scan session
 
 /**
  * EAN Validation Result

--- a/frontend/src/types/productViewModel.ts
+++ b/frontend/src/types/productViewModel.ts
@@ -91,7 +91,8 @@ export const SOURCE_LABELS: Record<DataSource, string> = {
   base_officielle: 'Base officielle',
   partenaire_enseigne: 'Partenaire enseigne',
   open_food_facts: 'Open Food Facts',
-  manuel: 'Saisie manuelle'
+  manuel: 'Saisie manuelle',
+  scan_utilisateur: 'Scan utilisateur'
 };
 
 /**


### PR DESCRIPTION
### Motivation
- Uniformiser le moteur de scan pour la page `/dev/scanner` afin d’utiliser le même scan continu que `ScannerHub` (boucle caméra + anti-doublon + historique + actions panier) tout en conservant le mode debug sans timeout bloquant.

### Description
- Ajout du hook réutilisable `frontend/src/hooks/useContinuousBarcodeScanner.ts` qui expose `{ videoRef, cameraError, barcodeSupport, scanActive, setScanActive, results, clear, removeItem, addAllOk, autoAddToCart, setAutoAddToCart }` et encapsule la boucle `BarcodeDetector`, la logique d’anti-spam (cooldown + same-code lock), la gate de stabilité et la résolution produit via `resolveBarcode()`.
- Migration de `frontend/src/pages/ScannerHub.tsx` pour utiliser le nouveau hook et rendre la preview vidéo, les contrôles start/pause, la liste bornée (50) des résultats, les badges de statut et les actions panier (ajout ligne, ajouter tous OK, vider, supprimer ligne, toggle auto-add).
- Mutualisation de la résolution produit dans `resolveBarcode()` (utilise `lookupProductByEan(barcode, { territoire, source: 'scan_utilisateur' })` puis `toProductViewModel` et mappe les non-référencés en `not_found`).
- TypeScript: ajout de la source `scan_utilisateur` et du label `Scan utilisateur` dans `frontend/src/types/ean.ts` et `frontend/src/types/productViewModel.ts` pour garder la typage cohérent.
- Mode debug conservé (`?debug=1`) mais suppression de l’arrêt automatique `notDetectedTimeout`; on affiche désormais une information passive `Aucun code détecté depuis X s` sans interrompre le flux.

### Testing
- Exécuté `npm run lint` (la commande s’est terminée avec succès et a retourné des warnings préexistants en dehors de ce périmètre).
- Exécuté `npm run build` avec succès (bundle Vite produit sans erreurs).
- Lancement local du serveur de dev et capture automatisée de la page debug via Playwright en `http://127.0.0.1:4173/scanner?debug=1`, avec screenshot généré (`artifacts/scanner-debug-continuous.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995dff7b9888321ba8fdd1b67718428)