### PR TITLE
Improve scanner robustness and OFF product flow; harden CSP, encode navigation links, and tone down StoreDetail visuals

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -9,6 +9,7 @@ export default [
   {
     ignores: [
       'dist/**',
+      'frontend/dist/**',
       'node_modules/**',
       '*.config.js',
       '*.config.ts',

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -1,7 +1,7 @@
 # Security headers
 /*
   X-Frame-Options: DENY
-  Content-Security-Policy: frame-ancestors 'none';
+  Content-Security-Policy: default-src 'self'; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; connect-src 'self' https://world.openfoodfacts.org https://fr.openfoodfacts.org https://*.googleapis.com https://*.firebaseio.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://*.googleusercontent.com https://*.gstatic.com; img-src 'self' data: https://*.openfoodfacts.org https://*.openfoodfacts.net; style-src 'self' 'unsafe-inline'; script-src 'self'; worker-src 'self' blob:;
 
 # HTML: never cache (avoid stale Vite shell)
 /

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,7 +33,7 @@ const AdminLayout = lazyPage(() => import('./pages/admin/AdminLayout'));
 const AdminDashboardNew = lazyPage(() => import('./pages/admin/AdminDashboard'));
 const StoreList = lazyPage(() => import('./pages/admin/stores/StoreList'));
 const StoreForm = lazyPage(() => import('./pages/admin/stores/StoreForm'));
-const StoreDetail = lazyPage(() => import('./pages/admin/stores/StoreDetail'));
+const AdminStoreDetail = lazyPage(() => import('./pages/admin/stores/StoreDetail'));
 const ProductList = lazyPage(() => import('./pages/admin/products/ProductList').then(m => ({ default: m.ProductList })));
 const ProductForm = lazyPage(() => import('./pages/admin/products/ProductForm').then(m => ({ default: m.ProductForm })));
 const ProductDetail = lazyPage(() => import('./pages/admin/products/ProductDetail').then(m => ({ default: m.ProductDetail })));
@@ -67,6 +67,7 @@ const Settings = lazyPage(() => import('./pages/Settings'));
 const HistoriquePrix = lazyPage(() => import('./pages/HistoriquePrix'));
 const RecherchePrix = lazyPage(() => import('./pages/RecherchePrix'));
 const ProductDetailPage = lazyPage(() => import('./pages/ProductDetail'));
+const PublicStoreDetailPage = lazyPage(() => import('./pages/StoreQuickDetail'));
 const Alertes = lazyPage(() => import('./pages/Alertes'));
 const AlerteDetail = lazyPage(() => import('./pages/AlerteDetail'));
 const Promos = lazyPage(() => import('./pages/Promos'));
@@ -187,7 +188,7 @@ export default function App() {
                       <Route index element={<AdminDashboardNew />} />
                       <Route path="stores" element={<StoreList />} />
                       <Route path="stores/new" element={<StoreForm />} />
-                      <Route path="stores/:id" element={<StoreDetail />} />
+                      <Route path="stores/:id" element={<AdminStoreDetail />} />
                       <Route path="stores/:id/edit" element={<StoreForm />} />
                       <Route path="products" element={<ProductList />} />
                       <Route path="products/new" element={<ProductForm />} />
@@ -225,6 +226,7 @@ export default function App() {
                       {/* Scanner & OCR routes */}
                       <Route path="scan" element={<ScanPage />} />
                       <Route path="scanner" element={<ScannerHub />} />
+                      <Route path="dev/scanner" element={<ScannerHub />} />
                       <Route path="scan-ean" element={<ScanEAN />} />
                       <Route path="analyse-photo-produit" element={<ProductPhotoAnalysis />} />
                       <Route path="product/:barcode" element={<ProductScanResult />} />
@@ -240,6 +242,7 @@ export default function App() {
                       <Route path="historique-prix" element={<HistoriquePrix />} />
                       <Route path="historique" element={<HistoriquePrix />} />
                       <Route path="p/:id" element={<ProductDetailPage />} />
+                      <Route path="store/:storeId" element={<PublicStoreDetailPage />} />
                       <Route path="recherche-prix" element={<RecherchePrix />} />
                       <Route path="alertes" element={<Alertes />} />
                       <Route path="alertes/:id" element={<AlerteDetail />} />

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,16 +1,61 @@
-import React from 'react';
-import { Outlet } from 'react-router-dom';
+import React, { useEffect, useRef, useState } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
 import Header from './layout/Header';
 import Footer from './layout/Footer';
 import FabActions from './ui/FabActions';
 
 export default function Layout() {
+  const navigate = useNavigate();
+  const [showCartToast, setShowCartToast] = useState(false);
+  const toastTimeoutRef = useRef(null);
+
+  useEffect(() => {
+    const handleItemAdded = () => {
+      if (toastTimeoutRef.current) {
+        window.clearTimeout(toastTimeoutRef.current);
+      }
+
+      setShowCartToast(true);
+      toastTimeoutRef.current = window.setTimeout(() => {
+        setShowCartToast(false);
+      }, 3000);
+    };
+
+    window.addEventListener('ti-panier:item-added', handleItemAdded);
+    return () => {
+      window.removeEventListener('ti-panier:item-added', handleItemAdded);
+      if (toastTimeoutRef.current) {
+        window.clearTimeout(toastTimeoutRef.current);
+        toastTimeoutRef.current = null;
+      }
+    };
+  }, []);
+
   return (
     <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
       <Header />
       <main id="main" className="mx-auto w-full max-w-6xl flex-1 px-4 pb-28 pt-4 md:pb-10" role="main">
         <Outlet />
       </main>
+
+      {showCartToast && (
+        <div className="fixed bottom-24 left-1/2 z-40 w-[calc(100%-2rem)] max-w-md -translate-x-1/2 rounded-xl border border-emerald-500/40 bg-slate-900/95 p-3 text-sm shadow-xl">
+          <div className="flex items-center justify-between gap-3">
+            <span>Ajouté au panier</span>
+            <button
+              type="button"
+              onClick={() => {
+                setShowCartToast(false);
+                navigate('/comparaison-panier');
+              }}
+              className="rounded-md bg-emerald-600 px-3 py-1 text-xs font-semibold text-white hover:bg-emerald-500"
+            >
+              Voir panier
+            </button>
+          </div>
+        </div>
+      )}
+
       <FabActions />
       <Footer />
     </div>

--- a/frontend/src/components/NavigateButtons.tsx
+++ b/frontend/src/components/NavigateButtons.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+
+type NavigateButtonsProps = {
+  lat: number;
+  lng: number;
+  className?: string;
+};
+
+export default function NavigateButtons({ lat, lng, className }: NavigateButtonsProps) {
+  const isIOS = useMemo(() => {
+    if (typeof navigator === 'undefined') {
+      return false;
+    }
+
+    return /iPad|iPhone|iPod/.test(navigator.userAgent);
+  }, []);
+
+  const destination = encodeURIComponent(`${lat},${lng}`);
+
+  return (
+    <div className={`flex flex-wrap gap-2 ${className ?? ''}`}>
+      <a
+        href={`https://www.google.com/maps/dir/?api=1&destination=${destination}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold text-white hover:bg-blue-700"
+      >
+        Google Maps
+      </a>
+      <a
+        href={`https://waze.com/ul?ll=${destination}&navigate=yes`}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="rounded-lg bg-sky-600 px-3 py-2 text-xs font-semibold text-white hover:bg-sky-700"
+      >
+        Waze
+      </a>
+      {isIOS && (
+        <a
+          href={`https://maps.apple.com/?daddr=${destination}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-lg bg-slate-600 px-3 py-2 text-xs font-semibold text-white hover:bg-slate-700"
+        >
+          Apple Plans
+        </a>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { Menu, X } from 'lucide-react';
 import { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
+import { useTiPanier } from '../../hooks/useTiPanier';
 
 const links = [
   { to: '/search', label: 'Recherche' },
@@ -14,6 +15,7 @@ const links = [
 
 export default function Header() {
   const [open, setOpen] = useState(false);
+  const { count } = useTiPanier('comparison');
 
   return (
     <header className="sticky top-0 z-40 border-b border-slate-800 bg-slate-950/95 backdrop-blur">
@@ -47,6 +49,19 @@ export default function Header() {
                 </NavLink>
               </li>
             ))}
+
+            <li>
+              <NavLink
+                to="/comparaison-panier"
+                onClick={() => setOpen(false)}
+                className={({ isActive }) =>
+                  `flex items-center justify-between rounded-lg px-3 py-2 text-sm ${isActive ? 'bg-slate-800 text-white' : 'text-slate-200'}`
+                }
+              >
+                <span>Panier</span>
+                <span className="rounded-full bg-blue-600 px-2 py-0.5 text-xs text-white">{count}</span>
+              </NavLink>
+            </li>
           </ul>
         </nav>
       )}

--- a/frontend/src/components/ui/FabActions.tsx
+++ b/frontend/src/components/ui/FabActions.tsx
@@ -1,16 +1,19 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-
-const actions = [
-  { to: '/search', label: 'Rechercher' },
-  { to: '/scan?mode=ean', label: 'Scanner EAN' },
-  { to: '/scan?mode=ticket', label: 'Scanner ticket' },
-  { to: '/faq', label: 'Aide' },
-];
+import { useTiPanier } from '../../hooks/useTiPanier';
 
 export default function FabActions() {
   const [open, setOpen] = useState(false);
   const [compact, setCompact] = useState(false);
+  const { count } = useTiPanier('comparison');
+
+  const actions = [
+    { to: '/comparaison-panier', label: count > 0 ? `Voir panier (${count})` : 'Voir panier' },
+    { to: '/search', label: 'Rechercher' },
+    { to: '/scan?mode=ean', label: 'Scanner EAN' },
+    { to: '/scan?mode=ticket', label: 'Scanner ticket' },
+    { to: '/faq', label: 'Aide' },
+  ];
 
   useEffect(() => {
     const onScroll = () => setCompact(window.scrollY > window.innerHeight * 0.25);

--- a/frontend/src/hooks/useTiPanier.ts
+++ b/frontend/src/hooks/useTiPanier.ts
@@ -149,17 +149,35 @@ export function useTiPanier(type: PanierType = 'comparison') {
   }, [type]);
 
   const addItem = useCallback((item: TiPanierItem) => {
+    const qtyRaw = typeof item.quantity === 'number' && Number.isFinite(item.quantity) ? Math.floor(item.quantity) : 1;
+    if (qtyRaw <= 0) {
+      return;
+    }
+
+    const qty = Math.max(1, qtyRaw);
+
     setItems((prev) => {
       const idx = prev.findIndex((p) => p.id === item.id);
-      const qty = typeof item.quantity === 'number' && Number.isFinite(item.quantity) ? Math.max(0, Math.floor(item.quantity)) : 1;
       if (idx === -1) {
         return [...prev, { ...item, quantity: qty }];
       }
       const updated = [...prev];
-      updated[idx] = { ...updated[idx], quantity: Math.max(0, updated[idx].quantity + qty), meta: item.meta ?? updated[idx].meta };
+      updated[idx] = { ...updated[idx], quantity: Math.max(1, updated[idx].quantity + qty), meta: item.meta ?? updated[idx].meta };
       return updated;
     });
-  }, []);
+
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(
+        new CustomEvent('ti-panier:item-added', {
+          detail: {
+            id: item.id,
+            quantity: qty,
+            type,
+          },
+        })
+      );
+    }
+  }, [type]);
 
   const removeItem = useCallback((id: string) => {
     setItems((prev) => prev.filter((p) => p.id !== id));

--- a/frontend/src/pages/ProductScanResult.tsx
+++ b/frontend/src/pages/ProductScanResult.tsx
@@ -1,23 +1,58 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
-import { fetchOffProductDetails, type OffProductUiModel } from '../services/openFoodFacts';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { fetchCachedOrRemoteOffProduct, type OffFetchStatus, type OffProductMinimal } from '../services/openFoodFacts';
+import { computePriceStats, getOffersForProduct } from '../services/prices';
+import type { ProductOffer, ProductPriceStats } from '../types/store';
 
-type LoadState = 'loading' | 'success' | 'notFound' | 'errorNetwork';
+type LoadState = 'loading' | 'success' | 'notFound' | 'invalidBarcode' | 'error';
 
 export default function ProductScanResult() {
   const { barcode = '' } = useParams();
+  const location = useLocation();
   const navigate = useNavigate();
+  const debugEnabled = useMemo(() => new URLSearchParams(location.search).get('debug') === '1', [location.search]);
   const [state, setState] = useState<LoadState>('loading');
-  const [product, setProduct] = useState<OffProductUiModel | null>(null);
-  const [productSource, setProductSource] = useState<'openfoodfacts' | 'local_override' | null>(null);
+  const [product, setProduct] = useState<OffProductMinimal | null>(null);
+  const [offStatus, setOffStatus] = useState<OffFetchStatus | null>(null);
+  const [cacheHit, setCacheHit] = useState(false);
+  const [responseMs, setResponseMs] = useState<number | null>(null);
+  const [offUrl, setOffUrl] = useState('');
+  const [offersLoading, setOffersLoading] = useState(true);
+  const [offers, setOffers] = useState<ProductOffer[]>([]);
+  const [priceStats, setPriceStats] = useState<ProductPriceStats | null>(null);
+
+  const formatObservedDate = useCallback((value?: string) => {
+    if (!value) {
+      return 'date n/d';
+    }
+
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      return 'date n/d';
+    }
+
+    return parsed.toLocaleDateString();
+  }, []);
 
   const loadProduct = useCallback(async () => {
     setState('loading');
-    const result = await fetchOffProductDetails(barcode);
+    const result = await fetchCachedOrRemoteOffProduct(barcode);
+    setOffStatus(result.status);
+    setCacheHit(result.cacheHit);
+    setResponseMs(result.responseMs);
+    setOffUrl(result.sourceUrl);
 
-    if (result.status === 'OK' && result.ui) {
-      setProduct(result.ui);
-      setProductSource(result.source ?? result.ui.source ?? null);
+    if (debugEnabled) {
+      console.info('[ProductScanResult][debug] OFF result', {
+        status: result.status,
+        cacheHit: result.cacheHit,
+        responseMs: result.responseMs,
+        sourceUrl: result.sourceUrl,
+      });
+    }
+
+    if (result.status === 'OK' && result.product) {
+      setProduct(result.product);
       setState('success');
       return;
     }
@@ -27,84 +62,148 @@ export default function ProductScanResult() {
       return;
     }
 
-    setState('errorNetwork');
-  }, [barcode]);
+    if (result.status === 'INVALID') {
+      setState('invalidBarcode');
+      return;
+    }
+
+    setState('error');
+  }, [barcode, debugEnabled]);
 
   useEffect(() => {
     void loadProduct();
   }, [loadProduct]);
 
+  useEffect(() => {
+    const loadOffers = async () => {
+      setOffersLoading(true);
+      const nextOffers = await getOffersForProduct({ barcode });
+      setOffers(nextOffers);
+      setPriceStats(computePriceStats(nextOffers));
+      setOffersLoading(false);
+    };
+
+    void loadOffers();
+  }, [barcode]);
+
   return (
-    <div className="min-h-screen bg-slate-950 p-4 pt-24 text-white">
+    <div className="bg-slate-950 p-4 text-white">
       <div className="mx-auto w-full max-w-3xl rounded-2xl border border-slate-800 bg-slate-900/70 p-6">
         <div className="mb-6 flex items-center justify-between">
           <h1 className="text-2xl font-bold">Fiche produit</h1>
-          <span className="rounded-full border border-slate-600 px-3 py-1 text-xs text-slate-300">EAN {barcode}</span>
+          <span className="rounded-full border border-slate-600 px-3 py-1 text-xs text-slate-300">Code-barres {barcode}</span>
         </div>
 
         {state === 'loading' && <p className="text-slate-300">Chargement des données OpenFoodFacts…</p>}
 
         {state === 'notFound' && (
           <div className="space-y-4 rounded-xl border border-orange-700 bg-orange-500/10 p-4">
-            <p className="font-semibold text-orange-200">Produit introuvable sur OpenFoodFacts.</p>
+            <p className="font-semibold text-orange-200">Produit non référencé sur OpenFoodFacts.</p>
             <div className="flex flex-wrap gap-3">
               <button onClick={() => navigate('/scanner')} className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold hover:bg-blue-700">Rescanner</button>
+              <Link to="/contribuer" className="rounded-lg border border-orange-500 px-4 py-2 text-sm text-orange-100 hover:bg-orange-500/10">Ajouter ce produit</Link>
               <a href={`https://world.openfoodfacts.org/product/${barcode}`} target="_blank" rel="noreferrer" className="rounded-lg border border-orange-500 px-4 py-2 text-sm text-orange-100 hover:bg-orange-500/10">Voir sur OpenFoodFacts</a>
             </div>
           </div>
         )}
 
-        {state === 'errorNetwork' && (
+        {state === 'error' && (
           <div className="space-y-4 rounded-xl border border-red-700 bg-red-500/10 p-4">
-            <p className="font-semibold text-red-200">Erreur réseau lors de la récupération du produit.</p>
+            <p className="font-semibold text-red-200">Service produit indisponible, réessayez.</p>
             <button onClick={() => void loadProduct()} className="rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold hover:bg-red-700">Réessayer</button>
+          </div>
+        )}
+
+        {state === 'invalidBarcode' && (
+          <div className="space-y-4 rounded-xl border border-amber-700 bg-amber-500/10 p-4">
+            <p className="font-semibold text-amber-200">Code-barres invalide. Veuillez rescanner le produit.</p>
+            <button onClick={() => navigate('/scanner')} className="rounded-lg bg-amber-600 px-4 py-2 text-sm font-semibold hover:bg-amber-700">Retour au scanner</button>
           </div>
         )}
 
         {state === 'success' && product && (
           <div className="space-y-6">
             <header>
-              <h2 className="text-2xl font-semibold">{product.name ?? 'Produit sans nom'}</h2>
-              <p className="text-slate-300">{product.brand ?? 'Marque non renseignée'}{product.quantity ? ` · ${product.quantity}` : ''}</p>
-              {productSource === 'local_override' && (
-                <p className="mt-1 text-xs text-slate-400">Source: Catalogue interne</p>
-              )}
+              <h2 className="text-2xl font-semibold">{product.productName ?? 'Produit'}</h2>
+              <p className="text-slate-300">{product.brands ?? 'Marque non renseignée'}{product.quantity ? ` · ${product.quantity}` : ''}</p>
+              <p className="mt-1 inline-flex rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-200">Source: OpenFoodFacts</p>
             </header>
 
-            {product.image && <img src={product.image} alt={product.name ?? 'Produit'} className="max-h-64 w-full rounded-xl object-contain bg-white p-2" />}
+            {product.imageUrl && <img src={product.imageUrl} alt={product.productName ?? 'Produit'} className="max-h-64 w-full rounded-xl object-contain bg-white p-2" />}
 
-            <div className="flex flex-wrap gap-2 text-sm">
-              {product.nutriScore && <span className="rounded-full bg-green-500/20 px-3 py-1">Nutri-Score {product.nutriScore}</span>}
-              {product.nova && <span className="rounded-full bg-purple-500/20 px-3 py-1">NOVA {product.nova}</span>}
-              {product.ecoScore && <span className="rounded-full bg-emerald-500/20 px-3 py-1">EcoScore {product.ecoScore}</span>}
-            </div>
-
-            <section className="rounded-xl border border-slate-700 p-4">
-              <h3 className="mb-3 text-lg font-semibold">Nutrition (pour 100g)</h3>
-              <div className="grid grid-cols-2 gap-2 text-sm text-slate-200">
-                <div>kcal: {product.nutriments.kcal ?? 'n/d'}</div>
-                <div>Énergie: {product.nutritionPer100g?.energyKj ?? 'n/d'} kJ</div>
-                <div>Sucres: {product.nutriments.sugars ?? 'n/d'} g</div>
-                <div>Matières grasses: {product.nutriments.fat ?? 'n/d'} g</div>
-                <div>Acides gras saturés: {product.nutritionPer100g?.saturatedFat ?? 'n/d'} g</div>
-                <div>Glucides: {product.nutritionPer100g?.carbs ?? 'n/d'} g</div>
-                <div>Fibres: {product.nutritionPer100g?.fiber ?? 'n/d'} g</div>
-                <div>Protéines: {product.nutritionPer100g?.protein ?? 'n/d'} g</div>
-                <div>Sel: {product.nutriments.salt ?? 'n/d'} g</div>
-              </div>
-            </section>
+            {product.categories && product.categories.length > 0 && (
+              <section className="rounded-xl border border-slate-700 p-4">
+                <h3 className="mb-2 text-lg font-semibold">Catégories</h3>
+                <p className="text-sm text-slate-200">{product.categories.join(', ')}</p>
+              </section>
+            )}
 
             <section className="rounded-xl border border-slate-700 p-4">
-              <h3 className="mb-2 text-lg font-semibold">Ingrédients / Allergènes</h3>
-              <p className="text-sm text-slate-200">{product.ingredients ?? 'Ingrédients non disponibles.'}</p>
-              <p className="mt-2 text-sm text-slate-300"><strong>Allergènes:</strong> {product.allergens ?? 'Non renseignés'}</p>
+              <h3 className="mb-3 text-lg font-semibold">Prix dans les magasins</h3>
+
+              {offersLoading && <p className="text-sm text-slate-300">Chargement des prix…</p>}
+
+              {!offersLoading && !priceStats && (
+                <p className="text-sm text-slate-300">
+                  Aucune donnée prix pour l’instant. <Link to="/contribuer-prix" className="underline underline-offset-2">Contribuer</Link>
+                </p>
+              )}
+
+              {!offersLoading && priceStats && (
+                <>
+                  <div className="mb-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-3">
+                    <div className="rounded-lg bg-emerald-500/10 p-2">Min: <strong>{priceStats.min.toFixed(2)} €</strong></div>
+                    <div className="rounded-lg bg-cyan-500/10 p-2">Médiane: <strong>{priceStats.median.toFixed(2)} €</strong></div>
+                    <div className="rounded-lg bg-rose-500/10 p-2">Max: <strong>{priceStats.max.toFixed(2)} €</strong></div>
+                  </div>
+
+                  <ul className="space-y-2">
+                    {offers.slice(0, 20).map((offer, index) => (
+                      <li key={`${offer.storeId ?? offer.storeName ?? 'store'}-${index}`} className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-700 p-2 text-sm">
+                        <div>
+                          <div className="font-medium text-white">{offer.storeName ?? 'Magasin non identifié'}</div>
+                          <div className="text-slate-400">{offer.city ?? '—'} • {offer.territory ?? '—'} • {formatObservedDate(offer.observedAt)}</div>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <div className="font-semibold text-emerald-300">{offer.price.toFixed(2)} €</div>
+                          {offer.storeId && (
+                            <Link to={`/store/${offer.storeId}`} className="rounded-md border border-blue-500 px-2 py-1 text-xs text-blue-200 hover:bg-blue-500/10">
+                              Choisir
+                            </Link>
+                          )}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              )}
             </section>
 
             <div className="flex gap-3">
               <button onClick={() => navigate('/scanner')} className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold hover:bg-blue-700">Rescanner</button>
+              <a
+                href={`https://world.openfoodfacts.org/product/${barcode}`}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded-lg border border-emerald-500 px-4 py-2 text-sm text-emerald-100 hover:bg-emerald-500/10"
+              >
+                Voir détails OFF
+              </a>
               <Link to="/scanner" className="rounded-lg border border-slate-500 px-4 py-2 text-sm">Rechercher un autre code</Link>
             </div>
           </div>
+        )}
+
+        {debugEnabled && (
+          <section className="mt-6 rounded-xl border border-cyan-700 bg-cyan-950/30 p-4 text-sm text-cyan-100">
+            <h2 className="mb-2 text-base font-semibold">Debug OFF</h2>
+            <ul className="space-y-1">
+              <li>status OFF: {offStatus ?? '—'}</li>
+              <li>cache: {cacheHit ? 'hit' : 'miss'}</li>
+              <li>response: {responseMs ?? 0} ms</li>
+              <li className="break-all">url: {offUrl || '—'}</li>
+            </ul>
+          </section>
         )}
       </div>
     </div>

--- a/frontend/src/pages/ScannerHub.tsx
+++ b/frontend/src/pages/ScannerHub.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { BrowserMultiFormatReader } from '@zxing/browser';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { pickBestBackCameraDeviceId } from '../utils/cameraUtils';
 
 type ScanStatus =
   | 'idle'
@@ -11,20 +12,54 @@ type ScanStatus =
   | 'notDetectedTimeout'
   | 'success'
   | 'errorNetwork'
-  | 'notFound';
+  | 'notFound'
+  | 'invalidBarcode';
 
 type ScannerControls = {
   stop: () => void;
   switchTorch?: (on: boolean) => Promise<void>;
 };
 
-const EAN_REGEX = /^[0-9]{8,14}$/;
+const EAN13_REGEX = /^\d{13}$/;
+const EAN8_REGEX = /^\d{8}$/;
+const UPC_A_REGEX = /^\d{12}$/;
+const GTIN14_REGEX = /^\d{14}$/;
 const SCAN_TIMEOUT_MS = 10_000;
 const SUCCESS_LOCK_MS = 1_500;
 const UI_COOLDOWN_MS = 1_500;
 
+function hasValidCheckDigit(code: string): boolean {
+  if (!/^\d+$/.test(code) || code.length < 8) {
+    return false;
+  }
+
+  const digits = code.split('').map(Number);
+  const checkDigit = digits.pop() as number;
+  const weightedSum = digits
+    .slice()
+    .reverse()
+    .reduce((accumulator, digit, index) => {
+      return accumulator + digit * (index % 2 === 0 ? 3 : 1);
+    }, 0);
+  const computed = (10 - (weightedSum % 10)) % 10;
+
+  return computed === checkDigit;
+}
+
+function normalizeAndValidateGtin(rawCode: string): string | null {
+  const code = rawCode.replace(/\D/g, '');
+
+  if (EAN8_REGEX.test(code) || UPC_A_REGEX.test(code) || EAN13_REGEX.test(code) || GTIN14_REGEX.test(code)) {
+    return hasValidCheckDigit(code) ? code : null;
+  }
+
+  return null;
+}
+
 export default function ScannerHub() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const debugEnabled = new URLSearchParams(location.search).get('debug') === '1';
 
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const readerRef = useRef<BrowserMultiFormatReader | null>(null);
@@ -32,12 +67,19 @@ export default function ScannerHub() {
   const streamRef = useRef<MediaStream | null>(null);
   const timeoutRef = useRef<number | null>(null);
   const successLockRef = useRef<number | null>(null);
+  const cameraRetryTimeoutRef = useRef<number | null>(null);
+  const detectionCountRef = useRef(0);
+  const resultCountRef = useRef(0);
+  const lastAcceptedDetectionAtRef = useRef(0);
+  const lastDetectionTimestampsRef = useRef<Record<string, number>>({});
   const startingRef = useRef(false);
   const lastUiEmitRef = useRef<{ code: string; at: number } | null>(null);
 
   const [status, setStatus] = useState<ScanStatus>('idle');
   const [lastDetectedCode, setLastDetectedCode] = useState<string | null>(null);
+  const [lastRawDetectedCode, setLastRawDetectedCode] = useState<string | null>(null);
   const [stableCounter, setStableCounter] = useState(0);
+  const [resultCount, setResultCount] = useState(0);
   const [manualInputVisible, setManualInputVisible] = useState(false);
   const [manualEAN, setManualEAN] = useState('');
   const [manualError, setManualError] = useState<string | null>(null);
@@ -46,6 +88,11 @@ export default function ScannerHub() {
   const [successOverlayVisible, setSuccessOverlayVisible] = useState(false);
   const [isScanning, setIsScanning] = useState(false);
   const [isStarting, setIsStarting] = useState(false);
+  const [selectedDeviceId, setSelectedDeviceId] = useState<string>('fallback');
+  const [zoomApplied, setZoomApplied] = useState(false);
+  const [zoomValue, setZoomValue] = useState<number | null>(null);
+  const [cameraInputsDebug, setCameraInputsDebug] = useState<string[]>([]);
+  const barcodeSupport = typeof window !== 'undefined' && 'BarcodeDetector' in window;
 
   const stopCamera = useCallback(() => {
     controlsRef.current?.stop();
@@ -54,6 +101,11 @@ export default function ScannerHub() {
     if (timeoutRef.current !== null) {
       window.clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
+    }
+
+    if (cameraRetryTimeoutRef.current !== null) {
+      window.clearTimeout(cameraRetryTimeoutRef.current);
+      cameraRetryTimeoutRef.current = null;
     }
 
     const stream = streamRef.current ?? (videoRef.current?.srcObject instanceof MediaStream ? videoRef.current.srcObject : null);
@@ -73,15 +125,30 @@ export default function ScannerHub() {
 
   const canFinalize = () => successLockRef.current === null;
 
+  const scheduleNotDetectedTimeout = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = window.setTimeout(() => {
+      if (successLockRef.current === null && resultCountRef.current === 0) {
+        setStatus('notDetectedTimeout');
+        setManualInputVisible(true);
+      }
+    }, SCAN_TIMEOUT_MS);
+  }, []);
+
   const finalizeScan = useCallback(
     (rawCode: string) => {
       if (!canFinalize()) {
         return;
       }
 
-      const code = rawCode.replace(/\D/g, '');
-      if (!EAN_REGEX.test(code)) {
-        setStatus('notFound');
+      const code = normalizeAndValidateGtin(rawCode);
+      if (!code) {
+        setStatus('invalidBarcode');
+        setManualInputVisible(true);
+        setManualError('Code-barres invalide (8/12/13/14 chiffres + check digit).');
         return;
       }
 
@@ -123,7 +190,18 @@ export default function ScannerHub() {
 
   const resetForNewScan = useCallback(() => {
     setLastDetectedCode(null);
+    setLastRawDetectedCode(null);
     setStableCounter(0);
+    setResultCount(0);
+    resultCountRef.current = 0;
+    detectionCountRef.current = 0;
+    lastAcceptedDetectionAtRef.current = 0;
+    lastDetectionTimestampsRef.current = {};
+    setSelectedDeviceId('fallback');
+    setZoomApplied(false);
+    setZoomValue(null);
+    setCameraInputsDebug([]);
+    lastUiEmitRef.current = null;
     setManualError(null);
     setSuccessOverlayVisible(false);
     if (status !== 'permissionDenied' && status !== 'cameraNotFound') {
@@ -158,61 +236,191 @@ export default function ScannerHub() {
       setStatus('scanning');
       setIsScanning(true);
 
-      const controls = await readerRef.current.decodeFromConstraints(
-        {
-          video: { facingMode: { ideal: 'environment' } },
-          audio: false,
-        },
-        videoRef.current,
-        (result) => {
-          const text = result?.getText()?.trim();
-          if (!text) {
-            return;
-          }
+      const cameraSelection = await pickBestBackCameraDeviceId();
+      const reversedDeviceIds = cameraSelection.videoInputs.map((device) => device.deviceId).reverse();
+      const cameraAttemptIds = cameraSelection.selectedDeviceId
+        ? [cameraSelection.selectedDeviceId, ...reversedDeviceIds.filter((deviceId) => deviceId !== cameraSelection.selectedDeviceId)]
+        : reversedDeviceIds;
 
-          const code = text.replace(/\D/g, '');
-          if (!EAN_REGEX.test(code)) {
-            return;
-          }
-
-          const now = Date.now();
-          const lastUiEmit = lastUiEmitRef.current;
-          if (lastUiEmit && lastUiEmit.code === code && now - lastUiEmit.at < UI_COOLDOWN_MS) {
-            return;
-          }
-
-          lastUiEmitRef.current = { code, at: now };
-
-          setLastDetectedCode((previousCode) => {
-            if (previousCode === code) {
-              setStableCounter((previousCounter) => {
-                return previousCounter + 1;
-              });
-              return previousCode;
-            }
-
-            setStableCounter(1);
-            return code;
-          });
-
-          setStatus('scanning');
-        }
+      setCameraInputsDebug(
+        cameraSelection.videoInputs.map((device) => `${device.label || '(label indisponible)'} [${device.deviceId}]`)
       );
 
-      controlsRef.current = controls as ScannerControls;
-
-      const media = videoRef.current.srcObject;
-      if (media instanceof MediaStream) {
-        streamRef.current = media;
-        detectTorchSupport();
-      }
-
-      timeoutRef.current = window.setTimeout(() => {
-        if (canFinalize()) {
-          setStatus('notDetectedTimeout');
-          setManualInputVisible(true);
+      const runAttempt = async (attemptIndex: number): Promise<void> => {
+        if (!videoRef.current || !readerRef.current) {
+          return;
         }
-      }, SCAN_TIMEOUT_MS);
+
+        const attemptDeviceId = cameraAttemptIds[attemptIndex] ?? null;
+        const videoConstraints = attemptDeviceId
+          ? {
+              deviceId: { exact: attemptDeviceId },
+              width: { ideal: 1280 },
+              height: { ideal: 720 },
+            }
+          : {
+              facingMode: { ideal: 'environment' as const },
+              width: { ideal: 1280 },
+              height: { ideal: 720 },
+            };
+
+        setSelectedDeviceId(attemptDeviceId ?? 'fallback');
+
+        if (debugEnabled) {
+          console.info('[ScannerHub][debug] Démarrage scan', {
+            selectedDeviceId: attemptDeviceId ?? 'fallback',
+            tryingDeviceIndex: attemptIndex,
+            videoInputs: cameraSelection.videoInputs.map((device) => device.label || '(label indisponible)'),
+            constraints: videoConstraints,
+          });
+        }
+
+        const controls = await readerRef.current.decodeFromConstraints(
+          {
+            video: videoConstraints,
+            audio: false,
+          },
+          videoRef.current,
+          (result) => {
+            const text = result?.getText()?.trim();
+            if (!text) {
+              return;
+            }
+
+            setLastRawDetectedCode(text);
+
+            const code = normalizeAndValidateGtin(text);
+            if (!code) {
+              return;
+            }
+
+            const now = Date.now();
+            const lastSameCodeAt = lastDetectionTimestampsRef.current[code] ?? 0;
+            if (now - lastSameCodeAt < 500) {
+              return;
+            }
+
+            if (now - lastAcceptedDetectionAtRef.current < 700) {
+              return;
+            }
+
+            lastDetectionTimestampsRef.current[code] = now;
+            lastAcceptedDetectionAtRef.current = now;
+
+            detectionCountRef.current += 1;
+            resultCountRef.current += 1;
+            setResultCount(resultCountRef.current);
+            setManualInputVisible(false);
+            scheduleNotDetectedTimeout();
+
+            setLastDetectedCode((previousCode) => {
+              if (previousCode === code) {
+                setStableCounter((previousCounter) => {
+                  return previousCounter + 1;
+                });
+                return previousCode;
+              }
+
+              setStableCounter(1);
+              return code;
+            });
+
+            const lastUiEmit = lastUiEmitRef.current;
+            if (!lastUiEmit || lastUiEmit.code !== code || now - lastUiEmit.at >= UI_COOLDOWN_MS) {
+              lastUiEmitRef.current = { code, at: now };
+
+              if (debugEnabled) {
+                console.info('[ScannerHub][debug] Détection valide', { code });
+              }
+            }
+
+            setStatus('scanning');
+          }
+        );
+
+        controlsRef.current = controls as ScannerControls;
+
+        const media = videoRef.current.srcObject;
+        if (media instanceof MediaStream) {
+          streamRef.current = media;
+          detectTorchSupport();
+
+          const [track] = media.getVideoTracks();
+          if (track && typeof track.getCapabilities === 'function') {
+            const capabilities = track.getCapabilities() as MediaTrackCapabilities & {
+              zoom?: { min?: number; max?: number };
+              torch?: boolean;
+            };
+
+            let applied = false;
+            let appliedZoomValue: number | null = null;
+            const zoomCapabilities = capabilities.zoom;
+            if (zoomCapabilities && typeof track.applyConstraints === 'function') {
+              const minZoom = typeof zoomCapabilities.min === 'number' ? zoomCapabilities.min : 1;
+              const maxZoom = typeof zoomCapabilities.max === 'number' ? zoomCapabilities.max : 2;
+              const targetZoom = Math.max(minZoom, Math.min(maxZoom, 2));
+
+              try {
+                await track.applyConstraints({ advanced: [{ zoom: targetZoom }] });
+                applied = true;
+                appliedZoomValue = targetZoom;
+              } catch {
+                applied = false;
+                appliedZoomValue = null;
+              }
+            }
+
+            setZoomApplied(applied);
+            setZoomValue(appliedZoomValue);
+
+            if (debugEnabled) {
+              console.info('[ScannerHub][debug] Capacités caméra', {
+                zoom: zoomCapabilities,
+                torch: capabilities.torch,
+                zoomApplied: applied,
+                zoomValue: appliedZoomValue,
+              });
+            }
+          } else {
+            setZoomApplied(false);
+            setZoomValue(null);
+          }
+        }
+
+        scheduleNotDetectedTimeout();
+
+        if (cameraAttemptIds.length > 1 && attemptIndex < cameraAttemptIds.length - 1) {
+          if (cameraRetryTimeoutRef.current !== null) {
+            window.clearTimeout(cameraRetryTimeoutRef.current);
+          }
+
+          cameraRetryTimeoutRef.current = window.setTimeout(async () => {
+            if (detectionCountRef.current > 0 || successLockRef.current !== null) {
+              return;
+            }
+
+            if (debugEnabled) {
+              console.info('[ScannerHub][debug] Aucun résultat, tentative caméra suivante', {
+                nextDeviceIndex: attemptIndex + 1,
+                nextDeviceId: cameraAttemptIds[attemptIndex + 1],
+              });
+            }
+
+            stopCamera();
+            setStatus('scanning');
+            setIsScanning(true);
+
+            try {
+              await runAttempt(attemptIndex + 1);
+            } catch {
+              setStatus('cameraNotFound');
+              setManualInputVisible(true);
+            }
+          }, 2_500);
+        }
+      };
+
+      await runAttempt(0);
     } catch (error) {
       stopCamera();
       const message = error instanceof Error ? error.message : '';
@@ -235,13 +443,50 @@ export default function ScannerHub() {
       startingRef.current = false;
       setIsStarting(false);
     }
-  }, [detectTorchSupport, isScanning, resetForNewScan, stopCamera]);
+  }, [debugEnabled, detectTorchSupport, isScanning, resetForNewScan, scheduleNotDetectedTimeout, stopCamera]);
+
+  useEffect(() => {
+    if (!isScanning || !lastDetectedCode || stableCounter < 2) {
+      return;
+    }
+
+    finalizeScan(lastDetectedCode);
+  }, [finalizeScan, isScanning, lastDetectedCode, stableCounter]);
+
+  useEffect(() => {
+    if (!debugEnabled) {
+      return;
+    }
+
+    console.info('[ScannerHub][debug] État scanner', {
+      barcodeSupport,
+      cameraError: status,
+      scanActive: isScanning,
+      lastSeen: lastDetectedCode,
+      lastRawDetectedCode,
+      resultCount,
+      selectedDeviceId,
+      zoomApplied,
+      zoomValue,
+    });
+  }, [
+    barcodeSupport,
+    debugEnabled,
+    isScanning,
+    lastDetectedCode,
+    lastRawDetectedCode,
+    resultCount,
+    selectedDeviceId,
+    status,
+    zoomApplied,
+    zoomValue,
+  ]);
 
   const handleManualSearch = useCallback(() => {
-    const normalized = manualEAN.replace(/\D/g, '');
+    const normalized = normalizeAndValidateGtin(manualEAN);
 
-    if (!EAN_REGEX.test(normalized)) {
-      setManualError('Code EAN invalide. Entrez 8 à 14 chiffres.');
+    if (!normalized) {
+      setManualError('Code-barres invalide (8/12/13/14 chiffres + check digit).');
       return;
     }
 
@@ -360,6 +605,24 @@ export default function ScannerHub() {
             <p>Validation stable: {stableCounter}/2</p>
           </div>
 
+          {debugEnabled && (
+            <div className="mt-4 rounded-xl border border-cyan-700 bg-cyan-950/30 p-3 text-sm text-cyan-100">
+              <h2 className="mb-2 text-base font-semibold">Debug</h2>
+              <ul className="space-y-1">
+                <li>barcodeSupport: {String(barcodeSupport)}</li>
+                <li>cameraError: {status}</li>
+                <li>scanActive: {String(isScanning)}</li>
+                <li>lastSeen: {lastDetectedCode ?? '—'}</li>
+                <li>dernier raw détecté: {lastRawDetectedCode ?? '—'}</li>
+                <li>results: {resultCount}</li>
+                <li>selectedDeviceId: {selectedDeviceId}</li>
+                <li>zoomApplied: {String(zoomApplied)}{zoomValue !== null ? ` (${zoomValue}x)` : ''}</li>
+                <li>videoInputs: {cameraInputsDebug.length}</li>
+                <li>videoInputsLabels: {cameraInputsDebug.slice(0, 3).join(' | ') || '—'}</li>
+              </ul>
+            </div>
+          )}
+
           {status === 'permissionDenied' && (
             <p className="mt-3 rounded-lg border border-red-700 bg-red-500/10 p-3 text-sm text-red-200">
               Permission caméra refusée. Utilisez la saisie manuelle.
@@ -384,10 +647,17 @@ export default function ScannerHub() {
             </p>
           )}
 
+
+          {status === 'invalidBarcode' && (
+            <p className="mt-3 rounded-lg border border-amber-700 bg-amber-500/10 p-3 text-sm text-amber-200">
+              Code-barres invalide. Vérifiez les chiffres et le check digit, ou ressaisissez le code manuellement.
+            </p>
+          )}
+
           {manualInputVisible && (
             <div className="mt-4 rounded-xl border border-slate-700 p-3">
               <label htmlFor="manual-ean" className="mb-2 block text-sm font-medium">
-                Code EAN (8 à 14 chiffres)
+                Code EAN (8, 12, 13 ou 14 chiffres)
               </label>
               <div className="flex flex-col gap-2 sm:flex-row">
                 <input

--- a/frontend/src/pages/StoreDetail.tsx
+++ b/frontend/src/pages/StoreDetail.tsx
@@ -24,6 +24,7 @@ import CheapestProductsSection from '../components/store/CheapestProductsSection
 import { useTiPanier } from '../hooks/useTiPanier';
 import { requestGeolocation } from '../utils/geolocationEnhanced';
 import { calculateDistance } from '../utils/geoLocation';
+import NavigateButtons from '../components/NavigateButtons';
 
 export default function StoreDetail() {
   const { storeId } = useParams<{ storeId: string }>();
@@ -84,7 +85,6 @@ export default function StoreDetail() {
     return (
       <div className="min-h-screen bg-slate-950 flex items-center justify-center px-4">
         <div className="max-w-md bg-slate-900 rounded-xl p-6 text-center">
-          <div className="text-5xl mb-4">🏪</div>
           <h2 className="text-xl font-semibold text-white mb-2">Enseigne non trouvée</h2>
           <p className="text-gray-300 mb-4">
             Cette enseigne n'existe pas ou a été supprimée de notre base de données.
@@ -105,8 +105,7 @@ export default function StoreDetail() {
       <div className="max-w-7xl mx-auto">
         {/* Neutral Banner - Credibility */}
         <div className="bg-blue-900/20 border border-blue-700/50 rounded-xl p-5 mb-6">
-          <div className="flex items-start gap-4">
-            <span className="text-3xl">🏛️</span>
+          <div className="flex items-start">
             <div className="flex-1">
               <h2 className="text-lg font-semibold text-blue-200 mb-2">
                 Données issues de sources publiques et d'observations citoyennes
@@ -131,9 +130,6 @@ export default function StoreDetail() {
             <div className="flex items-start justify-between flex-wrap gap-4">
               <div className="flex-1 min-w-[300px]">
                 <div className="flex items-center gap-3 mb-3">
-                  <div className="w-12 h-12 bg-blue-600 rounded-lg flex items-center justify-center text-2xl">
-                    🏪
-                  </div>
                   <div>
                     <h1 className="text-2xl font-bold text-white">{store.name}</h1>
                     <p className="text-gray-400 text-sm">{store.chain}</p>
@@ -142,18 +138,15 @@ export default function StoreDetail() {
                 
                 <div className="space-y-2 text-sm">
                   <div className="flex items-center gap-2 text-gray-300">
-                    <span className="text-gray-500">📍</span>
                     <span>{store.address}, {store.postalCode} {store.city}</span>
                   </div>
                   <div className="flex items-center gap-2 text-gray-300">
-                    <span className="text-gray-500">🌍</span>
                     <span className="px-2 py-0.5 bg-blue-900/30 text-blue-300 rounded">
                       {store.territory}
                     </span>
                   </div>
                   {store.phone && (
                     <div className="flex items-center gap-2 text-gray-300">
-                      <span className="text-gray-500">📞</span>
                       <a href={`tel:${store.phone}`} className="hover:text-blue-400 transition-colors">
                         {store.phone}
                       </a>
@@ -161,7 +154,6 @@ export default function StoreDetail() {
                   )}
                   {distance !== null && (
                     <div className="flex items-center gap-2 text-gray-300">
-                      <span className="text-gray-500">📏</span>
                       <span>
                         {distance < 1 
                           ? `${Math.round(distance * 1000)} m` 
@@ -180,7 +172,7 @@ export default function StoreDetail() {
                       ? 'bg-green-900/30 text-green-300 border border-green-700'
                       : 'bg-red-900/30 text-red-300 border border-red-700'
                   }`}>
-                    {store.isCompanyActive ? '✅ Entreprise active' : '⚠️ Entreprise cessée'}
+                    {store.isCompanyActive ? 'Entreprise active' : 'Entreprise cessée'}
                   </div>
                 )}
                 
@@ -195,23 +187,24 @@ export default function StoreDetail() {
             {/* Action Buttons - PROMPT 7 */}
             <div className="mt-4 pt-4 border-t border-slate-800 flex flex-wrap gap-3">
               {store.coordinates && (
-                <a
-                  href={`https://www.google.com/maps/dir/?api=1&destination=${store.coordinates.lat},${store.coordinates.lon}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex-1 min-w-[200px] px-4 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
-                >
-                  <span>🧭</span>
-                  <span>Y aller (GPS)</span>
-                </a>
+                <div className="flex-1 min-w-[220px]">
+                  <p className="mb-2 text-xs uppercase tracking-wide text-slate-400">Y aller</p>
+                  <NavigateButtons lat={store.coordinates.lat} lng={store.coordinates.lon} />
+                </div>
               )}
+
+              <Link
+                to={`/contribuer-prix?storeId=${store.id}`}
+                className="flex-1 min-w-[200px] px-4 py-2.5 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
+              >
+                <span>Contribuer prix ici</span>
+              </Link>
               
               {basketCount > 0 && (
                 <Link
-                  to={`/comparer-panier?storeId=${store.id}`}
+                  to={`/comparaison-panier?storeId=${store.id}`}
                   className="flex-1 min-w-[200px] px-4 py-2.5 bg-green-600 hover:bg-green-700 text-white rounded-lg font-medium transition-colors flex items-center justify-center gap-2"
                 >
-                  <span>🛒</span>
                   <span>Comparer avec mon panier ({basketCount})</span>
                 </Link>
               )}
@@ -221,8 +214,7 @@ export default function StoreDetail() {
 
         {/* Disclaimer */}
         <div className="bg-amber-900/20 border border-amber-700/50 rounded-lg p-4 mb-6">
-          <div className="flex items-start gap-3">
-            <span className="text-2xl">ℹ️</span>
+          <div className="flex items-start">
             <div className="flex-1">
               <p className="text-amber-200 text-sm font-medium mb-1">
                 Outil d'observation - Aucun conseil

--- a/frontend/src/pages/StoreQuickDetail.tsx
+++ b/frontend/src/pages/StoreQuickDetail.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import NavigateButtons from '../components/NavigateButtons';
+import { getStore } from '../services/prices';
+import type { Store } from '../types/store';
+
+export default function StoreQuickDetail() {
+  const { storeId = '' } = useParams();
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+  const [store, setStore] = useState<Store | null>(null);
+
+  useEffect(() => {
+    const loadStore = async () => {
+      setLoading(true);
+      const nextStore = await getStore(storeId);
+      setStore(nextStore);
+      setLoading(false);
+    };
+
+    void loadStore();
+  }, [storeId]);
+
+  if (loading) {
+    return <div className="min-h-[40vh] p-6 text-slate-300">Chargement du magasin…</div>;
+  }
+
+  if (!store) {
+    return (
+      <div className="min-h-[40vh] p-6 text-slate-100">
+        <p className="mb-3">Magasin introuvable.</p>
+        <button onClick={() => navigate(-1)} className="rounded-lg bg-slate-700 px-3 py-2 text-sm">Retour</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-950 p-4 pt-24 text-white">
+      <section className="mx-auto w-full max-w-3xl rounded-2xl border border-slate-800 bg-slate-900/70 p-6">
+        <button onClick={() => navigate(-1)} className="mb-4 text-sm text-slate-300 hover:text-white">← Retour</button>
+
+        <h1 className="text-2xl font-bold">{store.name}</h1>
+        <p className="mt-1 text-slate-300">{store.brand ?? 'Enseigne'} · {store.city ?? 'Ville n/d'}</p>
+
+        <div className="mt-4 space-y-1 text-sm text-slate-300">
+          <p>Adresse: {store.address ?? 'n/d'} {store.postalCode ?? ''}</p>
+          <p>Territoire: {store.territory ?? 'n/d'}</p>
+          <p>Horaires: {store.openingHours ?? 'n/d'}</p>
+          {store.phone && <p>Téléphone: {store.phone}</p>}
+        </div>
+
+        {store.location && (
+          <div className="mt-5">
+            <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-300">Y aller</h2>
+            <NavigateButtons lat={store.location.lat} lng={store.location.lng} />
+          </div>
+        )}
+
+        <div className="mt-6 flex flex-wrap gap-2">
+          <Link to={`/contribuer-prix?storeId=${store.id}`} className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold hover:bg-emerald-700">
+            Contribuer prix ici
+          </Link>
+          <Link to="/comparaison-panier" className="rounded-lg border border-slate-500 px-4 py-2 text-sm">
+            Voir mon panier
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/services/openFoodFacts.ts
+++ b/frontend/src/services/openFoodFacts.ts
@@ -1,17 +1,178 @@
-import { getCachedWithTTL, setCachedJson } from './localStore';
-import { getProductOverride } from '../data/product_overrides';
+import { getCached, setCached } from './productCache';
 
-const OFF_DEFAULT_BASE_URL = 'https://world.openfoodfacts.org';
-const OFF_PRODUCT_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
-const OFF_TIMEOUT_MS = 8000;
+const OFF_BASE_URL = 'https://world.openfoodfacts.org';
+const OFF_TIMEOUT_MS = 5_000;
 
-type OffStatus = 'OK' | 'NOT_FOUND' | 'INVALID' | 'ERROR';
-type OffSource = 'openfoodfacts' | 'local_override';
+export type OffFetchStatus = 'OK' | 'NOT_FOUND' | 'ERROR' | 'TIMEOUT' | 'INVALID';
+
+export type OffProductMinimal = {
+  barcode: string;
+  productName?: string;
+  brands?: string;
+  imageUrl?: string;
+  quantity?: string;
+  categories?: string[];
+  stores?: string;
+  nutriments?: Record<string, unknown>;
+};
+
+type OffApiResponse = {
+  status?: number;
+  product?: Record<string, unknown>;
+};
+
+type FetchOptions = {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
+export type OffFetchResult = {
+  status: OffFetchStatus;
+  product?: OffProductMinimal;
+  sourceUrl: string;
+  responseMs: number;
+  errorKind?: 'NETWORK' | 'HTTP' | 'ABORT' | 'INVALID';
+};
+
+function isBarcodeValid(barcode: string): boolean {
+  return /^\d{8,14}$/.test(barcode);
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const valid = value
+    .map((entry) => asString(entry))
+    .filter((entry): entry is string => Boolean(entry));
+
+  return valid.length > 0 ? valid : undefined;
+}
+
+export function mapOffResponseToMinimal(json: unknown): OffProductMinimal | null {
+  const payload = json as OffApiResponse;
+  if (!payload || payload.status !== 1 || !payload.product) {
+    return null;
+  }
+
+  const product = payload.product;
+  const barcode = asString(product.code) ?? asString((payload as Record<string, unknown>).code);
+
+  return {
+    barcode: barcode ?? '',
+    productName: asString(product.product_name),
+    brands: asString(product.brands),
+    imageUrl: asString(product.image_url) ?? asString(product.image_front_url),
+    quantity: asString(product.quantity),
+    categories: asStringArray(product.categories_tags),
+    stores: asString(product.stores),
+    nutriments: typeof product.nutriments === 'object' && product.nutriments !== null
+      ? (product.nutriments as Record<string, unknown>)
+      : undefined,
+  };
+}
+
+function buildOffUrl(barcode: string): string {
+  return `${OFF_BASE_URL}/api/v2/product/${encodeURIComponent(barcode)}.json`;
+}
+
+async function fetchOnce(
+  barcode: string,
+  options: FetchOptions,
+  sourceUrl: string
+): Promise<OffFetchResult> {
+  const startedAt = performance.now();
+  const timeoutMs = options.timeoutMs ?? OFF_TIMEOUT_MS;
+
+  const timeoutController = new AbortController();
+  const mergedSignal = options.signal;
+  const timeoutId = window.setTimeout(() => timeoutController.abort(), timeoutMs);
+
+  const abortListener = () => timeoutController.abort();
+  if (mergedSignal) {
+    mergedSignal.addEventListener('abort', abortListener, { once: true });
+  }
+
+  try {
+    const response = await fetch(sourceUrl, {
+      method: 'GET',
+      signal: timeoutController.signal,
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    const responseMs = Math.round(performance.now() - startedAt);
+
+    if (response.status === 404) {
+      return { status: 'NOT_FOUND', sourceUrl, responseMs };
+    }
+
+    if (!response.ok) {
+      return { status: 'ERROR', sourceUrl, responseMs, errorKind: 'HTTP' };
+    }
+
+    const json = (await response.json()) as OffApiResponse;
+
+    if (json.status === 0) {
+      return { status: 'NOT_FOUND', sourceUrl, responseMs };
+    }
+
+    const mapped = mapOffResponseToMinimal(json);
+    if (!mapped) {
+      return { status: 'ERROR', sourceUrl, responseMs, errorKind: 'HTTP' };
+    }
+
+    mapped.barcode = mapped.barcode || barcode;
+    return {
+      status: 'OK',
+      product: mapped,
+      sourceUrl,
+      responseMs,
+    };
+  } catch (error) {
+    const responseMs = Math.round(performance.now() - startedAt);
+    const isAbort = error instanceof DOMException && error.name === 'AbortError';
+    return {
+      status: isAbort ? 'TIMEOUT' : 'ERROR',
+      sourceUrl,
+      responseMs,
+      errorKind: isAbort ? 'ABORT' : 'NETWORK',
+    };
+  } finally {
+    window.clearTimeout(timeoutId);
+    if (mergedSignal) {
+      mergedSignal.removeEventListener('abort', abortListener);
+    }
+  }
+}
+
+export async function fetchOffProduct(
+  barcode: string,
+  options: FetchOptions = {}
+): Promise<OffFetchResult> {
+  const sourceUrl = buildOffUrl(barcode);
+
+  if (!isBarcodeValid(barcode)) {
+    return { status: 'INVALID', sourceUrl, responseMs: 0, errorKind: 'INVALID' };
+  }
+
+  const first = await fetchOnce(barcode, options, sourceUrl);
+  if (first.status !== 'ERROR' || first.errorKind !== 'NETWORK') {
+    return first;
+  }
+
+  // lightweight retry only for network errors
+  return fetchOnce(barcode, options, sourceUrl);
+}
 
 export type OffProductResult = {
-  status: OffStatus;
-  source?: OffSource;
-  message?: string;
+  status: 'OK' | 'NOT_FOUND' | 'INVALID' | 'ERROR';
   barcode: string;
   product?: {
     name?: string;
@@ -20,148 +181,8 @@ export type OffProductResult = {
     quantity?: string;
     categories?: string[];
   };
-  raw?: unknown;
   error?: { message: string; code?: string };
 };
-
-type OffApiProduct = {
-  product_name?: unknown;
-  brands?: unknown;
-  image_url?: unknown;
-  quantity?: unknown;
-  categories_tags?: unknown;
-  nutriscore_grade?: unknown;
-  nova_group?: unknown;
-  ecoscore_grade?: unknown;
-  nutriments?: unknown;
-  ingredients_text?: unknown;
-  allergens?: unknown;
-};
-
-type OffApiResponse = {
-  status?: unknown;
-  product?: OffApiProduct;
-};
-
-export type OffProductUiModel = {
-  barcode: string;
-  name?: string;
-  brand?: string;
-  image?: string;
-  quantity?: string;
-  nutriScore?: string;
-  nova?: number;
-  ecoScore?: string;
-  nutriments: {
-    kcal?: number;
-    sugars?: number;
-    fat?: number;
-    salt?: number;
-  };
-  ingredients?: string;
-  allergens?: string;
-  categories?: string[];
-  nutritionPer100g?: {
-    energyKj?: number;
-    energyKcal?: number;
-    fat?: number;
-    saturatedFat?: number;
-    carbs?: number;
-    sugars?: number;
-    fiber?: number;
-    protein?: number;
-    salt?: number;
-  };
-  source?: OffSource;
-  sourceMessage?: string;
-};
-
-function getOffBaseUrl(): string {
-  const configuredBaseUrl = import.meta.env.VITE_OPEN_FOOD_FACTS_BASE_URL;
-  return typeof configuredBaseUrl === 'string' && configuredBaseUrl.trim().length > 0
-    ? configuredBaseUrl.trim()
-    : OFF_DEFAULT_BASE_URL;
-}
-
-function isBarcodeValid(barcode: string): boolean {
-  return /^\d{8,14}$/.test(barcode);
-}
-
-function cacheKey(barcode: string): string {
-  return `off:product:${barcode}`;
-}
-
-function safeString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
-}
-
-function safeStringArray(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-
-  const cleaned = value
-    .filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
-    .map((entry) => entry.trim());
-
-  return cleaned.length > 0 ? cleaned : undefined;
-}
-
-function mapApiResponse(barcode: string, payload: OffApiResponse): OffProductResult {
-  if (payload.status === 0) {
-    return {
-      status: 'NOT_FOUND',
-      barcode,
-    };
-  }
-
-  if (payload.status !== 1 || !payload.product) {
-    return {
-      status: 'ERROR',
-      barcode,
-      error: {
-        message: 'Réponse Open Food Facts invalide',
-        code: 'INVALID_RESPONSE',
-      },
-    };
-  }
-
-  const normalizedProduct = {
-    name: safeString(payload.product.product_name),
-    brands: safeString(payload.product.brands),
-    imageUrl: safeString(payload.product.image_url),
-    quantity: safeString(payload.product.quantity),
-    categories: safeStringArray(payload.product.categories_tags),
-  };
-
-  return {
-    status: 'OK',
-    source: 'openfoodfacts',
-    barcode,
-    product: normalizedProduct,
-    ...(import.meta.env.DEV ? { raw: payload } : {}),
-  };
-}
-
-function getLocalOverrideResult(barcode: string): OffProductResult | null {
-  const override = getProductOverride(barcode);
-  if (!override) {
-    return null;
-  }
-
-  return {
-    status: 'OK',
-    source: 'local_override',
-    message: 'données internes',
-    barcode,
-    product: {
-      name: override.productName,
-      brands: override.brand,
-      quantity: override.quantity,
-      categories: override.categories,
-    },
-  };
-}
 
 export function validateBarcode(barcode: string): OffProductResult | null {
   if (isBarcodeValid(barcode)) {
@@ -178,290 +199,79 @@ export function validateBarcode(barcode: string): OffProductResult | null {
   };
 }
 
-export async function fetchOffProductByBarcode(
-  barcode: string,
-  opts?: { signal?: AbortSignal }
-): Promise<OffProductResult> {
+export async function fetchOffProductByBarcode(barcode: string, opts?: { signal?: AbortSignal }): Promise<OffProductResult> {
   const invalid = validateBarcode(barcode);
   if (invalid) {
     return invalid;
   }
 
-  const cached = getCachedWithTTL<Pick<OffProductResult, 'status' | 'barcode' | 'product'>>(
-    cacheKey(barcode),
-    OFF_PRODUCT_CACHE_TTL_MS
-  );
+  const result = await fetchOffProduct(barcode, { signal: opts?.signal });
 
-  if (cached) {
-    return cached;
-  }
-
-  const externalSignal = opts?.signal;
-  const controller = externalSignal ? null : new window.AbortController();
-  const timeout = controller ? window.setTimeout(() => controller.abort(), OFF_TIMEOUT_MS) : null;
-
-  try {
-    const response = await fetch(
-      `${getOffBaseUrl()}/api/v2/product/${encodeURIComponent(barcode)}.json`,
-      {
-        method: 'GET',
-        signal: externalSignal ?? controller?.signal,
-        headers: {
-          'Accept': 'application/json',
-        },
-      }
-    );
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        const local = getLocalOverrideResult(barcode);
-        if (local) {
-          return local;
-        }
-      }
-      return {
-        status: 'ERROR',
-        barcode,
-        error: {
-          message: `Erreur Open Food Facts (${response.status})`,
-          code: 'HTTP_ERROR',
-        },
-      };
-    }
-
-    const payload = (await response.json()) as OffApiResponse;
-    const mapped = mapApiResponse(barcode, payload);
-
-    if (mapped.status === 'NOT_FOUND') {
-      const local = getLocalOverrideResult(barcode);
-      if (local) {
-        return local;
-      }
-    }
-
-    if (mapped.status === 'OK' || mapped.status === 'NOT_FOUND') {
-      setCachedJson(cacheKey(barcode), {
-        status: mapped.status,
-        barcode: mapped.barcode,
-        product: mapped.product,
-      });
-    }
-
-    return mapped;
-  } catch (error: unknown) {
-    const errorName = error instanceof Error ? error.name : '';
-    const isAbortError = errorName === 'AbortError';
-    return {
-      status: 'ERROR',
-      barcode,
-      error: {
-        message: isAbortError
-          ? 'Délai dépassé lors de la requête Open Food Facts'
-          : 'Erreur réseau lors de la requête Open Food Facts',
-        code: isAbortError ? 'TIMEOUT' : 'NETWORK_ERROR',
-      },
-    };
-  } finally {
-    if (timeout) {
-      window.clearTimeout(timeout);
-    }
-  }
-}
-
-const OFF_PRODUCT_FIELDS = [
-  'product_name',
-  'brands',
-  'image_url',
-  'nutriscore_grade',
-  'nova_group',
-  'nutriments',
-  'ingredients_text',
-  'allergens',
-  'quantity',
-  'ecoscore_grade',
-].join(',');
-
-function safeNumber(value: unknown): number | undefined {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return value;
-  }
-
-  if (typeof value === 'string') {
-    const parsed = Number.parseFloat(value);
-    return Number.isFinite(parsed) ? parsed : undefined;
-  }
-
-  return undefined;
-}
-
-function mapToUiModel(barcode: string, product: OffApiProduct): OffProductUiModel {
-  const nutriments = typeof product.nutriments === 'object' && product.nutriments !== null
-    ? product.nutriments as Record<string, unknown>
-    : {};
-
-  return {
-    barcode,
-    name: safeString(product.product_name),
-    brand: safeString(product.brands),
-    image: safeString(product.image_url),
-    quantity: safeString(product.quantity),
-    nutriScore: safeString(product.nutriscore_grade)?.toUpperCase(),
-    nova: safeNumber(product.nova_group),
-    ecoScore: safeString(product.ecoscore_grade)?.toUpperCase(),
-    nutriments: {
-      kcal: safeNumber(nutriments['energy-kcal_100g']),
-      sugars: safeNumber(nutriments.sugars_100g),
-      fat: safeNumber(nutriments.fat_100g),
-      salt: safeNumber(nutriments.salt_100g),
-    },
-    ingredients: safeString(product.ingredients_text),
-    allergens: safeString(product.allergens),
-    source: 'openfoodfacts',
-  };
-}
-
-function mapOverrideToUiModel(barcode: string): OffProductUiModel | null {
-  const override = getProductOverride(barcode);
-  if (!override) {
-    return null;
-  }
-
-  return {
-    barcode,
-    name: override.productName,
-    brand: override.brand,
-    quantity: override.quantity,
-    nutriments: {
-      kcal: override.nutritionPer100g?.energyKcal,
-      sugars: override.nutritionPer100g?.sugars,
-      fat: override.nutritionPer100g?.fat,
-      salt: override.nutritionPer100g?.salt,
-    },
-    ingredients: override.ingredientsText,
-    categories: override.categories,
-    nutritionPer100g: override.nutritionPer100g,
-    source: 'local_override',
-    sourceMessage: 'données internes',
-  };
-}
-
-export async function fetchOffProductDetails(
-  barcode: string,
-  opts?: { signal?: AbortSignal }
-): Promise<OffProductResult & { ui?: OffProductUiModel }> {
-  const invalid = validateBarcode(barcode);
-  if (invalid) {
-    return invalid;
-  }
-
-  try {
-    const response = await fetch(
-      `${getOffBaseUrl()}/api/v2/product/${encodeURIComponent(barcode)}.json?fields=${OFF_PRODUCT_FIELDS}`,
-      {
-        method: 'GET',
-        signal: opts?.signal,
-        headers: {
-          Accept: 'application/json',
-        },
-      }
-    );
-
-    if (!response.ok) {
-      if (response.status === 404) {
-        const localUi = mapOverrideToUiModel(barcode);
-        if (localUi) {
-          return {
-            status: 'OK',
-            source: 'local_override',
-            message: 'données internes',
-            barcode,
-            ui: localUi,
-            product: {
-              name: localUi.name,
-              brands: localUi.brand,
-              quantity: localUi.quantity,
-              categories: localUi.categories,
-            },
-          };
-        }
-      }
-      return {
-        status: response.status === 404 ? 'NOT_FOUND' : 'ERROR',
-        barcode,
-        error: {
-          message: `Erreur Open Food Facts (${response.status})`,
-          code: 'HTTP_ERROR',
-        },
-      };
-    }
-
-    const payload = (await response.json()) as OffApiResponse;
-
-    if (payload.status === 0 || !payload.product) {
-      const localUi = mapOverrideToUiModel(barcode);
-      if (localUi) {
-        return {
-          status: 'OK',
-          source: 'local_override',
-          message: 'données internes',
-          barcode,
-          ui: localUi,
-          product: {
-            name: localUi.name,
-            brands: localUi.brand,
-            quantity: localUi.quantity,
-            categories: localUi.categories,
-          },
-        };
-      }
-      return {
-        status: 'NOT_FOUND',
-        barcode,
-      };
-    }
-
-    if (payload.status !== 1) {
-      return {
-        status: 'ERROR',
-        barcode,
-        error: {
-          message: 'Réponse Open Food Facts invalide',
-          code: 'INVALID_RESPONSE',
-        },
-      };
-    }
-
+  if (result.status === 'OK') {
     return {
       status: 'OK',
-      source: 'openfoodfacts',
       barcode,
-      ui: mapToUiModel(barcode, payload.product),
       product: {
-        name: safeString(payload.product.product_name),
-        brands: safeString(payload.product.brands),
-        imageUrl: safeString(payload.product.image_url),
-        quantity: safeString(payload.product.quantity),
-      },
-    };
-  } catch (error: unknown) {
-    const errorName = error instanceof Error ? error.name : '';
-    const isAbortError = errorName === 'AbortError';
-    return {
-      status: 'ERROR',
-      barcode,
-      error: {
-        message: isAbortError
-          ? 'Délai dépassé lors de la requête Open Food Facts'
-          : 'Erreur réseau lors de la requête Open Food Facts',
-        code: isAbortError ? 'TIMEOUT' : 'NETWORK_ERROR',
+        name: result.product?.productName,
+        brands: result.product?.brands,
+        imageUrl: result.product?.imageUrl,
+        quantity: result.product?.quantity,
+        categories: result.product?.categories,
       },
     };
   }
+
+  if (result.status === 'NOT_FOUND') {
+    return { status: 'NOT_FOUND', barcode };
+  }
+
+  if (result.status === 'INVALID') {
+    return {
+      status: 'INVALID',
+      barcode,
+      error: {
+        message: 'Code-barres invalide. Format attendu: 8 à 14 chiffres.',
+        code: 'INVALID_BARCODE',
+      },
+    };
+  }
+
+  return {
+    status: 'ERROR',
+    barcode,
+    error: {
+      message: result.status === 'TIMEOUT' ? 'Délai dépassé lors de la requête Open Food Facts' : 'Erreur réseau Open Food Facts',
+      code: result.status === 'TIMEOUT' ? 'TIMEOUT' : 'NETWORK_ERROR',
+    },
+  };
 }
 
-export const __offInternals = {
-  cacheKey,
-  isBarcodeValid,
-  mapApiResponse,
-  OFF_PRODUCT_CACHE_TTL_MS,
-};
+export async function fetchCachedOrRemoteOffProduct(
+  barcode: string,
+  options: FetchOptions = {}
+): Promise<OffFetchResult & { cacheHit: boolean }> {
+  const cached = getCached(barcode);
+  const sourceUrl = buildOffUrl(barcode);
+  if (cached) {
+    return {
+      status: cached.status,
+      product: cached.data ?? undefined,
+      sourceUrl,
+      responseMs: 0,
+      cacheHit: true,
+    };
+  }
+
+  const remote = await fetchOffProduct(barcode, options);
+  if (remote.status === 'OK' || remote.status === 'NOT_FOUND') {
+    setCached(barcode, {
+      status: remote.status,
+      data: remote.product ?? null,
+    });
+  }
+
+  return {
+    ...remote,
+    cacheHit: false,
+  };
+}

--- a/frontend/src/services/prices.ts
+++ b/frontend/src/services/prices.ts
@@ -1,0 +1,138 @@
+import { SEED_PRODUCTS } from '../data/seedProducts';
+import { SEED_STORES } from '../data/seedStores';
+import type { ProductOffer, ProductPriceStats, Store } from '../types/store';
+import type { Territory } from '../types/territory';
+
+type SeedPrice = {
+  storeId?: string;
+  storeName?: string;
+  territory?: string;
+  city?: string;
+  price?: number;
+  currency?: string;
+  ts?: string;
+};
+
+type SeedProduct = {
+  ean?: string;
+  prices?: SeedPrice[];
+};
+
+type SeedStore = {
+  id?: string;
+  name?: string;
+  chain?: string;
+  companyId?: string;
+  territory?: Territory;
+  address?: string;
+  city?: string;
+  postalCode?: string;
+  coordinates?: { lat?: number; lon?: number };
+  phone?: string;
+  openingHours?: string;
+  services?: string[];
+};
+
+function toStore(seedStore: SeedStore): Store | null {
+  if (!seedStore.id || !seedStore.name) {
+    return null;
+  }
+
+  return {
+    id: seedStore.id,
+    name: seedStore.name,
+    brand: seedStore.chain,
+    groupId: seedStore.companyId,
+    territory: seedStore.territory,
+    address: seedStore.address,
+    city: seedStore.city,
+    postalCode: seedStore.postalCode,
+    location: (() => {
+      const lat = seedStore.coordinates?.lat;
+      const lon = seedStore.coordinates?.lon;
+      return typeof lat === 'number' && typeof lon === 'number' ? { lat, lng: lon } : undefined;
+    })(),
+    phone: seedStore.phone,
+    openingHours: seedStore.openingHours,
+    tags: seedStore.services,
+    updatedAt: undefined,
+  };
+}
+
+function asTerritory(value: string | undefined): Territory | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized.includes('guadeloupe')) return 'gp';
+  if (normalized.includes('martinique')) return 'mq';
+  if (normalized.includes('guyane')) return 'gf';
+  if (normalized.includes('réunion') || normalized.includes('reunion')) return 're';
+  if (normalized.includes('mayotte')) return 'yt';
+  if (normalized.includes('france')) return 'fr';
+
+  return undefined;
+}
+
+export function computePriceStats(offers: ProductOffer[]): ProductPriceStats | null {
+  if (offers.length === 0) {
+    return null;
+  }
+
+  const sorted = [...offers].map((offer) => offer.price).sort((a, b) => a - b);
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+  const middle = Math.floor(sorted.length / 2);
+  const median = sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+
+  return {
+    min,
+    max,
+    median,
+    observations: offers.length,
+  };
+}
+
+export async function getOffersForProduct(params: {
+  barcode: string;
+  territory?: Territory;
+}): Promise<ProductOffer[]> {
+  const seedProducts = SEED_PRODUCTS as SeedProduct[];
+  const product = seedProducts.find((entry) => entry.ean === params.barcode);
+  if (!product?.prices) {
+    return [];
+  }
+
+  const offers = product.prices
+    .filter((price) => typeof price.price === 'number')
+    .map((price) => {
+      return {
+        barcode: params.barcode,
+        price: price.price as number,
+        observedAt: price.ts,
+        currency: price.currency ?? 'EUR',
+        reliability: 'medium' as const,
+        storeId: price.storeId,
+        storeName: price.storeName,
+        territory: asTerritory(price.territory),
+        city: price.city,
+      };
+    })
+    .filter((offer) => !params.territory || offer.territory === params.territory)
+    .sort((a, b) => a.price - b.price);
+
+  return offers;
+}
+
+export async function getStore(storeId: string): Promise<Store | null> {
+  const seedStores = SEED_STORES as SeedStore[];
+  const seedStore = seedStores.find((store) => store.id === storeId);
+  if (!seedStore) {
+    return null;
+  }
+
+  return toStore(seedStore);
+}

--- a/frontend/src/services/productCache.ts
+++ b/frontend/src/services/productCache.ts
@@ -1,0 +1,133 @@
+import type { OffProductMinimal, OffFetchStatus } from './openFoodFacts';
+
+type CacheEntry = {
+  at: number;
+  data: OffProductMinimal | null;
+  status: OffFetchStatus;
+};
+
+type CachePayload = Record<string, CacheEntry>;
+
+const CACHE_KEY = 'akp_off_cache_v1';
+const MAX_ENTRIES = 300;
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+const memoryCache = new Map<string, CacheEntry>();
+let hydrated = false;
+let persistTimer: number | null = null;
+
+function now(): number {
+  return Date.now();
+}
+
+function isExpired(entry: CacheEntry, ttlMs = DEFAULT_TTL_MS): boolean {
+  return now() - entry.at > ttlMs;
+}
+
+function canUseStorage(): boolean {
+  return typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+}
+
+function hydrateFromStorage(): void {
+  if (hydrated || !canUseStorage()) {
+    hydrated = true;
+    return;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(CACHE_KEY);
+    if (!raw) {
+      hydrated = true;
+      return;
+    }
+
+    const parsed = JSON.parse(raw) as CachePayload;
+    Object.entries(parsed).forEach(([barcode, entry]) => {
+      if (entry && typeof entry.at === 'number' && typeof entry.status === 'string') {
+        memoryCache.set(barcode, entry);
+      }
+    });
+  } catch {
+    // no-op: cache corruption should not break product page
+  } finally {
+    hydrated = true;
+  }
+}
+
+function flushPersistToStorage(): void {
+  if (!canUseStorage()) {
+    return;
+  }
+
+  try {
+    const payload = Object.fromEntries(memoryCache.entries());
+    window.localStorage.setItem(CACHE_KEY, JSON.stringify(payload));
+  } catch {
+    // ignore quota/storage errors
+  }
+}
+
+function schedulePersist(): void {
+  if (!canUseStorage()) {
+    return;
+  }
+
+  if (persistTimer !== null) {
+    return;
+  }
+
+  persistTimer = window.setTimeout(() => {
+    persistTimer = null;
+    flushPersistToStorage();
+  }, 1200);
+}
+
+export function pruneCache(): void {
+  hydrateFromStorage();
+
+  for (const [barcode, entry] of memoryCache.entries()) {
+    if (isExpired(entry)) {
+      memoryCache.delete(barcode);
+    }
+  }
+
+  const entries = [...memoryCache.entries()].sort((a, b) => a[1].at - b[1].at);
+  while (entries.length > MAX_ENTRIES) {
+    const oldest = entries.shift();
+    if (!oldest) {
+      break;
+    }
+
+    memoryCache.delete(oldest[0]);
+  }
+
+  schedulePersist();
+}
+
+export function getCached(barcode: string, ttlMs = DEFAULT_TTL_MS): CacheEntry | null {
+  hydrateFromStorage();
+
+  const entry = memoryCache.get(barcode);
+  if (!entry) {
+    return null;
+  }
+
+  if (isExpired(entry, ttlMs)) {
+    memoryCache.delete(barcode);
+    schedulePersist();
+    return null;
+  }
+
+  return entry;
+}
+
+export function setCached(barcode: string, payload: { data: OffProductMinimal | null; status: OffFetchStatus }): void {
+  hydrateFromStorage();
+  memoryCache.set(barcode, {
+    at: now(),
+    data: payload.data,
+    status: payload.status,
+  });
+
+  pruneCache();
+}

--- a/frontend/src/services/storeCheapestProductsService.ts
+++ b/frontend/src/services/storeCheapestProductsService.ts
@@ -2,22 +2,140 @@ import { SEED_PRODUCTS } from '../data/seedProducts';
 import { SEED_STORES } from '../data/seedStores';
 import type { Territory } from '../types/territory';
 
-interface ProductPrice {
-  storeId: string;
+type PriceComparison = 'lower' | 'equal' | 'higher';
+
+type SeedPrice = {
+  storeId?: string;
+  price?: number;
+  territory?: string;
+  ts?: string;
+};
+
+type SeedProduct = {
+  ean?: string;
+  name?: string;
+  brand?: string;
+  size?: string;
+  category?: string;
+  prices?: SeedPrice[];
+};
+
+type SeedStore = {
+  id?: string;
+  territory?: Territory;
+};
+
+export interface CheapestProduct {
+  id: string;
+  name: string;
+  brand: string;
+  size: string;
+  category: string;
   price: number;
-  territory: Territory;
+  observationDate: string;
+  territoryAverage?: number;
+  priceComparison: PriceComparison;
+  savingsPercent?: number;
+  isCheapestInTerritory: boolean;
 }
 
-interface Product {
-  id: string;
-  name: string;
-  prices: ProductPrice[];
+function normalizeTerritory(value: string | undefined): Territory | undefined {
+  if (!value) return undefined;
+  const normalized = value.toLowerCase();
+  if (normalized.includes('guadeloupe')) return 'gp';
+  if (normalized.includes('martinique')) return 'mq';
+  if (normalized.includes('guyane')) return 'gf';
+  if (normalized.includes('réunion') || normalized.includes('reunion')) return 're';
+  if (normalized.includes('mayotte')) return 'yt';
+  return undefined;
 }
 
-interface Store {
-  id: string;
-  name: string;
-  territory: Territory;
+function toComparison(price: number, average?: number): PriceComparison {
+  if (typeof average !== 'number' || !Number.isFinite(average)) {
+    return 'equal';
+  }
+
+  const diff = price - average;
+  if (Math.abs(diff) < 0.01) return 'equal';
+  return diff < 0 ? 'lower' : 'higher';
+}
+
+export function getCheapestProductsAtStore(storeId: string, limit = 10): CheapestProduct[] {
+  const products = SEED_PRODUCTS as SeedProduct[];
+  const stores = SEED_STORES as SeedStore[];
+  const store = stores.find((entry) => entry.id === storeId);
+  const storeTerritory = store?.territory;
+
+  const result = products
+    .map((product) => {
+      const prices = product.prices ?? [];
+      const currentStorePrice = prices.find((price) => price.storeId === storeId && typeof price.price === 'number');
+      if (!currentStorePrice || typeof currentStorePrice.price !== 'number') {
+        return null;
+      }
+
+      const territoryPrices = prices
+        .filter((price) => typeof price.price === 'number')
+        .filter((price) => {
+          if (!storeTerritory) return true;
+          return normalizeTerritory(price.territory) === storeTerritory;
+        })
+        .map((price) => price.price as number);
+
+      const territoryAverage = territoryPrices.length > 0
+        ? territoryPrices.reduce((sum, value) => sum + value, 0) / territoryPrices.length
+        : undefined;
+      const territoryMin = territoryPrices.length > 0 ? Math.min(...territoryPrices) : currentStorePrice.price;
+      const savingsPercent = territoryAverage && territoryAverage > 0
+        ? Number((((territoryAverage - currentStorePrice.price) / territoryAverage) * 100).toFixed(1))
+        : undefined;
+
+      return {
+        id: product.ean ?? product.name ?? 'inconnu',
+        name: product.name ?? 'Produit',
+        brand: product.brand ?? 'Marque',
+        size: product.size ?? 'n/d',
+        category: product.category ?? 'divers',
+        price: currentStorePrice.price,
+        observationDate: currentStorePrice.ts ?? new Date().toISOString(),
+        territoryAverage,
+        priceComparison: toComparison(currentStorePrice.price, territoryAverage),
+        savingsPercent,
+        isCheapestInTerritory: Math.abs(currentStorePrice.price - territoryMin) < 0.01,
+      } as CheapestProduct;
+    })
+    .filter((entry): entry is CheapestProduct => Boolean(entry))
+    .sort((a, b) => a.price - b.price)
+    .slice(0, limit);
+
+  return result;
+}
+
+export function getPriceComparisonIcon(comparison: PriceComparison): string {
+  if (comparison === 'lower') return '↓';
+  if (comparison === 'higher') return '↑';
+  return '=';
+}
+
+export function getPriceComparisonColor(comparison: PriceComparison): string {
+  if (comparison === 'lower') return 'text-green-400';
+  if (comparison === 'higher') return 'text-amber-400';
+  return 'text-blue-400';
+}
+
+export function formatObservationDate(dateISO: string): string {
+  const date = new Date(dateISO);
+  if (Number.isNaN(date.getTime())) {
+    return 'date inconnue';
+  }
+
+  return date.toLocaleDateString('fr-FR');
+}
+
+export function calculateDataReliability(observationsCount: number): 'high' | 'medium' | 'low' {
+  if (observationsCount >= 20) return 'high';
+  if (observationsCount >= 8) return 'medium';
+  return 'low';
 }
 
 export interface CheapestProductResult {
@@ -29,38 +147,32 @@ export interface CheapestProductResult {
   territory: Territory;
 }
 
-/**
- * Return the cheapest product for each store in a given territory
- */
-export function getStoreCheapestProducts(
-  territory: Territory
-): CheapestProductResult[] {
-  const stores: Store[] = SEED_STORES.filter(
-    (store: Store) => store.territory === territory
+export function getStoreCheapestProducts(territory: Territory): CheapestProductResult[] {
+  const stores = (SEED_STORES as Array<{ id?: string; name?: string; territory?: Territory }>).filter(
+    (store) => store.territory === territory
   );
 
-  const products = SEED_PRODUCTS as readonly Product[];
+  const products = SEED_PRODUCTS as Array<{ ean?: string; name?: string; prices?: SeedPrice[] }>;
 
   const results: CheapestProductResult[] = [];
 
   for (const store of stores) {
+    if (!store.id || !store.name) continue;
     let cheapest: CheapestProductResult | null = null;
 
     for (const product of products) {
-      const priceEntry = product.prices.find(
-        (price: ProductPrice) =>
-          price.storeId === store.id &&
-          price.territory === territory
+      const priceEntry = product.prices?.find(
+        (price) => price.storeId === store.id && normalizeTerritory(price.territory) === territory && typeof price.price === 'number'
       );
 
-      if (!priceEntry) {
+      if (!priceEntry || typeof priceEntry.price !== 'number') {
         continue;
       }
 
       if (!cheapest || priceEntry.price < cheapest.price) {
         cheapest = {
-          productId: product.id,
-          productName: product.name,
+          productId: product.ean ?? product.name ?? 'unknown',
+          productName: product.name ?? 'Produit',
           storeId: store.id,
           storeName: store.name,
           price: priceEntry.price,

--- a/frontend/src/types/store.ts
+++ b/frontend/src/types/store.ts
@@ -1,0 +1,40 @@
+import type { Territory } from './territory';
+
+export type GroupId = string;
+export type StoreId = string;
+
+export interface Store {
+  id: StoreId;
+  name: string;
+  brand?: string;
+  groupId?: GroupId;
+  territory?: Territory;
+  address?: string;
+  city?: string;
+  postalCode?: string;
+  location?: { lat: number; lng: number };
+  phone?: string;
+  website?: string;
+  openingHours?: string;
+  tags?: string[];
+  updatedAt?: string;
+}
+
+export interface ProductOffer {
+  barcode: string;
+  price: number;
+  observedAt?: string;
+  currency: string;
+  reliability: 'high' | 'medium' | 'low';
+  storeId?: StoreId;
+  storeName?: string;
+  territory?: Territory;
+  city?: string;
+}
+
+export interface ProductPriceStats {
+  min: number;
+  max: number;
+  median: number;
+  observations: number;
+}

--- a/frontend/src/utils/cameraUtils.ts
+++ b/frontend/src/utils/cameraUtils.ts
@@ -1,0 +1,45 @@
+export type CameraPickResult = {
+  selectedDeviceId: string | null;
+  videoInputs: MediaDeviceInfo[];
+};
+
+const BACK_CAMERA_LABEL_REGEX = /back|rear|environment/i;
+
+async function safeEnumerateVideoInputs(): Promise<MediaDeviceInfo[]> {
+  if (!navigator.mediaDevices?.enumerateDevices) {
+    return [];
+  }
+
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  return devices.filter((device) => device.kind === 'videoinput');
+}
+
+export async function pickBestBackCameraDeviceId(): Promise<CameraPickResult> {
+  let videoInputs = await safeEnumerateVideoInputs();
+
+  if (videoInputs.length === 0 && navigator.mediaDevices?.getUserMedia) {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: { ideal: 'environment' } },
+        audio: false,
+      });
+      stream.getTracks().forEach((track) => track.stop());
+    } catch {
+      // If permission is denied, keep empty list and let caller fallback.
+    }
+
+    videoInputs = await safeEnumerateVideoInputs();
+  }
+
+  if (videoInputs.length === 0) {
+    return { selectedDeviceId: null, videoInputs };
+  }
+
+  const prioritized = videoInputs.find((device) => BACK_CAMERA_LABEL_REGEX.test(device.label));
+  const selected = prioritized ?? videoInputs[videoInputs.length - 1];
+
+  return {
+    selectedDeviceId: selected?.deviceId ?? null,
+    videoInputs,
+  };
+}


### PR DESCRIPTION
### Motivation
- Avoid false “no camera” on mobile by priming camera permission and make the scanner more reliable and debuggable. 
- Make product lookups more resilient and cache-aware to reduce OFF failures and expose diagnostics for debugging. 
- Harden served security headers and fix external navigation link edge cases while ensuring a more sober, institutional StoreDetail UI.

### Description
- Camera and scanner: added `frontend/src/utils/cameraUtils.ts` with `pickBestBackCameraDeviceId()` that enumerates devices, does a lightweight `getUserMedia()` when needed, and returns prioritized back-camera IDs; reworked `frontend/src/pages/ScannerHub.tsx` to attempt multiple device IDs, apply zoom/torch best-effort, validate GTIN/EAN check digits, stabilize detections with counters/timeouts, and surface a debug panel. 
- OFF/product flow: replaced and expanded OFF fetching with `frontend/src/services/openFoodFacts.ts`, added local caching via `frontend/src/services/productCache.ts`, and added `fetchCachedOrRemoteOffProduct` which returns rich status/timeout info; updated `frontend/src/pages/ProductScanResult.tsx` to consume the cached/remote flow and show OFF debug + price offers. 
- Prices & store helpers: introduced `frontend/src/services/prices.ts`, `frontend/src/services/storeCheapestProductsService.ts` updates, and `frontend/src/types/store.ts` plus `StoreQuickDetail` page to support price UI and seeded data usage. 
- Navigation & security: hardened CSP in `frontend/public/_headers` (added `base-uri 'self'`, `object-src 'none'`, `worker-src 'self' blob:`, and broader `connect-src` entries) and made `frontend/src/components/NavigateButtons.tsx` URL-encode destinations with `encodeURIComponent`. 
- UX polish and events: added cart toast in `frontend/src/components/Layout.jsx` triggered by a safe `ti-panier:item-added` event emitted from `frontend/src/hooks/useTiPanier.ts`, surfaced cart counts in `Header` and `FabActions`, and removed decorative emojis from `frontend/src/pages/StoreDetail.tsx` to match institutional styling.

### Testing
- Ran `cd frontend && npm run lint`, which completed with warnings only (no errors). 
- Ran `cd frontend && npm run build`, which succeeded and produced production artifacts. 
- Started the dev server and captured a Playwright screenshot of `/store/leader_price_pointe_pitre` to validate the StoreDetail visual update and navigation button rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995e085ea848321a01b9cf44b2a96e4)