### PR TITLE
fix(ocr): handle asset preload failures and guard worker termination in `runOCR`

### DIFF
--- a/frontend/src/services/ocrService.ts
+++ b/frontend/src/services/ocrService.ts
@@ -331,30 +331,31 @@ export async function runOCR(
   const receiptMode = options?.receiptMode ?? false;
   const psmMode = options?.psm ?? (receiptMode ? OCR_PSM.SINGLE_COLUMN : OCR_PSM.AUTO);
   let timeoutId: number | undefined;
+  let worker: any = null;
   
   // Log mode for debugging
   console.log(`OCR mode: ${offline ? 'OFFLINE (local WASM)' : 'ONLINE'} receiptMode=${receiptMode} psm=${psmMode}`);
   console.log('[OCR] Asset paths', { WORKER_PATH, CORE_PATH, LANG_PATH, lang: effectiveLang });
 
-  // Lazy load Tesseract module (17MB) - only loads when OCR is actually used
-  const Tesseract = await loadTesseract();
-
-  await ensureAssetAvailable(WORKER_PATH, 'worker');
-  await ensureAssetAvailable(CORE_PATH, 'core');
-  await ensureAssetAvailable(`${LANG_PATH}/${effectiveLang}.traineddata.gz`, 'language');
-
-  const preprocessed = await preprocessImage(imageUrl, 1600, receiptMode);
-  const worker = await Tesseract.createWorker({
-    workerPath: WORKER_PATH,
-    corePath: CORE_PATH,
-    langPath: LANG_PATH,
-    gzip: true,
-    logger: (m: unknown) => console.debug('[OCR]', m),
-  });
-
   let timeoutTriggered = false;
 
   try {
+    // Lazy load Tesseract module (17MB) - only loads when OCR is actually used
+    const Tesseract = await loadTesseract();
+
+    await ensureAssetAvailable(WORKER_PATH, 'worker');
+    await ensureAssetAvailable(CORE_PATH, 'core');
+    await ensureAssetAvailable(`${LANG_PATH}/${effectiveLang}.traineddata.gz`, 'language');
+
+    const preprocessed = await preprocessImage(imageUrl, 1600, receiptMode);
+    worker = await Tesseract.createWorker({
+      workerPath: WORKER_PATH,
+      corePath: CORE_PATH,
+      langPath: LANG_PATH,
+      gzip: true,
+      logger: (m: unknown) => console.debug('[OCR]', m),
+    });
+
     // Tesseract.js runs entirely in the browser via WASM
     // No server calls - works offline by default
     await worker.loadLanguage(effectiveLang);
@@ -424,7 +425,9 @@ export async function runOCR(
     if (timeoutId !== undefined) {
       clearTimeout(timeoutId);
     }
-    await worker.terminate();
+    if (worker) {
+      await worker.terminate();
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent OCR asset/module preload failures from throwing out of `runOCR` and surfacing as the generic UI error `Une erreur est survenue lors de l'analyse du ticket`.
- Ensure the OCR worker is terminated only when it was actually created to avoid runtime crashes during cleanup.

### Description
- Moved Tesseract module loading, asset availability checks, image preprocessing and `createWorker` call inside the `try` block of `runOCR` to convert preload failures into structured OCR error results.
- Introduced a `worker` variable (`any`) scoped outside the `try` so it can be conditionally terminated in `finally`.
- Made worker termination conditional (`if (worker) { await worker.terminate(); }`) to avoid calling methods on an uninitialized worker.
- Modified file: `frontend/src/services/ocrService.ts`.

### Testing
- Ran type checking with `npm --prefix frontend run typecheck` and it completed successfully.
- Ran lint for the modified file with `npm --prefix frontend run lint -- src/services/ocrService.ts` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ae396e3c8321a5a600c40b0f74c8)