### PR TITLE
Add production readiness checklist and deployment verification scripts

### DIFF
--- a/docs/deployment-readiness-checklist.md
+++ b/docs/deployment-readiness-checklist.md
@@ -1,0 +1,61 @@
+# Checklist de conformité – A KI PRI SA YÉ
+
+Objectif: obtenir un pipeline **100% vert** avant mise en production, avec une revérification approfondie en **3 rounds successifs**, et comprendre précisément l’état de `main`.
+
+## 1) État cible "tout vert"
+
+- État GitHub `main`/Pages validé (dernier run `deploy-pages.yml` vert) ✅
+- CI (lint, typecheck, tests) ✅
+- Build GitHub Pages avec `BASE_PATH=/akiprisaye-web/` ✅
+- Vérification des chemins statiques (`verify-pages-build`) ✅
+- Vérification runtime locale type production (`verify-pages-runtime`) ✅
+- Validation du site déployé (`validate-deployment`) ✅
+- Répéter les contrôles sur 3 rounds consécutifs ✅
+
+## 2) Comprendre ce qui peut échouer sur la branche principale
+
+Le script `scripts/deployment-state-report.mjs` interroge GitHub API pour:
+
+- vérifier le **dernier run** `deploy-pages.yml` sur `main`,
+- signaler les échecs récents (historique),
+- afficher l’état GitHub Pages (`/pages`) quand disponible.
+
+Cela permet d’isoler:
+
+- un vrai incident `main` (dernier run rouge),
+- d’un historique rouge non bloquant (anciens runs / refs non-main).
+
+## 3) Commandes de contrôle renforcé (x3)
+
+Depuis la racine du repo:
+
+```bash
+npm run readiness:prod
+```
+
+Mode strict (recommandé): tout échec stoppe immédiatement le processus.
+
+## 4) Environnement réseau restreint (proxy, tunnel, etc.)
+
+Si votre runner bloque l’accès externe GitHub Pages/API:
+
+```bash
+npm run readiness:prod:network-tolerant
+```
+
+Ce mode n’ignore **que** les étapes réseau distantes (état GitHub + validation URL publique), mais conserve strictement tous les contrôles locaux.
+
+## 5) Validation distante stricte explicite
+
+```bash
+node scripts/production-readiness-check.mjs https://teetee971.github.io/akiprisaye-web teetee971/akiprisaye-web
+```
+
+## 6) Critère de livraison "preuve finale"
+
+La mise en prod est considérée prête quand:
+
+1. Les 3 rounds sont exécutés sans échec local.
+2. Le dernier run `deploy-pages.yml` sur `main` est vert.
+3. La validation distante du site public est verte.
+4. Le workflow `Deploy to GitHub Pages` est vert après push sur `main`.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "build:frontend": "cd frontend && npm ci --include=dev && npm run build",
     "install:frontend": "cd frontend && npm ci --include=dev",
     "lint": "cd frontend && npm run lint",
-    "lint:ci": "eslint \"frontend/src/**/*.{js,jsx,ts,tsx}\" \"price-api/src/**/*.{js,jsx,ts,tsx}\" --max-warnings=0"
+    "lint:ci": "eslint \"frontend/src/**/*.{js,jsx,ts,tsx}\" \"price-api/src/**/*.{js,jsx,ts,tsx}\" --max-warnings=0",
+    "readiness:prod": "node scripts/production-readiness-check.mjs",
+    "readiness:prod:network-tolerant": "ALLOW_NETWORK_FAILURE=1 node scripts/production-readiness-check.mjs"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.56.1",

