### PR TITLE
feat: add premium funnel UX, savings simulator and local freemium access

### DIFF
--- a/frontend/src/domain/shoppingList/premium/alerts.ts
+++ b/frontend/src/domain/shoppingList/premium/alerts.ts
@@ -1,0 +1,41 @@
+import type { PriceHistoryPoint } from './trend';
+
+export type AlertInput = {
+  price?: number;
+  priceHistory?: PriceHistoryPoint[];
+};
+
+function median(values: number[]): number | null {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[middle - 1] + sorted[middle]) / 2;
+  }
+  return sorted[middle];
+}
+
+export function computeAlerts(item: AlertInput): string[] {
+  const alerts: string[] = [];
+  if (!Number.isFinite(item.price)) return alerts;
+
+  const now = Date.now();
+  const cutoff = now - (30 * 24 * 60 * 60 * 1000);
+  const values30d = (item.priceHistory ?? [])
+    .filter((point) => {
+      const ts = new Date(point.observedAt).getTime();
+      return Number.isFinite(ts) && ts >= cutoff && Number.isFinite(point.price);
+    })
+    .map((point) => point.price);
+
+  const median30 = median(values30d);
+  if (!median30 || median30 <= 0) return alerts;
+
+  const lastPrice = item.price as number;
+  if (lastPrice < median30 * (1 - 0.05)) {
+    const deltaPct = ((median30 - lastPrice) / median30) * 100;
+    alerts.push(`Baisse -${deltaPct.toFixed(1)}% vs médiane 30j`);
+  }
+
+  return alerts;
+}

--- a/frontend/src/domain/shoppingList/premium/index.ts
+++ b/frontend/src/domain/shoppingList/premium/index.ts
@@ -1,0 +1,6 @@
+export * from './alerts';
+export * from './normalization';
+export * from './recommendation';
+export * from './scoring';
+export * from './trend';
+export * from './savingsSimulator';

--- a/frontend/src/domain/shoppingList/premium/normalization.ts
+++ b/frontend/src/domain/shoppingList/premium/normalization.ts
@@ -1,0 +1,64 @@
+export type QuantityUnit = 'kg' | 'g' | 'l' | 'ml' | 'unit';
+export type NormalizedUnit = 'kg' | 'l' | 'unit';
+
+export type NormalizePriceInput = {
+  price?: number;
+  unit?: string;
+  quantityValue?: number;
+  quantityUnit?: QuantityUnit;
+};
+
+export type NormalizePriceOutput = {
+  pricePerUnit?: number;
+  normalizedLabel: string;
+};
+
+function toNumber(value?: number): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+  return value;
+}
+
+function toTargetUnitQuantity(quantityValue?: number, quantityUnit?: QuantityUnit): { normalizedUnit: NormalizedUnit; quantity: number } | null {
+  const value = toNumber(quantityValue);
+  if (!value || !quantityUnit) return null;
+
+  if (quantityUnit === 'kg') return { normalizedUnit: 'kg', quantity: value };
+  if (quantityUnit === 'g') return { normalizedUnit: 'kg', quantity: value / 1000 };
+  if (quantityUnit === 'l') return { normalizedUnit: 'l', quantity: value };
+  if (quantityUnit === 'ml') return { normalizedUnit: 'l', quantity: value / 1000 };
+  return { normalizedUnit: 'unit', quantity: value };
+}
+
+export function normalizePrice(input: NormalizePriceInput): NormalizePriceOutput {
+  const price = toNumber(input.price);
+  if (!price) {
+    return { normalizedLabel: 'Prix indisponible' };
+  }
+
+  const normalizedQuantity = toTargetUnitQuantity(input.quantityValue, input.quantityUnit);
+  const normalizedUnit = input.unit === 'kg' || input.unit === 'l' || input.unit === 'unit' ? input.unit : normalizedQuantity?.normalizedUnit;
+
+  if (!normalizedQuantity || !normalizedUnit || normalizedQuantity.quantity <= 0) {
+    return {
+      pricePerUnit: price,
+      normalizedLabel: `${price.toFixed(2)} €/unité`,
+    };
+  }
+
+  if (normalizedUnit !== normalizedQuantity.normalizedUnit) {
+    return {
+      pricePerUnit: price,
+      normalizedLabel: `${price.toFixed(2)} €/unité`,
+    };
+  }
+
+  const perUnit = price / normalizedQuantity.quantity;
+  const unitLabel = normalizedUnit === 'kg' ? 'kg' : normalizedUnit === 'l' ? 'L' : 'unité';
+
+  return {
+    pricePerUnit: perUnit,
+    normalizedLabel: `${perUnit.toFixed(2)} €/` + unitLabel,
+  };
+}

