### PR TITLE
fix(price-api): D1 schema hardening, atomic upsert, PayPal webhook handling, workflow cache

### DIFF
--- a/.github/workflows/price-api-deploy.yml
+++ b/.github/workflows/price-api-deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy price-api (D1 + Worker)
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "price-api/**"
+      - ".github/workflows/price-api-deploy.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: price-api-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: price-api
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: price-api/package-lock.json
+
+      - name: Install deps (if package.json exists)
+        run: |
+          if [ -f package.json ]; then
+            npm ci || npm install
+          fi
+
+      - name: Apply D1 migrations (remote)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@4.68.0 d1 migrations apply price-db --remote
+
+      - name: Deploy Worker
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          npx --yes wrangler@4.68.0 deploy

--- a/price-api/migrations/0007_paypal_webhooks.sql
+++ b/price-api/migrations/0007_paypal_webhooks.sql
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS subscriptions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL,
+  plan TEXT NOT NULL,
+  status TEXT NOT NULL,
+  paypal_subscription_id TEXT UNIQUE,
+  payer_id TEXT,
+  email TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id_updated_at
+  ON subscriptions (user_id, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_status
+  ON subscriptions (status);
+
+CREATE TABLE IF NOT EXISTS webhook_events (
+  event_id TEXT PRIMARY KEY,
+  event_type TEXT NOT NULL,
+  create_time TEXT,
+  received_at TEXT DEFAULT (datetime('now')),
+  raw_json TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_events_received_at
+  ON webhook_events (received_at);
+
+CREATE TRIGGER IF NOT EXISTS trg_subscriptions_updated_at
+AFTER UPDATE ON subscriptions
+FOR EACH ROW
+WHEN NEW.updated_at = OLD.updated_at
+BEGIN
+  UPDATE subscriptions
+  SET updated_at = datetime('now')
+  WHERE id = OLD.id;
+END;

--- a/price-api/src/db.ts
+++ b/price-api/src/db.ts
@@ -8,12 +8,22 @@ import type {
   PriceAggregateRecord,
   PriceObservationRecord,
   ProductRecord,
+  SubscriptionRecord,
   Territory,
 } from './types';
 
 interface AggregateFingerprint {
   maxUpdatedAt: string | null;
   rowCount: number;
+}
+
+export interface SubscriptionUpsertPayload {
+  userId: string;
+  plan: string;
+  status: 'CREATED' | 'ACTIVE' | 'SUSPENDED' | 'CANCELLED';
+  paypalSubscriptionId: string;
+  payerId?: string;
+  email?: string;
 }
 
 export async function getAggregateFingerprint(
@@ -449,4 +459,61 @@ export async function updateReceiptJobCashier(
     )
     .bind(fields.cashierLabelRaw, fields.cashierHash, fields.cashierOperatorId, jobId)
     .run();
+}
+
+export async function recordWebhookEventIfNew(
+  db: D1Database,
+  payload: { eventId: string; eventType: string; createTime?: string; rawJson: string },
+): Promise<boolean> {
+  const cappedRawJson = payload.rawJson.length > 64000 ? payload.rawJson.slice(0, 64000) : payload.rawJson;
+  const result = await db
+    .prepare(
+      `INSERT OR IGNORE INTO webhook_events (event_id, event_type, create_time, raw_json)
+       VALUES (?, ?, ?, ?)`,
+    )
+    .bind(payload.eventId, payload.eventType, payload.createTime ?? null, cappedRawJson)
+    .run();
+
+  return Boolean(result.meta.changes && result.meta.changes > 0);
+}
+
+export async function upsertSubscriptionByPayPalId(db: D1Database, payload: SubscriptionUpsertPayload): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO subscriptions (user_id, plan, status, paypal_subscription_id, payer_id, email)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT(paypal_subscription_id) DO UPDATE SET
+         user_id = excluded.user_id,
+         plan = excluded.plan,
+         status = excluded.status,
+         payer_id = excluded.payer_id,
+         email = excluded.email,
+         updated_at = datetime('now')`,
+    )
+    .bind(
+      payload.userId,
+      payload.plan,
+      payload.status,
+      payload.paypalSubscriptionId,
+      payload.payerId ?? null,
+      payload.email ?? null,
+    )
+    .run();
+}
+
+export async function getLatestSubscriptions(db: D1Database, limit = 50): Promise<SubscriptionRecord[]> {
+  const safeLimit = Number.isFinite(limit) ? Math.min(Math.max(limit, 1), 200) : 50;
+  const { results } = await db
+    .prepare('SELECT * FROM subscriptions ORDER BY updated_at DESC LIMIT ?')
+    .bind(safeLimit)
+    .all<SubscriptionRecord>();
+
+  return results ?? [];
+}
+
+export async function getSubscriptionByUserId(db: D1Database, userId: string): Promise<SubscriptionRecord | null> {
+  return db
+    .prepare('SELECT * FROM subscriptions WHERE user_id = ? ORDER BY updated_at DESC LIMIT 1')
+    .bind(userId)
+    .first<SubscriptionRecord>();
 }

--- a/price-api/src/paypal.ts
+++ b/price-api/src/paypal.ts
@@ -1,0 +1,109 @@
+import type { Env } from './types';
+
+export interface PayPalWebhookEvent {
+  id: string;
+  event_type: string;
+  create_time?: string;
+  resource?: {
+    id?: string;
+    custom_id?: string;
+    plan_id?: string;
+    subscriber?: {
+      payer_id?: string;
+      email_address?: string;
+    };
+  };
+}
+
+interface PayPalVerifyResponse {
+  verification_status?: string;
+}
+
+function getPayPalBaseUrl(paypalEnv: Env['PAYPAL_ENV']): string {
+  return paypalEnv === 'live' ? 'https://api-m.paypal.com' : 'https://api-m.sandbox.paypal.com';
+}
+
+async function getPayPalAccessToken(env: Env): Promise<string> {
+  const credentials = `${env.PAYPAL_CLIENT_ID}:${env.PAYPAL_CLIENT_SECRET}`;
+  const encoded = btoa(credentials);
+  const response = await fetch(`${getPayPalBaseUrl(env.PAYPAL_ENV)}/v1/oauth2/token`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${encoded}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: 'grant_type=client_credentials',
+  });
+
+  if (!response.ok) {
+    throw new Error(`paypal_oauth_failed:${response.status}`);
+  }
+
+  const data = (await response.json()) as { access_token?: string };
+  if (!data.access_token) {
+    throw new Error('paypal_oauth_missing_token');
+  }
+
+  return data.access_token;
+}
+
+export async function verifyPayPalWebhookSignature(
+  request: Request,
+  env: Env,
+  webhookEvent: PayPalWebhookEvent,
+): Promise<boolean> {
+  try {
+    const transmissionId = request.headers.get('paypal-transmission-id');
+    const transmissionTime = request.headers.get('paypal-transmission-time');
+    const certUrl = request.headers.get('paypal-cert-url');
+    const authAlgo = request.headers.get('paypal-auth-algo');
+    const transmissionSig = request.headers.get('paypal-transmission-sig');
+
+    if (!transmissionId || !transmissionTime || !certUrl || !authAlgo || !transmissionSig) {
+      console.warn('paypal_signature_verification_failed', {
+        reason: 'missing_signature_headers',
+      });
+      return false;
+    }
+
+    const accessToken = await getPayPalAccessToken(env);
+    const verificationResponse = await fetch(`${getPayPalBaseUrl(env.PAYPAL_ENV)}/v1/notifications/verify-webhook-signature`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        auth_algo: authAlgo,
+        cert_url: certUrl,
+        transmission_id: transmissionId,
+        transmission_sig: transmissionSig,
+        transmission_time: transmissionTime,
+        webhook_id: env.PAYPAL_WEBHOOK_ID,
+        webhook_event: webhookEvent,
+      }),
+    });
+
+    if (!verificationResponse.ok) {
+      console.warn('paypal_signature_verification_failed', {
+        reason: 'verify_endpoint_non_200',
+        status: verificationResponse.status,
+      });
+      return false;
+    }
+
+    const verificationResult = (await verificationResponse.json()) as PayPalVerifyResponse;
+    if (verificationResult.verification_status !== 'SUCCESS') {
+      console.warn('paypal_signature_verification_failed', {
+        reason: 'verification_status_not_success',
+        verificationStatus: verificationResult.verification_status ?? 'undefined',
+      });
+    }
+    return verificationResult.verification_status === 'SUCCESS';
+  } catch (error) {
+    console.error('paypal_signature_verification_failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}

--- a/price-api/src/router.ts
+++ b/price-api/src/router.ts
@@ -8,11 +8,17 @@ import {
   getPriceAggregates,
   getProduct,
   getRecentObservations,
+  getLatestSubscriptions,
+  getSubscriptionByUserId,
   insertObservationAndRefreshAggregate,
+  recordWebhookEventIfNew,
+  upsertSubscriptionByPayPalId,
   upsertProduct,
 } from './db';
 import { withCors } from './cors';
 import { queueCsvImport } from './importCsv';
+import { verifyPayPalWebhookSignature, type PayPalWebhookEvent } from './paypal';
+import { mapPayPalEventTypeToSubscriptionStatus, mapPayPalPlanIdToInternalPlan } from './subscriptionPlans';
 import type { Env, PriceAggregateRecord, PriceObservationRecord, PriceStatus, PricesResponse, ProductResponse } from './types';
 import {
   adminObservationSchema,
@@ -82,6 +88,11 @@ function computeStatus(hasAggregates: boolean, hasProduct = false): PriceStatus 
   return 'NO_DATA';
 }
 
+function assertSubscriptionLookupToken(request: Request, adminToken: string): boolean {
+  const token = request.headers.get('X-Admin-Token');
+  return Boolean(token && token === adminToken);
+}
+
 export async function handleRequest(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
   const url = new URL(request.url);
   const origin = request.headers.get('Origin');
@@ -91,6 +102,101 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
   }
 
   try {
+    if (request.method === 'POST' && url.pathname === '/v1/webhooks/paypal') {
+      const bodyText = await request.text();
+      let event: PayPalWebhookEvent;
+      try {
+        event = JSON.parse(bodyText) as PayPalWebhookEvent;
+      } catch {
+        console.warn('paypal_webhook_ignored', { reason: 'invalid_json' });
+        return withCors(json({ error: 'invalid_json' }, 400), origin, env);
+      }
+
+      const eventId = event.id ?? 'unknown';
+      const eventType = event.event_type ?? 'unknown';
+
+      if (!event.id || !event.event_type) {
+        console.warn('paypal_webhook_ignored', { eventId, eventType, reason: 'missing_event_identity' });
+        return withCors(json({ status: 'ignored', reason: 'missing_event_identity' }, 200), origin, env);
+      }
+
+      const isVerified = await verifyPayPalWebhookSignature(request, env, event);
+      if (!isVerified) {
+        console.warn('paypal_webhook_rejected', { eventId, eventType, reason: 'invalid_signature' });
+        return withCors(json({ error: 'invalid_signature' }, 401), origin, env);
+      }
+
+      const status = mapPayPalEventTypeToSubscriptionStatus(event.event_type);
+      if (!status) {
+        console.log('paypal_webhook_ignored', { eventId, eventType, reason: 'unsupported_event_type' });
+        return withCors(json({ status: 'ignored', reason: 'unsupported_event_type' }, 200), origin, env);
+      }
+
+      const isNewEvent = await recordWebhookEventIfNew(env.PRICE_DB, {
+        eventId: event.id,
+        eventType: event.event_type,
+        createTime: event.create_time,
+        rawJson: bodyText,
+      });
+
+      if (!isNewEvent) {
+        console.log('paypal_webhook_ignored', { eventId, eventType, reason: 'duplicate_event' });
+        return withCors(json({ status: 'ignored', reason: 'duplicate_event' }, 200), origin, env);
+      }
+
+      const userId = event.resource?.custom_id;
+      if (!userId) {
+        console.warn('paypal_webhook_ignored', { eventId, eventType, reason: 'missing_custom_id' });
+        return withCors(json({ status: 'ignored', reason: 'missing_custom_id' }, 200), origin, env);
+      }
+
+      const subscriptionId = event.resource?.id;
+      if (!subscriptionId) {
+        console.warn('paypal_webhook_ignored', { eventId, eventType, reason: 'missing_subscription_id' });
+        return withCors(json({ status: 'ignored', reason: 'missing_subscription_id' }, 200), origin, env);
+      }
+
+      await upsertSubscriptionByPayPalId(env.PRICE_DB, {
+        userId,
+        plan: mapPayPalPlanIdToInternalPlan(event.resource?.plan_id),
+        status,
+        paypalSubscriptionId: subscriptionId,
+        payerId: event.resource?.subscriber?.payer_id,
+        email: event.resource?.subscriber?.email_address,
+      });
+
+      console.log('paypal_webhook_processed', { eventId, eventType, status, userId, subscriptionId });
+
+      return withCors(json({ status: 'processed' }, 200), origin, env);
+    }
+
+    if (request.method === 'GET' && url.pathname === '/v1/me/subscription') {
+      if (!assertSubscriptionLookupToken(request, env.PRICE_ADMIN_TOKEN)) {
+        return withCors(json({ error: 'unauthorized' }, 401), origin, env);
+      }
+
+      const userId = url.searchParams.get('user_id');
+      if (!userId) {
+        return withCors(json({ error: 'missing_user_id' }, 400), origin, env);
+      }
+
+      // TODO: remplacer user_id query param par une authentification utilisateur (JWT/session).
+      const subscription = await getSubscriptionByUserId(env.PRICE_DB, userId);
+      if (!subscription) {
+        return withCors(json({ status: 'FREE' }, 200), origin, env);
+      }
+
+      return withCors(
+        json({
+          status: subscription.status,
+          plan: subscription.plan,
+          updatedAt: subscription.updated_at,
+        }),
+        origin,
+        env,
+      );
+    }
+
     if (request.method === 'GET' && url.pathname === '/v1/prices') {
       const parsed = getPricesQuerySchema.parse(Object.fromEntries(url.searchParams.entries()));
       const retailer = parsed.retailer ? validateRetailer(parsed.retailer) : undefined;
@@ -195,6 +301,12 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
         const limit = Number(url.searchParams.get('limit') ?? '50');
         const jobs = await getImportJobs(env.PRICE_DB, Number.isFinite(limit) ? Math.min(Math.max(limit, 1), 200) : 50);
         return withCors(adminJson({ status: 'OK', jobs }, 200), origin, env);
+      }
+
+      if (request.method === 'GET' && url.pathname === '/v1/admin/subscriptions') {
+        const limit = Number(url.searchParams.get('limit') ?? '50');
+        const subscriptions = await getLatestSubscriptions(env.PRICE_DB, limit);
+        return withCors(adminJson({ status: 'OK', subscriptions }, 200), origin, env);
       }
 
       if (request.method === 'GET' && /^\/v1\/admin\/import\/jobs\/[^/]+$/.test(url.pathname)) {

--- a/price-api/src/subscriptionPlans.ts
+++ b/price-api/src/subscriptionPlans.ts
@@ -1,0 +1,30 @@
+export type SubscriptionStatus = 'CREATED' | 'ACTIVE' | 'SUSPENDED' | 'CANCELLED';
+
+const EVENT_TYPE_TO_STATUS: Record<string, SubscriptionStatus> = {
+  'BILLING.SUBSCRIPTION.CREATED': 'CREATED',
+  'BILLING.SUBSCRIPTION.ACTIVATED': 'ACTIVE',
+  'BILLING.SUBSCRIPTION.SUSPENDED': 'SUSPENDED',
+  'BILLING.SUBSCRIPTION.CANCELLED': 'CANCELLED',
+};
+
+const PAYPAL_PLAN_ID_TO_INTERNAL_PLAN: Record<string, 'PREMIUM_MONTHLY' | 'PRO_MONTHLY'> = {
+  // TODO: remplacez par vos vrais plan_id PayPal Sandbox/Live.
+  PREMIUM_SANDBOX_PLAN_ID: 'PREMIUM_MONTHLY',
+  PRO_SANDBOX_PLAN_ID: 'PRO_MONTHLY',
+};
+
+export function mapPayPalEventTypeToSubscriptionStatus(eventType?: string): SubscriptionStatus | null {
+  if (!eventType) {
+    return null;
+  }
+
+  return EVENT_TYPE_TO_STATUS[eventType] ?? null;
+}
+
+export function mapPayPalPlanIdToInternalPlan(planId?: string): string {
+  if (!planId) {
+    return 'PLAN_UNKNOWN';
+  }
+
+  return PAYPAL_PLAN_ID_TO_INTERNAL_PLAN[planId] ?? `PAYPAL_PLAN:${planId}`;
+}

--- a/price-api/src/types.ts
+++ b/price-api/src/types.ts
@@ -14,6 +14,10 @@ export interface Env {
   ALLOWED_ORIGINS?: string;
   CASHIER_HASH_SALT?: string;
   PRICE_IMPORTS: R2Bucket;
+  PAYPAL_CLIENT_ID: string;
+  PAYPAL_CLIENT_SECRET: string;
+  PAYPAL_WEBHOOK_ID: string;
+  PAYPAL_ENV: 'sandbox' | 'live';
 }
 
 export type ReceiptJobStatus = 'created' | 'processing' | 'completed' | 'failed';
@@ -94,6 +98,18 @@ export interface ImportRowRecord {
   status: ImportRowStatus;
   error_message: string | null;
   created_at: string;
+}
+
+export interface SubscriptionRecord {
+  id: number;
+  user_id: string;
+  plan: string;
+  status: string;
+  paypal_subscription_id: string | null;
+  payer_id: string | null;
+  email: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface ApiResponseBase {

--- a/price-api/tests/subscriptionWebhook.test.ts
+++ b/price-api/tests/subscriptionWebhook.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { recordWebhookEventIfNew, upsertSubscriptionByPayPalId } from '../src/db';
+import { mapPayPalEventTypeToSubscriptionStatus } from '../src/subscriptionPlans';
+
+interface SubscriptionRow {
+  user_id: string;
+  plan: string;
+  status: string;
+  paypal_subscription_id: string;
+  payer_id: string | null;
+  email: string | null;
+}
+
+class FakeD1PreparedStatement {
+  private args: unknown[] = [];
+
+  constructor(
+    private readonly sql: string,
+    private readonly state: { webhookEvents: Set<string>; subscriptions: SubscriptionRow[] },
+  ) {}
+
+  bind(...args: unknown[]): this {
+    this.args = args;
+    return this;
+  }
+
+  async run(): Promise<{ meta: { changes: number } }> {
+    if (this.sql.includes('INSERT OR IGNORE INTO webhook_events')) {
+      const [eventId] = this.args as [string];
+      const existed = this.state.webhookEvents.has(eventId);
+      if (!existed) {
+        this.state.webhookEvents.add(eventId);
+      }
+      return { meta: { changes: existed ? 0 : 1 } };
+    }
+
+    if (this.sql.includes('INSERT INTO subscriptions')) {
+      const [userId, plan, status, paypalSubscriptionId, payerId, email] = this.args as [
+        string,
+        string,
+        string,
+        string,
+        string | null,
+        string | null,
+      ];
+
+      const existing = this.state.subscriptions.find((item) => item.paypal_subscription_id === paypalSubscriptionId);
+      if (existing) {
+        existing.user_id = userId;
+        existing.plan = plan;
+        existing.status = status;
+        existing.payer_id = payerId;
+        existing.email = email;
+      } else {
+        this.state.subscriptions.push({
+          user_id: userId,
+          plan,
+          status,
+          paypal_subscription_id: paypalSubscriptionId,
+          payer_id: payerId,
+          email,
+        });
+      }
+
+      return { meta: { changes: 1 } };
+    }
+
+    throw new Error(`Unsupported run SQL in test: ${this.sql}`);
+  }
+
+  async first<T>(): Promise<T | null> {
+    throw new Error(`Unsupported first SQL in test: ${this.sql}`);
+  }
+}
+
+class FakeD1Database {
+  private readonly state = {
+    webhookEvents: new Set<string>(),
+    subscriptions: [] as SubscriptionRow[],
+  };
+
+  prepare(sql: string): FakeD1PreparedStatement {
+    return new FakeD1PreparedStatement(sql, this.state);
+  }
+
+  get subscriptions(): SubscriptionRow[] {
+    return this.state.subscriptions;
+  }
+}
+
+describe('subscription webhook logic', () => {
+  it('applique idempotence sur webhook_events avec INSERT OR IGNORE', async () => {
+    const db = new FakeD1Database() as unknown as D1Database;
+
+    const first = await recordWebhookEventIfNew(db, {
+      eventId: 'evt_1',
+      eventType: 'BILLING.SUBSCRIPTION.ACTIVATED',
+      createTime: '2026-02-23T00:00:00Z',
+      rawJson: '{}',
+    });
+
+    const second = await recordWebhookEventIfNew(db, {
+      eventId: 'evt_1',
+      eventType: 'BILLING.SUBSCRIPTION.ACTIVATED',
+      createTime: '2026-02-23T00:00:00Z',
+      rawJson: '{}',
+    });
+
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+
+  it('fait un insert puis update pour un même paypal_subscription_id', async () => {
+    const fake = new FakeD1Database();
+    const db = fake as unknown as D1Database;
+
+    await upsertSubscriptionByPayPalId(db, {
+      userId: 'user_1',
+      plan: 'PREMIUM_MONTHLY',
+      status: 'CREATED',
+      paypalSubscriptionId: 'I-SUB-123',
+      payerId: 'PAYER-1',
+      email: 'old@example.com',
+    });
+
+    await upsertSubscriptionByPayPalId(db, {
+      userId: 'user_1',
+      plan: 'PREMIUM_MONTHLY',
+      status: 'ACTIVE',
+      paypalSubscriptionId: 'I-SUB-123',
+      payerId: 'PAYER-1',
+      email: 'new@example.com',
+    });
+
+    expect(fake.subscriptions).toHaveLength(1);
+    expect(fake.subscriptions[0]?.status).toBe('ACTIVE');
+    expect(fake.subscriptions[0]?.email).toBe('new@example.com');
+  });
+
+  it('mappe correctement event_type PayPal vers status interne', () => {
+    expect(mapPayPalEventTypeToSubscriptionStatus('BILLING.SUBSCRIPTION.CREATED')).toBe('CREATED');
+    expect(mapPayPalEventTypeToSubscriptionStatus('BILLING.SUBSCRIPTION.ACTIVATED')).toBe('ACTIVE');
+    expect(mapPayPalEventTypeToSubscriptionStatus('BILLING.SUBSCRIPTION.SUSPENDED')).toBe('SUSPENDED');
+    expect(mapPayPalEventTypeToSubscriptionStatus('BILLING.SUBSCRIPTION.CANCELLED')).toBe('CANCELLED');
+    expect(mapPayPalEventTypeToSubscriptionStatus('PAYMENT.SALE.COMPLETED')).toBeNull();
+  });
+});

--- a/price-api/wrangler.toml
+++ b/price-api/wrangler.toml
@@ -4,13 +4,14 @@ compatibility_date = "2026-02-18"
 workers_dev = true
 
 [vars]
+# En dev local (Vite). En prod, on ajoutera https://akiprisaye-web.pages.dev et/ou ton domaine.
 ALLOWED_ORIGINS = "http://localhost:5173,http://127.0.0.1:5173"
 CASHIER_HASH_SALT = "CHANGE_ME_LONG_RANDOM"
 
 [[d1_databases]]
 binding = "PRICE_DB"
 database_name = "price-db"
-database_id = "REPLACE_WITH_D1_DATABASE_ID"
+database_id = "c7ae3626-9154-4625-9d25-606d6dcf5374"
 migrations_dir = "migrations"
 
 [[r2_buckets]]


### PR DESCRIPTION
### Motivation
- Make the price-api ready for pre-production by preventing runtime surprises (missing schema pieces, race conditions, and unprotected admin lookups). 
- Improve reliability of D1 migrations and GH Actions deploy to avoid overlapping/hung jobs and speed installs with node cache.

### Description
- Hardened D1 migration `0007_paypal_webhooks.sql` by using `IF NOT EXISTS`, adding useful indexes and a trigger to auto-update `updated_at` on updates.
- Reworked DB layer in `src/db.ts` to cap webhook payloads, return reliable idempotence info, and replace read-then-write with an atomic `INSERT ... ON CONFLICT(paypal_subscription_id) DO UPDATE` upsert for subscriptions.
- Added PayPal webhook support and verification with `src/paypal.ts`, mapping logic in `src/subscriptionPlans.ts`, and expanded `types.ts` with subscription and PayPal env types.
- Secured subscription lookup by standardizing on `X-Admin-Token` in `src/router.ts`, added the PayPal webhook route, an admin `GET /v1/admin/subscriptions` endpoint, and updated the webhook processing flow to record idempotent events.
- Small CI/workflow improvement in `.github/workflows/price-api-deploy.yml` to enable `actions/setup-node` npm cache via `cache: "npm"` and `cache-dependency-path: price-api/package-lock.json` while keeping `wrangler@4.68.0` pinned and concurrency/timeout settings.
- Updated unit tests (`price-api/tests/subscriptionWebhook.test.ts`) to reflect the atomic upsert semantics and idempotent webhook recording.

### Testing
- Ran type checking with `npm --prefix price-api run typecheck`, which succeeded.
- Ran unit tests with `npm --prefix price-api test` (Vitest), all tests passed: 4 files, 15 tests total (all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bd8b18cb883218a1dbb2efd954219)