### PR TITLE
fix: restore frontend pages build

### DIFF
--- a/frontend/src/pages/Contact.tsx
+++ b/frontend/src/pages/Contact.tsx
@@ -39,13 +39,11 @@ export default function Contact() {
     const trimmedMessage = formData.message.trim();
 
     if (!trimmedName || !trimmedEmail || !trimmedMessage) {
-    if (!formData.name || !formData.email || !formData.message) {
       toast.error('Veuillez remplir les champs obligatoires.');
       return;
     }
 
     if (!trimmedEmail.includes('@')) {
-    if (!formData.email.includes('@')) {
       toast.error('Veuillez entrer une adresse email valide.');
       return;
     }
@@ -56,10 +54,6 @@ export default function Contact() {
       `Email : ${trimmedEmail}`,
       '',
       trimmedMessage,
-      `Nom : ${formData.name}`,
-      `Email : ${formData.email}`,
-      '',
-      formData.message,
     ].join('\n');
 
     const mailtoUrl = `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
@@ -172,7 +166,6 @@ export default function Contact() {
           </section>
 
           <aside id="pro" className="space-y-4">
-          <aside className="space-y-4">
             <div className="rounded-2xl border border-slate-800 bg-slate-900/80 p-5">
               <div className="flex items-center gap-3">
                 <div className="rounded-xl bg-blue-950/70 p-2 text-blue-300">

--- a/frontend/src/pages/Transparence.tsx
+++ b/frontend/src/pages/Transparence.tsx
@@ -18,51 +18,42 @@ type StatusCardProps = {
 };
 
 const AVAILABLE_NOW: StatusItem[] = [
-  { id: 'compareur-public', text: 'Consultation libre du comparateur sans obligation de compte pour découvrir le service.' },
-  { id: 'pages-publiques', text: 'Page méthodologie, observatoire et pages explicatives accessibles publiquement.' },
-  { id: 'statut-produit', text: 'Communication explicite sur ce qui est disponible maintenant vs. ce qui reste en préparation.' },
+  {
+    id: 'compareur-public',
+    text: 'Consultation libre du comparateur sans obligation de compte pour découvrir le service.',
+  },
+  {
+    id: 'pages-publiques',
+    text: 'Page méthodologie, observatoire et pages explicatives accessibles publiquement.',
+  },
+  {
+    id: 'statut-produit',
+    text: 'Communication explicite sur ce qui est disponible maintenant vs. ce qui reste en préparation.',
+  },
 ];
 
 const IN_PROGRESS: StatusItem[] = [
   { id: 'open-data-enrichi', text: 'Open data enrichi avec exports mieux documentés.' },
   { id: 'couverture-etendue', text: 'Couverture plus large des territoires et des catégories suivies.' },
-  { id: 'historique-profond', text: 'Historique de données plus profond et plus lisible pour le grand public.' },
+  {
+    id: 'historique-profond',
+    text: 'Historique de données plus profond et plus lisible pour le grand public.',
+  },
 ];
 
 const PRIVACY_COMMITMENTS: StatusItem[] = [
   { id: 'pas-de-vente', text: 'Pas de vente de données personnelles.' },
-  { id: 'pas-d-ambigui-te', text: 'Pas d’ambiguïté entre page de confidentialité et page de transparence produit.' },
-  { id: 'beta-visible', text: 'Signalement visible lorsqu’une fonctionnalité est en bêta, limitée ou en préparation.' },
-const AVAILABLE_NOW = [
-  'Consultation libre du comparateur sans obligation de compte pour découvrir le service.',
-  'Page méthodologie, observatoire et pages explicatives accessibles publiquement.',
-  'Communication explicite sur ce qui est disponible maintenant vs. ce qui reste en préparation.',
+  {
+    id: 'pas-d-ambigui-te',
+    text: 'Pas d’ambiguïté entre page de confidentialité et page de transparence produit.',
+  },
+  {
+    id: 'beta-visible',
+    text: 'Signalement visible lorsqu’une fonctionnalité est en bêta, limitée ou en préparation.',
+  },
 ];
 
-const IN_PROGRESS = [
-  'Open data enrichi avec exports mieux documentés.',
-  'Couverture plus large des territoires et des catégories suivies.',
-  'Historique de données plus profond et plus lisible pour le grand public.',
-];
-
-const PRIVACY_COMMITMENTS = [
-  'Pas de vente de données personnelles.',
-  'Pas d’ambiguïté entre page de confidentialité et page de transparence produit.',
-  'Signalement visible lorsqu’une fonctionnalité est en bêta, limitée ou en préparation.',
-];
-
-function StatusCard({
-  title,
-  icon,
-  items,
-  tone = 'neutral',
-}: StatusCardProps) {
-}: {
-  title: string;
-  icon: React.ReactNode;
-  items: string[];
-  tone?: 'neutral' | 'success' | 'warning';
-}) {
+function StatusCard({ title, icon, items, tone = 'neutral' }: StatusCardProps) {
   const tones = {
     neutral: 'border-slate-800 bg-slate-900/80',
     success: 'border-emerald-800/60 bg-emerald-950/30',
@@ -80,9 +71,6 @@ function StatusCard({
           <li key={item.id} className="flex gap-3">
             <span className="mt-1 h-1.5 w-1.5 rounded-full bg-current opacity-80" aria-hidden="true" />
             <span>{item.text}</span>
-          <li key={item} className="flex gap-3">
-            <span className="mt-1 h-1.5 w-1.5 rounded-full bg-current opacity-80" aria-hidden="true" />
-            <span>{item}</span>
           </li>
         ))}
       </ul>
@@ -98,40 +86,6 @@ export default function Transparence() {
         description="Comprenez clairement ce qu’A KI PRI SA YÉ propose déjà, ce qui est en cours de déploiement et nos engagements de confidentialité."
         canonical="https://teetee971.github.io/akiprisaye-web/transparence"
       />
-
-      <div className="min-h-screen bg-slate-950 text-slate-100">
-        <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
-          <HeroImage
-            src={PAGE_HERO_IMAGES.transparence}
-            alt="Transparence et confiance"
-            gradient="from-slate-950 to-slate-800"
-            height="h-44 sm:h-56"
-          >
-            <h1 className="text-3xl font-extrabold text-white drop-shadow sm:text-4xl">
-              🔎 Transparence
-            </h1>
-            <p className="mt-2 max-w-2xl text-sm text-slate-200 drop-shadow sm:text-base">
-              Cette page explique simplement ce qui est disponible maintenant, ce qui est encore en cours de
-              déploiement, et comment nous traitons la confidentialité.
-            </p>
-          </HeroImage>
-
-          <section className="mt-6 rounded-2xl border border-slate-800 bg-slate-900/80 p-6">
-            <div className="flex items-start gap-3">
-              <div className="rounded-xl bg-blue-950/70 p-2 text-blue-300">
-                <FileText className="h-5 w-5" aria-hidden="true" />
-              </div>
-              <div>
-                <h2 className="text-lg font-semibold text-white">Pourquoi cette page existe</h2>
-                <p className="mt-2 text-sm leading-6 text-slate-300">
-                  Un visiteur doit pouvoir distinguer en quelques secondes ce qui relève de la promesse produit, de la
-                  couverture réelle et des engagements de confidentialité. Nous avons donc séparé ici les statuts
-                  “disponible”, “en préparation” et “engagements”.
-                </p>
-              </div>
-            </div>
-          </section>
-
 
       <div className="min-h-screen bg-slate-950 text-slate-100">
         <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
@@ -212,15 +166,21 @@ export default function Transparence() {
               <div className="mt-4 space-y-3 text-sm text-slate-300">
                 <div className="rounded-xl border border-slate-800 bg-slate-950/60 p-4">
                   <p className="font-medium text-white">Comparateur &amp; découverte</p>
-                  <p className="mt-1 text-slate-400">Accessible publiquement pour comprendre la proposition de valeur.</p>
+                  <p className="mt-1 text-slate-400">
+                    Accessible publiquement pour comprendre la proposition de valeur.
+                  </p>
                 </div>
                 <div className="rounded-xl border border-slate-800 bg-slate-950/60 p-4">
                   <p className="font-medium text-white">Pages de confiance</p>
-                  <p className="mt-1 text-slate-400">Méthodologie, transparence et contact doivent rester cohérents entre eux.</p>
+                  <p className="mt-1 text-slate-400">
+                    Méthodologie, transparence et contact doivent rester cohérents entre eux.
+                  </p>
                 </div>
                 <div className="rounded-xl border border-slate-800 bg-slate-950/60 p-4">
                   <p className="font-medium text-white">Open data</p>
-                  <p className="mt-1 text-slate-400">Présenté comme un chantier progressif, pas comme une promesse déjà totalement livrée.</p>
+                  <p className="mt-1 text-slate-400">
+                    Présenté comme un chantier progressif, pas comme une promesse déjà totalement livrée.
+                  </p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- The GitHub Pages build was failing because Vite/esbuild encountered JSX/TypeScript parse errors in frontend pages, blocking the `deploy-pages` workflow step.
- Errors originated from malformed/duplicated code in `frontend/src/pages/Contact.tsx` and `frontend/src/pages/Transparence.tsx` that produced unexpected tokens and unclosed tags during the production build.

### Description
- Fixed `frontend/src/pages/Contact.tsx` by removing duplicated validation branches and duplicated `body` entries, and by eliminating an accidental nested `<aside>` so the JSX structure is well-formed.
- Fixed `frontend/src/pages/Transparence.tsx` by removing duplicated/partial array declarations and malformed `StatusCard` fragments, restoring a single consistent `StatusItem[]` implementation and a correct `StatusCard` signature and JSX mapping.
- Reformatted a few list/JSX fragments to ensure proper closing tags and stable iteration over `items` in `StatusCard`.
- Changes are limited to `frontend/src/pages/Contact.tsx` and `frontend/src/pages/Transparence.tsx` to restore successful parsing and production bundling.

### Testing
- Ran a production build with the Pages environment simulation: `cd frontend && GITHUB_PAGES=true BASE_PATH=/akiprisaye-web/ NODE_OPTIONS=--max-old-space-size=4096 npm run build` and the build completed successfully.
- Ran linting with `cd frontend && npm run lint` which passed; only the repository's pre-existing accessibility warnings remain.
- Ran TypeScript checks with `cd frontend && npx tsc -p tsconfig.ci.json --noEmit` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c19a5d7ad88321a6edb49cb8d625d8)