--- a/frontend/src/domain/shoppingList/premium/recommendation.ts
+++ b/frontend/src/domain/shoppingList/premium/recommendation.ts
@@ -1,0 +1,31 @@
+import { computeAlerts } from './alerts';
+import { computeConfidenceScore } from './scoring';
+import { computeTrend, type PriceHistoryPoint } from './trend';
+
+export type RecommendationInput = {
+  price?: number;
+  source?: string;
+  lastObservedAt?: string;
+  priceHistory?: PriceHistoryPoint[];
+};
+
+export type PremiumRecommendation = {
+  verdict: string;
+  reason: string;
+};
+
+export function computePremiumRecommendation(item: RecommendationInput): PremiumRecommendation {
+  const trend7 = computeTrend(item.priceHistory ?? [], 7);
+  const score = computeConfidenceScore(item);
+  const alerts = computeAlerts(item);
+
+  if (trend7.trend === 'down' && alerts.length > 0) {
+    return { verdict: 'Attendre', reason: alerts[0] };
+  }
+
+  if (trend7.trend === 'up' && score >= 70) {
+    return { verdict: 'Acheter maintenant', reason: 'Tendance haussière avec confiance élevée' };
+  }
+
+  return { verdict: 'Surveiller', reason: 'Données insuffisantes ou signal neutre' };
+}

--- a/frontend/src/domain/shoppingList/premium/savingsSimulator.ts
+++ b/frontend/src/domain/shoppingList/premium/savingsSimulator.ts
@@ -1,0 +1,46 @@
+import type { PriceHistoryPoint } from './trend';
+
+export type SavingsSimulatorItem = {
+  quantity?: number;
+  lastPrice?: number;
+  trend30?: 'up' | 'down' | 'flat';
+  priceHistory?: PriceHistoryPoint[];
+};
+
+export type SavingsSimulationResult = {
+  potentialSavings: number;
+  currency: 'EUR';
+  trackedItems: number;
+};
+
+function minPriceLast30Days(history: PriceHistoryPoint[]): number | null {
+  const cutoff = Date.now() - (30 * 24 * 60 * 60 * 1000);
+  const prices = history
+    .filter((point) => {
+      const ts = new Date(point.observedAt).getTime();
+      return Number.isFinite(ts) && ts >= cutoff && Number.isFinite(point.price) && point.price > 0;
+    })
+    .map((point) => point.price);
+
+  if (!prices.length) return null;
+  return Math.min(...prices);
+}
+
+export function simulateMonthlySavings(items: SavingsSimulatorItem[]): SavingsSimulationResult {
+  const potentialSavings = items.reduce((sum, item) => {
+    if (item.trend30 !== 'down') return sum;
+    if (!item.lastPrice || item.lastPrice <= 0) return sum;
+
+    const min30 = minPriceLast30Days(item.priceHistory ?? []);
+    if (!min30 || min30 >= item.lastPrice) return sum;
+
+    const quantity = item.quantity && item.quantity > 0 ? item.quantity : 1;
+    return sum + ((item.lastPrice - min30) * quantity);
+  }, 0);
+
+  return {
+    potentialSavings: Number(potentialSavings.toFixed(2)),
+    currency: 'EUR',
+    trackedItems: items.length,
+  };
+}

