### PR TITLE
chore(price-api): improve duplicate webhook resync diagnostics and fix conflict markers

### DIFF
--- a/price-api/src/paypal.ts
+++ b/price-api/src/paypal.ts
@@ -4,8 +4,11 @@ export interface PayPalWebhookEvent {
   id: string;
   event_type: string;
   create_time?: string;
+  resource_type?: string;
   resource?: {
     id?: string;
+    billing_agreement_id?: string;
+    subscription_id?: string;
     custom_id?: string;
     plan_id?: string;
     subscriber?: {

--- a/price-api/src/router.ts
+++ b/price-api/src/router.ts
@@ -12,7 +12,6 @@ import {
   getSubscriptionByUserId,
   insertObservationAndRefreshAggregate,
   recordWebhookEventIfNew,
-  upsertSubscriptionByPayPalId,
   upsertProduct,
 } from './db';
 import { withCors } from './cors';
@@ -105,52 +104,87 @@ function hasMissingPayPalSignatureHeaders(request: Request): boolean {
   return requiredHeaders.some((headerName) => !request.headers.get(headerName));
 }
 
-async function syncPaypalSubscriptionEvent(db: D1Database, event: PayPalWebhookEvent): Promise<void> {
-  const subscriptionId = event.resource?.id;
+const UNKNOWN_USER_ID = '__unknown__';
+const UNKNOWN_PLAN_CODE = 'UNKNOWN';
+
+export function getPaypalSubscriptionId(event: PayPalWebhookEvent): string | null {
+  const candidateIds = [event.resource?.id, event.resource?.billing_agreement_id, event.resource?.subscription_id];
+  return (
+    candidateIds.find((candidate): candidate is string => typeof candidate === 'string' && candidate.startsWith('I-')) ?? null
+  );
+}
+
+export async function syncPaypalSubscriptionEvent(db: D1Database, event: PayPalWebhookEvent): Promise<void> {
+  const subscriptionId = getPaypalSubscriptionId(event);
+
   if (!subscriptionId) {
+    console.warn('paypal_webhook_ignored', {
+      eventId: event.id ?? 'unknown',
+      eventType: event.event_type ?? 'unknown',
+      reason: 'missing_paypal_subscription_id',
+      resourceType: event.resource_type ?? 'unknown',
+    });
     return;
   }
 
-  if (event.event_type === 'BILLING.SUBSCRIPTION.CREATED') {
-    await db
-      .prepare(
-        `INSERT INTO subscriptions (
-          id,
-          user_id,
-          plan_code,
-          status,
-          paypal_subscription_id,
-          created_at,
-          updated_at
-        ) VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))
-        ON CONFLICT(id) DO UPDATE SET
-          user_id = excluded.user_id,
-          plan_code = excluded.plan_code,
-          status = excluded.status,
-          paypal_subscription_id = excluded.paypal_subscription_id,
-          updated_at = datetime('now')`,
-      )
-      .bind(subscriptionId, 'sandbox-user', 'premium', 'active', subscriptionId)
-      .run();
-
+  const mappedStatus = mapPayPalEventTypeToSubscriptionStatus(event.event_type);
+  if (!mappedStatus) {
+    console.log('paypal_webhook_ignored', {
+      eventId: event.id ?? 'unknown',
+      eventType: event.event_type ?? 'unknown',
+      reason: 'unsupported_event_type_for_sync',
+      paypalSubscriptionId: subscriptionId,
+      resourceType: event.resource_type ?? 'unknown',
+    });
     return;
   }
 
-  if (event.event_type === 'BILLING.SUBSCRIPTION.CANCELLED') {
-    await db
-      .prepare(`UPDATE subscriptions SET status = 'cancelled', updated_at = datetime('now') WHERE id = ?`)
-      .bind(subscriptionId)
-      .run();
+  await db
+    .prepare(
+      `INSERT INTO subscriptions (
+        id,
+        user_id,
+        plan_code,
+        status,
+        paypal_subscription_id,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        user_id = CASE
+          WHEN subscriptions.user_id IS NULL OR subscriptions.user_id = ?
+          THEN excluded.user_id
+          ELSE subscriptions.user_id
+        END,
+        plan_code = CASE
+          WHEN subscriptions.plan_code IS NULL OR subscriptions.plan_code = ? OR subscriptions.plan_code = 'PLAN_UNKNOWN'
+          THEN excluded.plan_code
+          ELSE subscriptions.plan_code
+        END,
+        status = excluded.status,
+        paypal_subscription_id = excluded.paypal_subscription_id,
+        updated_at = excluded.updated_at`,
+    )
+    .bind(
+      subscriptionId,
+      event.resource?.custom_id ?? UNKNOWN_USER_ID,
+      event.resource?.plan_id ? mapPayPalPlanIdToInternalPlan(event.resource.plan_id) : UNKNOWN_PLAN_CODE,
+      mappedStatus,
+      subscriptionId,
+      new Date().toISOString(),
+      new Date().toISOString(),
+      UNKNOWN_USER_ID,
+      UNKNOWN_PLAN_CODE,
+    )
+    .run();
 
-    return;
-  }
-
-  if (event.event_type === 'BILLING.SUBSCRIPTION.SUSPENDED') {
-    await db
-      .prepare(`UPDATE subscriptions SET status = 'suspended', updated_at = datetime('now') WHERE id = ?`)
-      .bind(subscriptionId)
-      .run();
-  }
+  console.log('paypal_subscription_synced', {
+    eventId: event.id ?? 'unknown',
+    eventType: event.event_type,
+    resourceType: event.resource_type ?? 'unknown',
+    paypalSubscriptionId: subscriptionId,
+    status: mappedStatus,
+  });
 }
 
 export async function handleRequest(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
@@ -200,18 +234,19 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
       });
 
       if (!isNewEvent) {
+        const duplicateSubscriptionId = getPaypalSubscriptionId(event);
+        await syncPaypalSubscriptionEvent(env.PRICE_DB, event);
+        console.log('paypal_webhook_duplicate_resynced', {
+          eventId,
+          eventType,
+          paypalSubscriptionId: duplicateSubscriptionId ?? 'unknown',
+        });
         console.log('paypal_webhook_ignored', { eventId, eventType, reason: 'duplicate_event' });
         return withCors(json({ status: 'ignored', reason: 'duplicate_event' }, 200), origin, env);
       }
 
-<<<<<<< HEAD
-      await syncPaypalSubscriptionEvent(env.PRICE_DB, event);
-
-      if (hasMissingPayPalSignatureHeaders(request)) {
-=======
       if (hasMissingPayPalSignatureHeaders(request)) {
         await syncPaypalSubscriptionEvent(env.PRICE_DB, event);
->>>>>>> origin/main
         console.warn('paypal_webhook_processed_unverified', {
           eventId,
           eventType,
@@ -226,39 +261,26 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
         return withCors(json({ error: 'invalid_signature' }, 401), origin, env);
       }
 
-<<<<<<< HEAD
-=======
       await syncPaypalSubscriptionEvent(env.PRICE_DB, event);
-
->>>>>>> origin/main
       const status = mapPayPalEventTypeToSubscriptionStatus(event.event_type);
       if (!status) {
         console.log('paypal_webhook_ignored', { eventId, eventType, reason: 'unsupported_event_type' });
         return withCors(json({ status: 'ignored', reason: 'unsupported_event_type' }, 200), origin, env);
       }
 
-      const userId = event.resource?.custom_id;
-      if (!userId) {
-        console.warn('paypal_webhook_ignored', { eventId, eventType, reason: 'missing_custom_id' });
-        return withCors(json({ status: 'ignored', reason: 'missing_custom_id' }, 200), origin, env);
-      }
-
-      const subscriptionId = event.resource?.id;
+      const subscriptionId = getPaypalSubscriptionId(event);
       if (!subscriptionId) {
         console.warn('paypal_webhook_ignored', { eventId, eventType, reason: 'missing_subscription_id' });
         return withCors(json({ status: 'ignored', reason: 'missing_subscription_id' }, 200), origin, env);
       }
 
-      await upsertSubscriptionByPayPalId(env.PRICE_DB, {
-        userId,
-        plan: mapPayPalPlanIdToInternalPlan(event.resource?.plan_id),
+      console.log('paypal_webhook_processed', {
+        eventId,
+        eventType,
         status,
-        paypalSubscriptionId: subscriptionId,
-        payerId: event.resource?.subscriber?.payer_id,
-        email: event.resource?.subscriber?.email_address,
+        userId: event.resource?.custom_id ?? UNKNOWN_USER_ID,
+        subscriptionId,
       });
-
-      console.log('paypal_webhook_processed', { eventId, eventType, status, userId, subscriptionId });
 
       return withCors(json({ status: 'processed' }, 200), origin, env);
     }

--- a/price-api/tests/subscriptionWebhook.test.ts
+++ b/price-api/tests/subscriptionWebhook.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { recordWebhookEventIfNew, upsertSubscriptionByPayPalId } from '../src/db';
+import type { PayPalWebhookEvent } from '../src/paypal';
+import { getPaypalSubscriptionId, handleRequest, syncPaypalSubscriptionEvent } from '../src/router';
 import { mapPayPalEventTypeToSubscriptionStatus } from '../src/subscriptionPlans';
+import type { Env } from '../src/types';
 
 interface SubscriptionRow {
   user_id: string;
@@ -9,6 +12,16 @@ interface SubscriptionRow {
   paypal_subscription_id: string;
   payer_id: string | null;
   email: string | null;
+}
+
+interface SyncedSubscriptionRow {
+  id: string;
+  user_id: string | null;
+  plan_code: string | null;
+  status: string;
+  paypal_subscription_id: string;
+  created_at: string;
+  updated_at: string;
 }
 
 class FakeD1PreparedStatement {
@@ -88,6 +101,160 @@ class FakeD1Database {
   }
 }
 
+class SyncFakeD1PreparedStatement {
+  private args: unknown[] = [];
+
+  constructor(private readonly sql: string, private readonly state: { subscriptions: SyncedSubscriptionRow[] }) {}
+
+  bind(...args: unknown[]): this {
+    this.args = args;
+    return this;
+  }
+
+  async run(): Promise<{ meta: { changes: number } }> {
+    if (!this.sql.includes('INSERT INTO subscriptions')) {
+      throw new Error(`Unsupported run SQL in test: ${this.sql}`);
+    }
+
+    const [id, userId, planCode, status, paypalSubscriptionId, createdAt, updatedAt, unknownUserId, unknownPlanCode] = this.args as [
+      string,
+      string | null,
+      string | null,
+      string,
+      string,
+      string,
+      string,
+      string,
+      string,
+    ];
+
+    const existing = this.state.subscriptions.find((item) => item.id === id);
+    if (existing) {
+      if (existing.user_id === null || existing.user_id === unknownUserId) {
+        existing.user_id = userId;
+      }
+      if (existing.plan_code === null || existing.plan_code === unknownPlanCode || existing.plan_code === 'PLAN_UNKNOWN') {
+        existing.plan_code = planCode;
+      }
+      existing.status = status;
+      existing.paypal_subscription_id = paypalSubscriptionId;
+      existing.updated_at = updatedAt;
+      return { meta: { changes: 1 } };
+    }
+
+    this.state.subscriptions.push({
+      id,
+      user_id: userId,
+      plan_code: planCode,
+      status,
+      paypal_subscription_id: paypalSubscriptionId,
+      created_at: createdAt,
+      updated_at: updatedAt,
+    });
+
+    return { meta: { changes: 1 } };
+  }
+}
+
+class SyncFakeD1Database {
+  private readonly state = {
+    subscriptions: [] as SyncedSubscriptionRow[],
+  };
+
+  prepare(sql: string): SyncFakeD1PreparedStatement {
+    return new SyncFakeD1PreparedStatement(sql, this.state);
+  }
+
+  get subscriptions(): SyncedSubscriptionRow[] {
+    return this.state.subscriptions;
+  }
+}
+
+class RouteFakeD1PreparedStatement {
+  private args: unknown[] = [];
+
+  constructor(
+    private readonly sql: string,
+    private readonly state: { webhookEvents: Set<string>; subscriptions: SyncedSubscriptionRow[] },
+  ) {}
+
+  bind(...args: unknown[]): this {
+    this.args = args;
+    return this;
+  }
+
+  async run(): Promise<{ meta: { changes: number } }> {
+    if (this.sql.includes('INSERT OR IGNORE INTO webhook_events')) {
+      const [eventId] = this.args as [string];
+      const existed = this.state.webhookEvents.has(eventId);
+      if (!existed) {
+        this.state.webhookEvents.add(eventId);
+      }
+      return { meta: { changes: existed ? 0 : 1 } };
+    }
+
+    if (this.sql.includes('INSERT INTO subscriptions')) {
+      const [id, userId, planCode, status, paypalSubscriptionId, createdAt, updatedAt, unknownUserId, unknownPlanCode] = this.args as [
+        string,
+        string | null,
+        string | null,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+      ];
+
+      const existing = this.state.subscriptions.find((item) => item.id === id);
+      if (existing) {
+        if (existing.user_id === null || existing.user_id === unknownUserId) {
+          existing.user_id = userId;
+        }
+        if (existing.plan_code === null || existing.plan_code === unknownPlanCode || existing.plan_code === 'PLAN_UNKNOWN') {
+          existing.plan_code = planCode;
+        }
+        existing.status = status;
+        existing.paypal_subscription_id = paypalSubscriptionId;
+        existing.updated_at = updatedAt;
+        return { meta: { changes: 1 } };
+      }
+
+      this.state.subscriptions.push({
+        id,
+        user_id: userId,
+        plan_code: planCode,
+        status,
+        paypal_subscription_id: paypalSubscriptionId,
+        created_at: createdAt,
+        updated_at: updatedAt,
+      });
+      return { meta: { changes: 1 } };
+    }
+
+    throw new Error(`Unsupported run SQL in test: ${this.sql}`);
+  }
+}
+
+class RouteFakeD1Database {
+  private readonly state: { webhookEvents: Set<string>; subscriptions: SyncedSubscriptionRow[] };
+
+  constructor(existingEventIds: string[] = []) {
+    this.state = {
+      webhookEvents: new Set(existingEventIds),
+      subscriptions: [],
+    };
+  }
+
+  prepare(sql: string): RouteFakeD1PreparedStatement {
+    return new RouteFakeD1PreparedStatement(sql, this.state);
+  }
+
+  get subscriptions(): SyncedSubscriptionRow[] {
+    return this.state.subscriptions;
+  }
+}
+
 describe('subscription webhook logic', () => {
   it('applique idempotence sur webhook_events avec INSERT OR IGNORE', async () => {
     const db = new FakeD1Database() as unknown as D1Database;
@@ -137,11 +304,151 @@ describe('subscription webhook logic', () => {
     expect(fake.subscriptions[0]?.email).toBe('new@example.com');
   });
 
+  it('upsert un webhook CREATED avec resource_type Agreement', async () => {
+    const fake = new SyncFakeD1Database();
+    const db = fake as unknown as D1Database;
+    const event: PayPalWebhookEvent = {
+      id: 'WH-1',
+      event_type: 'BILLING.SUBSCRIPTION.CREATED',
+      resource_type: 'Agreement',
+      resource: {
+        id: 'I-TEST123',
+      },
+    };
+
+    await syncPaypalSubscriptionEvent(db, event);
+
+    expect(fake.subscriptions).toHaveLength(1);
+    expect(fake.subscriptions[0]?.id).toBe('I-TEST123');
+    expect(fake.subscriptions[0]?.paypal_subscription_id).toBe('I-TEST123');
+    expect(fake.subscriptions[0]?.status).toBe('CREATED');
+  });
+
+  it('crée un stub puis enrichit user_id/plan_code sur event suivant', async () => {
+    const fake = new SyncFakeD1Database();
+    const db = fake as unknown as D1Database;
+
+    await syncPaypalSubscriptionEvent(db, {
+      id: 'WH-CREATED-1',
+      event_type: 'BILLING.SUBSCRIPTION.CREATED',
+      resource_type: 'Agreement',
+      resource: {
+        id: 'I-TEST123',
+      },
+    });
+
+    expect(fake.subscriptions).toHaveLength(1);
+    expect(fake.subscriptions[0]?.id).toBe('I-TEST123');
+    expect(fake.subscriptions[0]?.user_id).toBe('__unknown__');
+    expect(fake.subscriptions[0]?.plan_code).toBe('UNKNOWN');
+    expect(fake.subscriptions[0]?.status).toBe('CREATED');
+
+    await syncPaypalSubscriptionEvent(db, {
+      id: 'WH-ACTIVATED-1',
+      event_type: 'BILLING.SUBSCRIPTION.ACTIVATED',
+      resource_type: 'Agreement',
+      resource: {
+        id: 'I-TEST123',
+        custom_id: 'user_123',
+        plan_id: 'PREMIUM_SANDBOX_PLAN_ID',
+      },
+    });
+
+    expect(fake.subscriptions).toHaveLength(1);
+    expect(fake.subscriptions[0]?.id).toBe('I-TEST123');
+    expect(fake.subscriptions[0]?.user_id).toBe('user_123');
+    expect(fake.subscriptions[0]?.plan_code).toBe('PREMIUM_MONTHLY');
+    expect(fake.subscriptions[0]?.status).toBe('ACTIVE');
+  });
+
+  it('extrait paypalSubscriptionId avec fallback billing_agreement_id/subscription_id', () => {
+    expect(
+      getPaypalSubscriptionId({
+        id: 'WH-2',
+        event_type: 'BILLING.SUBSCRIPTION.CREATED',
+        resource: { id: 'I-ID-FIRST', billing_agreement_id: 'I-ID-SECOND', subscription_id: 'I-ID-THIRD' },
+      }),
+    ).toBe('I-ID-FIRST');
+
+    expect(
+      getPaypalSubscriptionId({
+        id: 'WH-3',
+        event_type: 'BILLING.SUBSCRIPTION.CREATED',
+        resource: { billing_agreement_id: 'I-ID-SECOND', subscription_id: 'I-ID-THIRD' },
+      }),
+    ).toBe('I-ID-SECOND');
+
+    expect(
+      getPaypalSubscriptionId({
+        id: 'WH-4',
+        event_type: 'BILLING.SUBSCRIPTION.CREATED',
+        resource: { subscription_id: 'I-ID-THIRD' },
+      }),
+    ).toBe('I-ID-THIRD');
+
+    expect(
+      getPaypalSubscriptionId({
+        id: 'WH-5',
+        event_type: 'BILLING.SUBSCRIPTION.CREATED',
+        resource: { id: 'NOT-VALID' },
+      }),
+    ).toBeNull();
+  });
+
   it('mappe correctement event_type PayPal vers status interne', () => {
     expect(mapPayPalEventTypeToSubscriptionStatus('BILLING.SUBSCRIPTION.CREATED')).toBe('CREATED');
     expect(mapPayPalEventTypeToSubscriptionStatus('BILLING.SUBSCRIPTION.ACTIVATED')).toBe('ACTIVE');
     expect(mapPayPalEventTypeToSubscriptionStatus('BILLING.SUBSCRIPTION.SUSPENDED')).toBe('SUSPENDED');
     expect(mapPayPalEventTypeToSubscriptionStatus('BILLING.SUBSCRIPTION.CANCELLED')).toBe('CANCELLED');
     expect(mapPayPalEventTypeToSubscriptionStatus('PAYMENT.SALE.COMPLETED')).toBeNull();
+  });
+
+  it('resynchronise subscriptions même sur duplicate_event', async () => {
+    const duplicateEventId = 'WH-DUPLICATE-1';
+    const fakeDb = new RouteFakeD1Database([duplicateEventId]);
+    const env = {
+      PRICE_DB: fakeDb as unknown as D1Database,
+      PRICE_ADMIN_TOKEN: 'admin-token',
+      PAYPAL_CLIENT_ID: 'paypal-client-id',
+      PAYPAL_CLIENT_SECRET: 'paypal-client-secret',
+      PAYPAL_WEBHOOK_ID: 'paypal-webhook-id',
+      PAYPAL_ENV: 'sandbox',
+      PRICE_IMPORTS: {} as R2Bucket,
+    } as Env;
+
+    const event: PayPalWebhookEvent = {
+      id: duplicateEventId,
+      event_type: 'BILLING.SUBSCRIPTION.CREATED',
+      resource_type: 'Agreement',
+      resource: {
+        id: 'I-DUPLICATE-123',
+      },
+    };
+
+    const response = await handleRequest(
+      new Request('https://example.com/v1/webhooks/paypal', {
+        method: 'POST',
+        body: JSON.stringify(event),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+      env,
+      {
+        waitUntil: () => {
+          // no-op for test
+        },
+        passThroughOnException: () => {
+          // no-op for test
+        },
+        props: {},
+      } as unknown as ExecutionContext,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ status: 'ignored', reason: 'duplicate_event' });
+    expect(fakeDb.subscriptions).toHaveLength(1);
+    expect(fakeDb.subscriptions[0]?.id).toBe('I-DUPLICATE-123');
+    expect(fakeDb.subscriptions[0]?.status).toBe('CREATED');
   });
 });


### PR DESCRIPTION
### Motivation
- Remove lingering Git conflict markers in `router.ts` which prevent TypeScript compilation. 
- Ensure duplicate PayPal webhook events still trigger idempotent subscription resynchronization so `subscriptions` can be backfilled. 
- Improve diagnostics when resyncing duplicates by logging the resolved PayPal subscription id. 
- Harden sync logic to reliably extract a subscription id from multiple PayPal payload fields and upsert subscriptions with sensible defaults.

### Description
- Removed conflict marker leftovers and normalized the handler flow so the duplicate-event branch runs before signature checks and still calls `syncPaypalSubscriptionEvent`. 
- Added `getPaypalSubscriptionId(...)` helper to pick a PayPal subscription id from `resource.id`, `resource.billing_agreement_id`, or `resource.subscription_id`. 
- Reworked `syncPaypalSubscriptionEvent(...)` to perform an idempotent `INSERT ... ON CONFLICT` upsert that preserves existing `user_id`/`plan_code` when appropriate, and emit `paypal_subscription_synced` logs. 
- Enhanced duplicate-event handling to compute and include `paypalSubscriptionId` in the `paypal_webhook_duplicate_resynced` log payload while still returning `{ status: 'ignored', reason: 'duplicate_event' }`. 
- Adjusted PayPal event typings to include `resource_type`, `billing_agreement_id`, and `subscription_id`. 
- Extended and added route-level tests (`RouteFakeD1Database`) to cover sync behavior, `getPaypalSubscriptionId` extraction, and duplicate-event resync behavior, and removed use of the removed `upsertSubscriptionByPayPalId` path.

### Testing
- Ran the targeted unit tests with `npm test -- --run tests/subscriptionWebhook.test.ts` and all tests passed (7 tests). 
- Ran type checks with `npm run typecheck` (`tsc --noEmit`) and the typecheck succeeded. 
- Verified no Git conflict markers remain with `rg -n "<<<<<<<|>>>>>>>|=======" price-api/src/router.ts` which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699de994e2348321a7d200f8d69121b6)