--- a/scripts/deployment-state-report.mjs
+++ b/scripts/deployment-state-report.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+const DEFAULT_REPO = 'teetee971/akiprisaye-web';
+const repoSlug = process.argv[2] || process.env.GITHUB_REPOSITORY || DEFAULT_REPO;
+const [owner, repo] = repoSlug.split('/');
+
+if (!owner || !repo) {
+  console.error(`❌ Format de repo invalide: "${repoSlug}". Attendu: owner/repo`);
+  process.exit(1);
+}
+
+const API_BASE = `https://api.github.com/repos/${owner}/${repo}`;
+const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+
+function headers() {
+  return {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'akiprisaye-production-audit',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+async function getJson(path) {
+  const response = await fetch(`${API_BASE}${path}`, {
+    headers: headers(),
+    signal: AbortSignal.timeout(20_000),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`${path} -> HTTP ${response.status}: ${text.slice(0, 180)}`);
+  }
+
+  return response.json();
+}
+
+function printRun(prefix, run) {
+  console.log(`${prefix} #${run.run_number} ${run.status}/${run.conclusion ?? 'n/a'} — ${run.head_branch} @ ${run.head_sha.slice(0, 7)}`);
+  console.log(`   ${run.html_url}`);
+}
+
+async function main() {
+  console.log('🔎 ÉTAT DU DÉPLOIEMENT SUR LA BRANCHE MAIN');
+  console.log('==========================================');
+  console.log(`Repo: ${owner}/${repo}`);
+
+  const workflowRuns = await getJson('/actions/workflows/deploy-pages.yml/runs?branch=main&per_page=5');
+  const runs = workflowRuns.workflow_runs || [];
+
+  if (runs.length === 0) {
+    throw new Error('Aucun run du workflow deploy-pages.yml trouvé sur main.');
+  }
+
+  const latest = runs[0];
+  console.log('');
+  console.log('Dernier run deploy-pages.yml (main):');
+  printRun('•', latest);
+
+  if (latest.status !== 'completed') {
+    throw new Error('Le dernier run deploy-pages.yml sur main n’est pas terminé.');
+  }
+
+  if (latest.conclusion !== 'success') {
+    throw new Error(`Le dernier run deploy-pages.yml sur main est en échec (${latest.conclusion}).`);
+  }
+
+  console.log('✅ Le dernier run deploy-pages.yml sur main est vert.');
+
+  const failing = runs.filter((run) => run.status === 'completed' && run.conclusion !== 'success');
+  if (failing.length > 0) {
+    console.log('⚠️  Runs récents en échec (historique, pas forcément bloquant si dernier run vert):');
+    for (const run of failing.slice(0, 3)) {
+      printRun('  -', run);
+    }
+  }
+
+  let pagesInfo;
+  try {
+    pagesInfo = await getJson('/pages');
+    console.log('');
+    console.log('GitHub Pages:');
+    console.log(`• status: ${pagesInfo.status}`);
+    console.log(`• source: ${pagesInfo.source?.branch || 'n/a'} / ${pagesInfo.source?.path || 'n/a'}`);
+    console.log(`• build_type: ${pagesInfo.build_type}`);
+    console.log(`• url: ${pagesInfo.html_url}`);
+  } catch (error) {
+    console.log(`⚠️  Impossible de lire /pages: ${error.message}`);
+  }
+
+  console.log('');
+  console.log('✅ Rapport état main/deploiement terminé.');
+}
+
+main().catch((error) => {
+  console.error('');
+  console.error(`❌ État déploiement non conforme: ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/scripts/production-readiness-check.mjs
+++ b/scripts/production-readiness-check.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+
+const DEPLOYMENT_URL = process.argv[2] || 'https://teetee971.github.io/akiprisaye-web';
+const REPO_SLUG = process.argv[3] || process.env.GITHUB_REPOSITORY || 'teetee971/akiprisaye-web';
+const ROUNDS = 3;
+const allowNetworkFailure = process.env.ALLOW_NETWORK_FAILURE === '1';
+
+const checks = [
+  { label: 'Diagnostic état main/deploiement GitHub', cmd: 'node', args: ['scripts/deployment-state-report.mjs', REPO_SLUG] },
+  { label: 'Lint frontend', cmd: 'npm', args: ['--prefix', 'frontend', 'run', 'lint'] },
+  { label: 'Typecheck frontend (CI)', cmd: 'npm', args: ['--prefix', 'frontend', 'run', 'typecheck:ci'] },
+  { label: 'Tests frontend (CI)', cmd: 'npm', args: ['--prefix', 'frontend', 'run', 'test:ci'] },
+  {
+    label: 'Build frontend (GitHub Pages BASE_PATH)',
+    cmd: 'npm',
+    args: ['--prefix', 'frontend', 'run', 'build'],
+    env: {
+      BASE_PATH: '/akiprisaye-web/',
+      NODE_OPTIONS: '--max-old-space-size=4096',
+    },
+  },
+  { label: 'Verify build paths', cmd: 'node', args: ['scripts/verify-pages-build.mjs'], cwd: 'frontend' },
+  { label: 'Verify runtime paths', cmd: 'node', args: ['scripts/verify-pages-runtime.mjs'], cwd: 'frontend' },
+];
+
+function runStep({ label, cmd, args, env, cwd }, round) {
+  console.log(`\n▶️  [Round ${round}/${ROUNDS}] ${label}`);
+  const result = spawnSync(cmd, args, {
+    stdio: 'inherit',
+    env: { ...process.env, ...(env || {}) },
+    cwd: cwd || process.cwd(),
+  });
+
+  if (result.status !== 0) {
+    if (allowNetworkFailure && (label.includes('deploiement GitHub') || label.includes('Validation du déploiement'))) {
+      console.warn(`⚠️  ${label} non concluant en environnement restreint (ALLOW_NETWORK_FAILURE=1).`);
+      return;
+    }
+
+    throw new Error(`Échec: ${label} (code ${result.status ?? 'inconnu'})`);
+  }
+}
+
+function runRemoteValidation(round) {
+  runStep(
+    {
+      label: `Validation du déploiement public ${DEPLOYMENT_URL}`,
+      cmd: 'node',
+      args: ['scripts/validate-deployment.mjs', DEPLOYMENT_URL],
+    },
+    round,
+  );
+}
+
+for (let round = 1; round <= ROUNDS; round += 1) {
+  console.log('\n============================================================');
+  console.log(`🔁 ROUND ${round}/${ROUNDS} — Vérification production approfondie`);
+  console.log('============================================================');
+
+  for (const check of checks) {
+    runStep(check, round);
+  }
+
+  runRemoteValidation(round);
+}
+
+console.log('\n🏁 PREUVE FINALE');
+console.log('✅ 3/3 rounds de vérification exécutés.');
+console.log(`✅ Déploiement cible: ${DEPLOYMENT_URL}`);
+console.log(`✅ Repository audité: ${REPO_SLUG}`);
+console.log(`✅ Horodatage UTC: ${new Date().toISOString()}`);
+console.log(`✅ Mode tolérance réseau: ${allowNetworkFailure ? 'activé (ALLOW_NETWORK_FAILURE=1)' : 'désactivé (strict)'}`);
+console.log('✅ Statut: checklist exécutée jusqu’au bout (voir logs des rounds).');


### PR DESCRIPTION
### Motivation
- Provide an auditable, repeatable production readiness flow to ensure the `main` branch and GitHub Pages deployment are healthy before releases.
- Surface deployment-state diagnostics and automate a 3-round, strict verification that runs lint/typecheck/tests/build and remote validation.
- Support restricted-network runners with a tolerant mode to skip only remote checks while keeping local validations strict.

### Description
- Add `docs/deployment-readiness-checklist.md` with the checklist, commands, and delivery criteria for a 3-round verification process. 
- Add `scripts/deployment-state-report.mjs` to query the GitHub API for the latest `deploy-pages.yml` runs and GitHub Pages status and to fail early if the last run on `main` is not finished or successful. 
- Add `scripts/production-readiness-check.mjs` which orchestrates 3 rounds of checks (deployment report, `lint`, `typecheck:ci`, `test:ci`, `build` with `BASE_PATH`, and runtime/build verifications) and includes a network-tolerant mode via `ALLOW_NETWORK_FAILURE=1`. 
- Update `package.json` to add `readiness:prod` and `readiness:prod:network-tolerant` scripts and a small formatting fix to the existing `lint:ci` script entry. 

### Testing
- No automated tests were executed as part of this PR; the new `readiness:prod` script is designed to run existing CI tasks (`lint`, `typecheck:ci`, `test:ci`, build and verification scripts) when invoked and will surface their success or failure at runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4fe5ab9b48321a13944f547a8957d)