--- a/frontend/src/domain/shoppingList/premium/scoring.ts
+++ b/frontend/src/domain/shoppingList/premium/scoring.ts
@@ -1,0 +1,48 @@
+import type { PriceHistoryPoint } from './trend';
+
+export type ConfidenceInput = {
+  source?: string;
+  lastObservedAt?: string;
+  priceHistory?: PriceHistoryPoint[];
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function stdDeviation(values: number[]): number {
+  if (values.length < 2) return 0;
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
+  const variance = values.reduce((sum, value) => sum + ((value - mean) ** 2), 0) / values.length;
+  return Math.sqrt(variance);
+}
+
+export function computeConfidenceScore(item: ConfidenceInput): number {
+  let score = 50;
+
+  const source = (item.source ?? '').toLowerCase();
+  if (source === 'open_prices' || source === 'data_gouv') {
+    score += 20;
+  }
+
+  const lastObservedAt = item.lastObservedAt ? new Date(item.lastObservedAt).getTime() : Number.NaN;
+  if (Number.isFinite(lastObservedAt)) {
+    const daysAgo = (Date.now() - lastObservedAt) / (24 * 60 * 60 * 1000);
+    if (daysAgo <= 7) score += 10;
+  }
+
+  const prices = (item.priceHistory ?? []).map((point) => point.price).filter((value) => Number.isFinite(value));
+  if (prices.length >= 5) {
+    score += 10;
+  }
+
+  if (prices.length >= 3) {
+    const mean = prices.reduce((sum, value) => sum + value, 0) / prices.length;
+    const dispersionRatio = mean > 0 ? stdDeviation(prices) / mean : 0;
+    if (dispersionRatio > 0.25) {
+      score -= 10;
+    }
+  }
+
+  return clamp(Math.round(score), 0, 100);
+}

--- a/frontend/src/domain/shoppingList/premium/tests/normalization.test.ts
+++ b/frontend/src/domain/shoppingList/premium/tests/normalization.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { normalizePrice } from '../normalization';
+
+describe('normalizePrice', () => {
+  it('normalizes kg from grams', () => {
+    const result = normalizePrice({ price: 3, unit: 'kg', quantityValue: 500, quantityUnit: 'g' });
+    expect(result.pricePerUnit).toBeCloseTo(6, 4);
+    expect(result.normalizedLabel).toContain('€/kg');
+  });
+
+  it('normalizes liters from ml', () => {
+    const result = normalizePrice({ price: 2.4, unit: 'l', quantityValue: 750, quantityUnit: 'ml' });
+    expect(result.pricePerUnit).toBeCloseTo(3.2, 4);
+    expect(result.normalizedLabel).toContain('€/L');
+  });
+
+  it('falls back to unit price when quantity data is missing', () => {
+    const result = normalizePrice({ price: 1.99 });
+    expect(result.pricePerUnit).toBeCloseTo(1.99, 4);
+    expect(result.normalizedLabel).toContain('€/unité');
+  });
+});

--- a/frontend/src/domain/shoppingList/premium/tests/savingsSimulator.test.ts
+++ b/frontend/src/domain/shoppingList/premium/tests/savingsSimulator.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { simulateMonthlySavings } from '../savingsSimulator';
+
+function daysAgo(days: number) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+describe('simulateMonthlySavings', () => {
+  it('computes savings when trend is down and min30 is lower than last price', () => {
+    const result = simulateMonthlySavings([
+      {
+        quantity: 2,
+        trend30: 'down',
+        lastPrice: 4,
+        priceHistory: [
+          { price: 3.5, observedAt: daysAgo(10) },
+          { price: 4, observedAt: daysAgo(1) },
+        ],
+      },
+    ]);
+
+    expect(result.potentialSavings).toBeCloseTo(1, 4);
+  });
+
+  it('ignores items with flat or up trend', () => {
+    const result = simulateMonthlySavings([
+      {
+        quantity: 3,
+        trend30: 'flat',
+        lastPrice: 5,
+        priceHistory: [{ price: 4, observedAt: daysAgo(5) }],
+      },
+    ]);
+
+    expect(result.potentialSavings).toBe(0);
+  });
+});

--- a/frontend/src/domain/shoppingList/premium/tests/scoring.test.ts
+++ b/frontend/src/domain/shoppingList/premium/tests/scoring.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { computeConfidenceScore } from '../scoring';
+
+function daysAgo(days: number) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+describe('computeConfidenceScore', () => {
+  it('increases score for reliable source, freshness and enough points', () => {
+    const score = computeConfidenceScore({
+      source: 'open_prices',
+      lastObservedAt: daysAgo(2),
+      priceHistory: [
+        { price: 10, observedAt: daysAgo(10) },
+        { price: 10.1, observedAt: daysAgo(8) },
+        { price: 10.2, observedAt: daysAgo(6) },
+        { price: 10.3, observedAt: daysAgo(4) },
+        { price: 10.4, observedAt: daysAgo(2) },
+      ],
+    });
+
+    expect(score).toBeGreaterThanOrEqual(80);
+  });
+
+  it('decreases score when price dispersion is high', () => {
+    const score = computeConfidenceScore({
+      source: 'scan_utilisateur',
+      lastObservedAt: daysAgo(20),
+      priceHistory: [
+        { price: 2, observedAt: daysAgo(30) },
+        { price: 20, observedAt: daysAgo(20) },
+        { price: 3, observedAt: daysAgo(10) },
+        { price: 15, observedAt: daysAgo(5) },
+        { price: 1, observedAt: daysAgo(1) },
+      ],
+    });
+
+    expect(score).toBeLessThanOrEqual(50);
+  });
+});

--- a/frontend/src/domain/shoppingList/premium/tests/trend.test.ts
+++ b/frontend/src/domain/shoppingList/premium/tests/trend.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { computeTrend } from '../trend';
+
+function daysAgo(days: number) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+describe('computeTrend', () => {
+  it('detects up trend', () => {
+    const result = computeTrend([
+      { price: 10, observedAt: daysAgo(13) },
+      { price: 10.5, observedAt: daysAgo(10) },
+      { price: 12, observedAt: daysAgo(3) },
+      { price: 12.2, observedAt: daysAgo(1) },
+    ], 7);
+
+    expect(result.trend).toBe('up');
+    expect(result.deltaPct).not.toBeNull();
+  });
+
+  it('detects down trend', () => {
+    const result = computeTrend([
+      { price: 12, observedAt: daysAgo(13) },
+      { price: 11.8, observedAt: daysAgo(10) },
+      { price: 10.2, observedAt: daysAgo(3) },
+      { price: 10, observedAt: daysAgo(1) },
+    ], 7);
+
+    expect(result.trend).toBe('down');
+    expect(result.deltaPct).not.toBeNull();
+  });
+
+  it('detects flat trend with low variation', () => {
+    const result = computeTrend([
+      { price: 10, observedAt: daysAgo(13) },
+      { price: 10.02, observedAt: daysAgo(10) },
+      { price: 10.05, observedAt: daysAgo(3) },
+      { price: 10.07, observedAt: daysAgo(1) },
+    ], 7);
+
+    expect(result.trend).toBe('flat');
+  });
+});

--- a/frontend/src/domain/shoppingList/premium/trend.ts
+++ b/frontend/src/domain/shoppingList/premium/trend.ts
@@ -1,0 +1,53 @@
+export type TrendDirection = 'up' | 'down' | 'flat';
+
+export type PriceHistoryPoint = {
+  price: number;
+  observedAt: string;
+};
+
+export type TrendOutput = {
+  trend: TrendDirection;
+  deltaPct: number | null;
+};
+
+function average(values: number[]): number | null {
+  if (!values.length) return null;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+export function computeTrend(history: PriceHistoryPoint[], windowDays: number): TrendOutput {
+  if (!Array.isArray(history) || history.length < 2 || windowDays <= 0) {
+    return { trend: 'flat', deltaPct: null };
+  }
+
+  const now = Date.now();
+  const windowMs = windowDays * 24 * 60 * 60 * 1000;
+  const recentStart = now - windowMs;
+  const previousStart = now - (windowMs * 2);
+
+  const recent: number[] = [];
+  const previous: number[] = [];
+
+  history.forEach((point) => {
+    const observedAt = new Date(point.observedAt).getTime();
+    if (!Number.isFinite(observedAt) || !Number.isFinite(point.price)) return;
+
+    if (observedAt >= recentStart && observedAt <= now) {
+      recent.push(point.price);
+    } else if (observedAt >= previousStart && observedAt < recentStart) {
+      previous.push(point.price);
+    }
+  });
+
+  const recentAvg = average(recent);
+  const previousAvg = average(previous);
+
+  if (recentAvg === null || previousAvg === null || previousAvg <= 0) {
+    return { trend: 'flat', deltaPct: null };
+  }
+
+  const deltaPct = ((recentAvg - previousAvg) / previousAvg) * 100;
+  if (Math.abs(deltaPct) < 1.5) return { trend: 'flat', deltaPct };
+  if (deltaPct > 0) return { trend: 'up', deltaPct };
+  return { trend: 'down', deltaPct };
+}

--- a/frontend/src/domain/shoppingList/types.ts
+++ b/frontend/src/domain/shoppingList/types.ts
@@ -14,13 +14,22 @@ export interface ShoppingListItem {
   brand?: string;
   barcode?: string;
   qty: number;
-  unit?: string;
+  unit?: 'unit' | 'kg' | 'l';
+  quantityValue?: number;
+  quantityUnit?: 'kg' | 'g' | 'l' | 'ml' | 'unit';
   territory?: string;
-<<<<<<< HEAD
   imageUrl?: string;
   imageThumbUrl?: string;
-=======
->>>>>>> origin/main
+  normalized?: {
+    pricePerUnit?: number;
+    normalizedLabel?: string;
+  };
+  premium?: {
+    score?: number;
+    trend7?: 'up' | 'down' | 'flat';
+    trend30?: 'up' | 'down' | 'flat';
+    alerts?: string[];
+  };
   createdAt: string;
   updatedAt: string;
   priceHistory: PriceObservation[];

--- a/frontend/src/hooks/useContinuousBarcodeScanner.ts
+++ b/frontend/src/hooks/useContinuousBarcodeScanner.ts
@@ -52,6 +52,24 @@ function nowIso() {
   return new Date().toISOString();
 }
 
+
+function parseQuantityDetails(quantity?: string): { quantityValue?: number; quantityUnit?: 'kg' | 'g' | 'l' | 'ml' | 'unit'; unit?: 'kg' | 'l' | 'unit' } {
+  if (!quantity) return {};
+  const match = quantity.toLowerCase().replace(',', '.').match(/(\d+(?:\.\d+)?)\s*(kg|g|ml|l|x|unite|unité|unit)/);
+  if (!match) return {};
+
+  const quantityValue = Number.parseFloat(match[1]);
+  if (!Number.isFinite(quantityValue) || quantityValue <= 0) return {};
+
+  const raw = match[2];
+  if (raw === 'kg' || raw === 'g') {
+    return { quantityValue, quantityUnit: raw, unit: 'kg' };
+  }
+  if (raw === 'l' || raw === 'ml') {
+    return { quantityValue, quantityUnit: raw, unit: 'l' };
+  }
+  return { quantityValue, quantityUnit: 'unit', unit: 'unit' };
+}
 function parseDisplayPrice(displayPrice?: string) {
   if (!displayPrice) return undefined;
   const normalized = displayPrice.replace(',', '.').match(/\d+(?:\.\d+)?/);
@@ -86,7 +104,6 @@ export async function resolveBarcode(
     name: viewModel.nom || `Produit (EAN: ${barcode})`,
     brand: viewModel.marque !== 'Non spécifiée' ? viewModel.marque : ((result.product as { marque?: string }).marque),
     quantity: viewModel.contenance ?? (result.product as { quantity?: string }).quantity,
-<<<<<<< HEAD
     imageThumbUrl: (result.product as { imageThumbnail?: string; image_small_url?: string; image_thumb_url?: string }).imageThumbnail
       ?? (result.product as { image_small_url?: string; image_thumb_url?: string }).image_small_url
       ?? (result.product as { image_thumb_url?: string }).image_thumb_url
@@ -95,9 +112,6 @@ export async function resolveBarcode(
     imageUrl: viewModel.imageUrl
       ?? (result.product as { imageThumbnail?: string }).imageThumbnail
       ?? undefined,
-=======
-    imageUrl: viewModel.imageUrl,
->>>>>>> origin/main
     price: parseDisplayPrice(viewModel.prix),
   };
 
@@ -172,6 +186,8 @@ export function useContinuousBarcodeScanner(options: UseContinuousBarcodeScanner
       },
     });
 
+    const quantityDetails = parseQuantityDetails(product.quantity);
+
     addShoppingListItem(
       {
         id: barcode,
@@ -181,11 +197,9 @@ export function useContinuousBarcodeScanner(options: UseContinuousBarcodeScanner
         history: product.price ? [product.price] : undefined,
         source: 'scan_utilisateur',
         lastObservedAt: new Date().toISOString(),
-<<<<<<< HEAD
         imageThumbUrl: product.imageThumbUrl ?? product.imageUrl ?? undefined,
         imageUrl: product.imageUrl ?? product.imageThumbUrl ?? undefined,
-=======
->>>>>>> origin/main
+        ...quantityDetails,
       },
       maxItems,
     );

--- a/frontend/src/pages/ListePage.tsx
+++ b/frontend/src/pages/ListePage.tsx
@@ -3,7 +3,8 @@ import { Link } from 'react-router-dom';
 import { useEntitlements } from '../billing/useEntitlements';
 import { assertQuotaOrThrow, QuotaExceededError } from '../billing/quotaService';
 import { decideForItem } from '../domain/decision/decisionEngine';
-import { addShoppingListItem, getShoppingListItems, removeShoppingListItem } from '../store/useShoppingListStore';
+import { addShoppingListItem, getShoppingListItems, getUserAccessState, isPremiumAccessActive, removeShoppingListItem, setUserPlan, startPremiumTrial } from '../store/useShoppingListStore';
+import { simulateMonthlySavings } from '../domain/shoppingList/premium';
 
 export default function ListePage() {
   const { can, quota, explain } = useEntitlements();
@@ -11,6 +12,10 @@ export default function ListePage() {
   const [name, setName] = useState('');
   const [territories, setTerritories] = useState<string[]>(['Guadeloupe']);
   const [alerts, setAlerts] = useState<{ threshold?: number; dropPercent?: number }>({});
+  const [userAccess, setUserAccess] = useState(() => getUserAccessState());
+  const [isPremiumEnabled, setIsPremiumEnabled] = useState(false);
+  const [showUpgradeModal, setShowUpgradeModal] = useState(false);
+  const isPremium = isPremiumAccessActive(userAccess);
 
   const stats = useMemo(() => {
     const prices = items.flatMap((it) => it.history ?? []).filter((n): n is number => Number.isFinite(n));
@@ -42,6 +47,21 @@ export default function ListePage() {
       })),
     [items],
   );
+
+
+  const savingsSimulation = useMemo(() => simulateMonthlySavings(
+    items.map((item) => ({
+      quantity: item.quantity,
+      lastPrice: item.history?.[item.history.length - 1],
+      trend30: item.premium?.trend30,
+      priceHistory: (item.history ?? []).map((price, index, array) => ({
+        price,
+        observedAt: new Date(Date.now() - ((array.length - 1 - index) * 24 * 60 * 60 * 1000)).toISOString(),
+      })),
+    })),
+  ), [items]);
+
+  const displaySavings = isPremium ? `${savingsSimulation.potentialSavings.toFixed(2)} €` : `${Math.floor(savingsSimulation.potentialSavings)}€ ···`;
 
   const onAdd = () => {
     if (!name.trim()) return;
@@ -148,13 +168,83 @@ export default function ListePage() {
         )}
       </div>
 
+
+      <div className="rounded-lg border border-slate-700 p-3">
+        <h2 className="font-semibold">Mode Premium</h2>
+        <p className="text-sm text-slate-300">
+          Plan actuel: <strong>{userAccess.userPlan === 'premium' ? 'Premium' : 'Gratuit'}</strong>
+        </p>
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <button
+            className="rounded border border-slate-600 px-3 py-1 text-sm"
+            onClick={() => {
+              setUserPlan('free');
+              setUserAccess(getUserAccessState());
+              setIsPremiumEnabled(false);
+            }}
+          >
+            Basculer en Free
+          </button>
+          <button
+            className="rounded border border-emerald-600 px-3 py-1 text-sm"
+            onClick={() => {
+              setUserPlan('premium');
+              setUserAccess(getUserAccessState());
+            }}
+          >
+            Basculer en Premium
+          </button>
+          <button
+            className="rounded border border-indigo-500 px-3 py-1 text-sm"
+            onClick={() => {
+              startPremiumTrial();
+              setUserAccess(getUserAccessState());
+              setShowUpgradeModal(false);
+            }}
+          >
+            Essai gratuit 7 jours
+          </button>
+          <label className="ml-2 flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={isPremiumEnabled}
+              disabled={!isPremium}
+              onChange={(event) => setIsPremiumEnabled(event.target.checked)}
+            />
+            Activer l'affichage premium
+          </label>
+        </div>
+        <div className="mt-3 rounded border border-indigo-500/40 bg-indigo-950/20 p-3 text-sm">
+          <p className="font-medium">Simulateur d'économie mensuelle</p>
+          <p className="text-indigo-100">Vous auriez pu économiser ce mois-ci : <strong>{displaySavings}</strong></p>
+          {!isPremium && (
+            <button className="mt-2 rounded bg-indigo-600 px-3 py-1 text-xs" onClick={() => setShowUpgradeModal(true)}>
+              Débloquer analyse complète
+            </button>
+          )}
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2 text-xs">
+          {['Voir tendance 30 jours', 'Voir recommandation détaillée', 'Activer alerte personnalisée'].map((label) => (
+            <button
+              key={label}
+              type="button"
+              className="rounded border border-slate-600 px-2 py-1"
+              onClick={() => {
+                if (!isPremium) setShowUpgradeModal(true);
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
       <ul className="space-y-2">
         {items.map((item) => {
           const lastPrice = item.history?.[item.history.length - 1];
           const rec = recommendations.find((r) => r.itemId === item.id)?.rec;
           return (
             <li key={item.id} className="rounded border border-slate-700 p-3">
-<<<<<<< HEAD
               <div className="flex items-start gap-3">
                 {item.imageThumbUrl ? (
                   <img
@@ -180,6 +270,15 @@ export default function ListePage() {
                   <div className="mt-1 text-xs text-slate-400">
                     Dernier prix: {lastPrice ? `${lastPrice.toFixed(2)} €` : 'N/A'} · Source: {item.source ?? 'local'} · Date: {item.lastObservedAt ? new Date(item.lastObservedAt).toLocaleString() : 'N/A'}
                   </div>
+                  {isPremiumEnabled && isPremium && (
+                    <div className="mt-1 rounded border border-indigo-500/40 bg-indigo-900/20 px-2 py-1 text-xs text-indigo-100">
+                      <span>
+                        {item.normalized?.normalizedLabel ?? 'Prix unitaire indisponible'} · Trend 7j: {item.premium?.trend7 ?? 'flat'} · Trend 30j: {item.premium?.trend30 ?? 'flat'}
+                      </span>
+                      <span className="ml-2">Score: {item.premium?.score ?? 0}/100</span>
+                      {item.premium?.alerts?.length ? <span className="ml-2">Alertes: {item.premium.alerts.join(' | ')}</span> : null}
+                    </div>
+                  )}
                   {rec && (
                     <div className="mt-1 text-sm text-blue-200">
                       Décision: <strong>{rec.verdict}</strong> — {rec.reason}
@@ -187,24 +286,40 @@ export default function ListePage() {
                   )}
                 </div>
               </div>
-=======
-              <div className="flex items-center justify-between">
-                <span>{item.name} × {item.quantity}</span>
-                <button className="text-red-300" onClick={() => setItems(removeShoppingListItem(item.id))}>Retirer</button>
-              </div>
-              <div className="mt-1 text-xs text-slate-400">
-                Dernier prix: {lastPrice ? `${lastPrice.toFixed(2)} €` : 'N/A'} · Source: {item.source ?? 'local'} · Date: {item.lastObservedAt ? new Date(item.lastObservedAt).toLocaleString() : 'N/A'}
-              </div>
-              {rec && (
-                <div className="mt-1 text-sm text-blue-200">
-                  Décision: <strong>{rec.verdict}</strong> — {rec.reason}
-                </div>
-              )}
->>>>>>> origin/main
             </li>
           );
         })}
       </ul>
+
+      {showUpgradeModal && !isPremium && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <div className="w-full max-w-lg rounded-xl border border-indigo-500/40 bg-slate-900 p-5">
+            <h3 className="text-xl font-semibold">Optimisez vos achats intelligemment</h3>
+            <p className="mt-2 text-sm text-slate-300">
+              Détection automatique des meilleures périodes, alertes personnalisées, comparaison multi-magasins et simulation d'économies mensuelles.
+            </p>
+            <div className="mt-4 rounded border border-indigo-500/30 bg-indigo-950/20 p-3 text-sm">
+              <p>Premium: <strong>2.99€ / mois</strong> ou <strong>24.99€ / an</strong></p>
+            </div>
+            <div className="mt-4 flex gap-2">
+              <button
+                className="rounded bg-indigo-600 px-3 py-2 text-sm"
+                onClick={() => {
+                  startPremiumTrial();
+                  setUserAccess(getUserAccessState());
+                  setShowUpgradeModal(false);
+                }}
+              >
+                Essai gratuit 7 jours
+              </button>
+              <button className="rounded border border-slate-600 px-3 py-2 text-sm" onClick={() => setShowUpgradeModal(false)}>
+                Continuer en version gratuite
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
     </div>
   );
 }

--- a/frontend/src/store/useShoppingListStore.ts
+++ b/frontend/src/store/useShoppingListStore.ts
@@ -1,6 +1,59 @@
 import { emitUpgradePrompt } from '../billing/upgradePrompt';
+import { computeAlerts, computeConfidenceScore, computeTrend, normalizePrice, type PriceHistoryPoint } from '../domain/shoppingList/premium';
 
 const STORAGE_KEY = 'akiprisaye_shopping_list_v1';
+
+const PLAN_STORAGE_KEY = 'akiprisaye_user_plan_v1';
+
+export type UserPlan = 'free' | 'premium';
+
+export function getUserPlan(): UserPlan {
+  try {
+    const raw = window.localStorage.getItem(PLAN_STORAGE_KEY);
+    return raw === 'premium' ? 'premium' : 'free';
+  } catch {
+    return 'free';
+  }
+}
+
+export function setUserPlan(plan: UserPlan) {
+  window.localStorage.setItem(PLAN_STORAGE_KEY, plan);
+  window.dispatchEvent(new CustomEvent('akiprisaye:user-plan-updated', { detail: { plan } }));
+}
+
+
+const DEFAULT_TRIAL_DURATION_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type UserAccessState = {
+  userPlan: UserPlan;
+  premiumTrialEndsAt?: number;
+};
+
+export function getUserAccessState(): UserAccessState {
+  try {
+    const plan = getUserPlan();
+    const raw = window.localStorage.getItem('akiprisaye_premium_trial_ends_at');
+    const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+    return {
+      userPlan: plan,
+      premiumTrialEndsAt: Number.isFinite(parsed) && parsed > 0 ? parsed : undefined,
+    };
+  } catch {
+    return { userPlan: 'free' };
+  }
+}
+
+export function startPremiumTrial(durationMs = DEFAULT_TRIAL_DURATION_MS): number {
+  const endsAt = Date.now() + Math.max(1, durationMs);
+  window.localStorage.setItem('akiprisaye_premium_trial_ends_at', String(endsAt));
+  window.dispatchEvent(new CustomEvent('akiprisaye:user-plan-updated', { detail: { plan: getUserPlan(), premiumTrialEndsAt: endsAt } }));
+  return endsAt;
+}
+
+export function isPremiumAccessActive(state: UserAccessState = getUserAccessState()): boolean {
+  if (state.userPlan === 'premium') return true;
+  return Boolean(state.premiumTrialEndsAt && state.premiumTrialEndsAt > Date.now());
+}
 
 export interface ShoppingListStoreItem {
   id: string;
@@ -11,11 +64,53 @@ export interface ShoppingListStoreItem {
   history?: number[];
   source?: string;
   lastObservedAt?: string;
-<<<<<<< HEAD
   imageUrl?: string;
   imageThumbUrl?: string;
-=======
->>>>>>> origin/main
+  unit?: 'unit' | 'kg' | 'l';
+  quantityValue?: number;
+  quantityUnit?: 'kg' | 'g' | 'l' | 'ml' | 'unit';
+  normalized?: {
+    pricePerUnit?: number;
+    normalizedLabel?: string;
+  };
+  premium?: {
+    score?: number;
+    trend7?: 'up' | 'down' | 'flat';
+    trend30?: 'up' | 'down' | 'flat';
+    alerts?: string[];
+  };
+}
+
+function inferPriceHistory(item: ShoppingListStoreItem): PriceHistoryPoint[] {
+  if (!Array.isArray(item.history) || item.history.length === 0) return [];
+  const endAt = item.lastObservedAt ? new Date(item.lastObservedAt).getTime() : Date.now();
+  return item.history
+    .filter((price) => Number.isFinite(price))
+    .map((price, index, array) => ({
+      price,
+      observedAt: new Date(endAt - ((array.length - 1 - index) * 24 * 60 * 60 * 1000)).toISOString(),
+    }));
+}
+
+function enrichWithPremium(item: ShoppingListStoreItem): ShoppingListStoreItem {
+  const priceHistory = inferPriceHistory(item);
+  const normalized = normalizePrice({
+    price: item.price,
+    unit: item.unit,
+    quantityValue: item.quantityValue,
+    quantityUnit: item.quantityUnit,
+  });
+
+  return {
+    ...item,
+    normalized,
+    premium: {
+      score: computeConfidenceScore({ source: item.source, lastObservedAt: item.lastObservedAt, priceHistory }),
+      trend7: computeTrend(priceHistory, 7).trend,
+      trend30: computeTrend(priceHistory, 30).trend,
+      alerts: computeAlerts({ price: item.price, priceHistory }),
+    },
+  };
 }
 
 function readStorage(): ShoppingListStoreItem[] {
@@ -52,20 +147,22 @@ export function addShoppingListItem(item: ShoppingListStoreItem, maxItems: numbe
   const next = existing
     ? items.map((current) =>
         current.id === item.id
-<<<<<<< HEAD
-          ? {
+          ? enrichWithPremium({
               ...current,
               quantity: current.quantity + item.quantity,
               price: item.price ?? current.price,
               imageUrl: item.imageUrl ?? current.imageUrl,
               imageThumbUrl: item.imageThumbUrl ?? current.imageThumbUrl,
-            }
-=======
-          ? { ...current, quantity: current.quantity + item.quantity, price: item.price ?? current.price }
->>>>>>> origin/main
+              unit: item.unit ?? current.unit,
+              quantityValue: item.quantityValue ?? current.quantityValue,
+              quantityUnit: item.quantityUnit ?? current.quantityUnit,
+              source: item.source ?? current.source,
+              lastObservedAt: item.lastObservedAt ?? current.lastObservedAt,
+              history: item.price ? [...(current.history ?? []), item.price] : current.history,
+            })
           : current,
       )
-    : [...items, item];
+    : [...items, enrichWithPremium(item)];
 
   writeStorage(next);
   return { ok: true as const, items: next };
@@ -78,11 +175,10 @@ export function removeShoppingListItem(id: string) {
 }
 
 export function updateShoppingListItem(id: string, patch: Partial<ShoppingListStoreItem>) {
-  const next = readStorage().map((item) => (item.id === id ? { ...item, ...patch } : item));
+  const next = readStorage().map((item) => (item.id === id ? enrichWithPremium({ ...item, ...patch }) : item));
   writeStorage(next);
   return next;
 }
-
 
 export function getShoppingListCount() {
   return readStorage().reduce((sum, item) => sum + item.quantity, 0);

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -43,12 +43,10 @@ export default defineConfig({
       abs('./src/test/shoppingListPersistence.test.ts'),
       abs('./src/test/offCacheFallback.test.ts'),
       abs('./src/test/scannerFallback.test.tsx'),
-<<<<<<< HEAD
       abs('./src/test/listePage.thumbnails.test.tsx'),
-=======
->>>>>>> origin/main
       abs('./src/test/decisionEngine.test.ts'),
       abs('./src/domain/decision/__tests__/decisionEngine.test.ts'),
+      abs('./src/domain/shoppingList/premium/tests/*.test.ts'),
       abs('./scripts/verify-pages-api.test.ts'),
     ],
 


### PR DESCRIPTION
### Motivation
- Provide a clear FREE vs PREMIUM conversion funnel in the Liste page while keeping premium insights gated behind an explicit activation and local plan state. 
- Ship a first-version savings simulator engine to surface an economic benefit that drives upgrades without a billing integration. 
- Keep premium calculations local so the product team can iterate rapidly without breaking existing Cloudflare Pages + local store architecture.

### Description
- Add a premium domain module with `trend`, `scoring`, `normalization`, `alerts`, `recommendation` and a new `savingsSimulator` exported from `frontend/src/domain/shoppingList/premium/index.ts`. 
- Implement `simulateMonthlySavings()` in `frontend/src/domain/shoppingList/premium/savingsSimulator.ts` and unit tests in `frontend/src/domain/shoppingList/premium/tests/savingsSimulator.test.ts`. 
- Extend the shopping-list store in `frontend/src/store/useShoppingListStore.ts` with `userPlan` storage, `getUserAccessState()`, `startPremiumTrial()` and `isPremiumAccessActive()` plus `enrichWithPremium()` to compute `normalized` and `premium` metadata for items. 
- Integrate a premium funnel UX into `frontend/src/pages/ListePage.tsx`: premium block with plan toggle, trial CTA modal, locked actions triggers, and the savings simulator display that is blurred/partial for free users and full for premium users. 
- Improve scanner flow in `frontend/src/hooks/useContinuousBarcodeScanner.ts` by parsing quantity details and spreading `quantityValue`/`quantityUnit`/`unit` into items added from scans.

### Testing
- Ran `npm -C frontend run test:ci` and all tests passed (`34` test files, `97` tests passed). 
- Ran `npm -C frontend run build` and the production build completed successfully. 
- The new premium simulator unit tests were included under `frontend/src/domain/shoppingList/premium/tests` and executed as part of the CI run (they passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a4edf7a2c8321832f0c94661b6a39)