### PR TITLE
Update scanner heading to SCANNER V3 DEV TEST

### DIFF
--- a/frontend/src/pages/ScannerHub.tsx
+++ b/frontend/src/pages/ScannerHub.tsx
@@ -88,7 +88,7 @@ export default function ScannerHub() {
 
       <main className="min-h-screen bg-slate-950 p-4 pt-24 text-white">
         <section className="mx-auto w-full max-w-4xl rounded-2xl border border-slate-800 bg-slate-900 p-4">
-          <h1 className="mb-3 text-2xl font-semibold">Scanner un code-barres</h1>
+          <h1 className="mb-3 text-2xl font-semibold">SCANNER V3 DEV TEST</h1>
           <p className="mb-4 text-sm text-slate-300">
             Scan continu actif: caméra en boucle, anti-doublon et ajout rapide au panier.
           </p>


### PR DESCRIPTION
### Motivation
- Modifier le titre affiché de la page de scan pour remplacer `Scanner un code-barres` par `SCANNER V3 DEV TEST` afin de refléter un message de test/variation de développement.

### Description
- Remplacé le texte du `h1` dans `frontend/src/pages/ScannerHub.tsx` pour afficher `SCANNER V3 DEV TEST` au lieu de `Scanner un code-barres` et aucune autre logique n'a été modifiée.

### Testing
- Exécuté `npm run lint --prefix frontend` (terminé avec warnings existants du dépôt mais sans erreurs bloquantes) et démarré le serveur de développement puis capturé une capture d'écran de `/scanner` pour vérifier visuellement que le nouveau titre s'affiche correctement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996594fc42483219d221c2cf2b62783)