### PR TITLE
Run frontend typecheck in CI and add root `typecheck` script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Build
         working-directory: frontend
         run: npm run build
+      - name: Typecheck
+        working-directory: frontend
+        run: npm run -s typecheck
       - name: Run tests
         working-directory: frontend
         run: npm run test:ci || echo "Tests skipped (browser-only)"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "vite build",
     "dev": "cd frontend && npm run dev",
     "preview": "cd frontend && npm run preview",
+    "typecheck": "cd frontend && npm run -s typecheck",
     "build:frontend": "cd frontend && npm ci --include=dev && npm run build",
     "install:frontend": "cd frontend && npm ci --include=dev",
     "lint": "cd frontend && npm run lint"


### PR DESCRIPTION
### Motivation
- Ensure the frontend's TypeScript type checks are executed during CI to catch type errors early in the build pipeline.

### Description
- Add a `Typecheck` step to `.github/workflows/ci.yml` that runs `npm run -s typecheck` in the `frontend` working directory as part of the `build-test` job.
- Add a root-level `typecheck` script to `package.json` that delegates to the frontend via `cd frontend && npm run -s typecheck`.

### Testing
- No automated CI run was executed as part of this change; the workflow now includes a `Typecheck` step which will run frontend type checks when the workflow runs.
- The existing `Run tests` step (`npm run test:ci`) remains unchanged and will continue to run as before.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e4b6547288321bfbe6ad28519e1c2)