### PR TITLE
Extract default news limit constant and use it in Actualites and tests

### DIFF
--- a/frontend/src/constants/news.js
+++ b/frontend/src/constants/news.js
@@ -8,3 +8,6 @@ export const MULTI_TERRITORY_VALUES = ['Tous territoires', 'DROM-COM'];
 
 // Category filter constants
 export const ALL_CATEGORIES = 'ALL';
+
+// API defaults
+export const DEFAULT_NEWS_LIMIT = 30;

--- a/frontend/src/pages/Actualites.jsx
+++ b/frontend/src/pages/Actualites.jsx
@@ -5,6 +5,7 @@ import OptimizedImage from '../components/OptimizedImage';
 import { PAGE_HERO_IMAGES } from '../config/imageAssets';
 import { newsFallback } from '../data/newsFallback';
 import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
+import { DEFAULT_NEWS_LIMIT } from '../constants/news';
 
 const TERRITORY_LABELS = {
   all: 'Tous territoires',
@@ -36,7 +37,7 @@ export default function Actualites() {
   const [type, setType] = useState('');
   const [impact, setImpact] = useState('');
   const [verifiedOnly, setVerifiedOnly] = useState(false);
-  const [limit, setLimit] = useState(30);
+  const [limit, setLimit] = useState(DEFAULT_NEWS_LIMIT);
   const [state, setState] = useState({ status: 'loading', items: [], mode: 'mock' });
   const [openEvidence, setOpenEvidence] = useState({});
   const [showFeaturedMedia, setShowFeaturedMedia] = useState(false);

--- a/frontend/src/test/actualites.page.test.jsx
+++ b/frontend/src/test/actualites.page.test.jsx
@@ -3,6 +3,7 @@ import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { HelmetProvider } from 'react-helmet-async';
 import Actualites from '../pages/Actualites';
+import { DEFAULT_NEWS_LIMIT } from '../constants/news';
 
 describe('Actualites page', () => {
   let container;
@@ -53,7 +54,7 @@ describe('Actualites page', () => {
     expect(latest).toContain('territory=gp');
     expect(latest).toContain('type=bons_plans');
     expect(latest).toContain('impact=fort');
-    expect(latest).toContain('limit=30');
+    expect(latest).toContain(`limit=${DEFAULT_NEWS_LIMIT}`);
     expect(latest).not.toContain('&q=');
   });
 


### PR DESCRIPTION
### Motivation

- Centralize the default page size for news requests so the value isn't duplicated in the page and tests.

### Description

- Add `DEFAULT_NEWS_LIMIT` export in `frontend/src/constants/news.js` and remove the hardcoded `30` from `Actualites.jsx` by initializing `limit` with `DEFAULT_NEWS_LIMIT`.
- Update `frontend/src/test/actualites.page.test.jsx` to import `DEFAULT_NEWS_LIMIT` and assert the generated API URL contains `limit=${DEFAULT_NEWS_LIMIT}` instead of a hardcoded value.

### Testing

- Ran unit tests with `vitest`, including the updated `actualites.page.test.jsx`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1ab93c37483218b809312d61fd7de)