### PR TITLE
Comparateur: add local fallback search, normalization, territory handling and UI insights

### DIFF
--- a/frontend/src/pages/Comparateur.jsx
+++ b/frontend/src/pages/Comparateur.jsx
@@ -12,6 +12,111 @@ const sortResults = (items, sortBy) => {
   return [...items].sort((a, b) => Number(a.price) - Number(b.price));
 };
 
+const normalize = (value) =>
+  String(value ?? '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim();
+
+const scoreProductMatch = (product, query) => {
+  const q = normalize(query);
+  if (!q) return 0;
+
+  const fields = [
+    product.name,
+    product.brand,
+    product.ean,
+    ...(Array.isArray(product.synonyms) ? product.synonyms : []),
+  ].map((item) => normalize(item));
+
+  if (fields.some((field) => field === q)) return 100;
+  if (fields.some((field) => field.startsWith(q))) return 80;
+  if (fields.some((field) => field.includes(q))) return 60;
+  return 0;
+};
+
+const normalizeTerritoryCode = (territory) => {
+  const cleaned = normalize(territory).replace(/[^a-z0-9]/g, '');
+  if (!cleaned) return 'gp';
+  if (cleaned === 'france' || cleaned === 'metropole') return 'fr';
+  return cleaned;
+};
+
+const formatStoreLabel = (storeId) => {
+  const raw = String(storeId ?? '').trim();
+  if (!raw) return 'Prix local';
+  return raw
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+};
+
+const formatObservedAt = (value) => {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat('fr-FR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  }).format(date);
+};
+
+const searchLocalFallback = async (query) => {
+  try {
+    const base = import.meta.env.BASE_URL || '/';
+    const response = await fetch(`${base}data/expanded-prices.json`, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!response.ok) return [];
+    const payload = await response.json();
+    const products = Array.isArray(payload?.products) ? payload.products : [];
+    const observations = Array.isArray(payload?.observations) ? payload.observations : [];
+    if (!products.length || !observations.length) return [];
+
+    const matchedProducts = products
+      .map((product) => ({ product, score: scoreProductMatch(product, query) }))
+      .filter((entry) => entry.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 6)
+      .map((entry) => entry.product);
+
+    if (!matchedProducts.length) return [];
+
+    const productMap = new Map(matchedProducts.map((product) => [product.id, product]));
+    const latestByProductStore = new Map();
+
+    for (const obs of observations) {
+      const productId = obs?.productId;
+      if (!productMap.has(productId)) continue;
+      const storeKey = `${productId}::${obs.storeId || 'store'}`;
+      const previous = latestByProductStore.get(storeKey);
+      if (!previous || String(obs.observedAt || '') > String(previous.observedAt || '')) {
+        latestByProductStore.set(storeKey, obs);
+      }
+    }
+
+    return Array.from(latestByProductStore.values())
+      .filter((obs) => Number(obs.price) > 0)
+      .map((obs, index) => {
+        const product = productMap.get(obs.productId);
+        return {
+          id: `local-${obs.productId}-${obs.storeId || index}`,
+          title: product?.name || query,
+          merchant: formatStoreLabel(obs.storeId),
+          price: Number(obs.price),
+          url: '',
+          observedAt: obs.observedAt || null,
+          source: 'local-fallback',
+        };
+      })
+      .sort((a, b) => a.price - b.price)
+      .slice(0, 20);
+  } catch {
+    return [];
+  }
+};
+
 export default function Comparateur() {
   const { user } = useAuth();
   const { plan, isPro } = usePlan();
@@ -22,8 +127,40 @@ export default function Comparateur() {
   const [results, setResults] = useState([]);
   const [sortBy, setSortBy] = useState('price_asc');
   const [paywall, setPaywall] = useState(null);
+  const territory = useMemo(() => {
+    if (typeof window === 'undefined') return 'gp';
+    const stored = window.localStorage.getItem('akiprisaye-territory')
+      || window.localStorage.getItem('territory')
+      || 'gp';
+    return normalizeTerritoryCode(stored);
+  }, []);
 
   const sorted = useMemo(() => sortResults(results, sortBy), [results, sortBy]);
+  const comparisonInsight = useMemo(() => {
+    if (sorted.length < 2) return null;
+    const cheapest = sorted[0];
+    const priciest = sorted[sorted.length - 1];
+    const savings = Number(priciest.price) - Number(cheapest.price);
+    if (savings <= 0) return null;
+    return {
+      cheapest,
+      priciest,
+      savings,
+    };
+  }, [sorted]);
+  const usesLocalFallback = useMemo(
+    () => sorted.some((item) => item.source === 'local-fallback'),
+    [sorted],
+  );
+  const staleLocalFallback = useMemo(() => {
+    const localDates = sorted
+      .filter((item) => item.source === 'local-fallback' && item.observedAt)
+      .map((item) => new Date(item.observedAt));
+    if (!localDates.length) return false;
+    const newest = localDates.reduce((max, current) => (current > max ? current : max), localDates[0]);
+    const daysOld = (Date.now() - newest.getTime()) / (1000 * 60 * 60 * 24);
+    return daysOld > 30;
+  }, [sorted]);
 
   const onSearch = async (event) => {
     event.preventDefault();
@@ -48,7 +185,6 @@ export default function Comparateur() {
     setLoading(true);
     try {
       // Fetch from all sources in parallel
-      const territory = 'gp';
       const isBarcode = /^\d{8,14}$/.test(trimmed);
 
       const [searchRes, obsRes, webRes] = await Promise.allSettled([
@@ -79,6 +215,7 @@ export default function Comparateur() {
         merchant: item.merchant ?? item.source ?? 'Web',
         price: Number(item.price ?? item.extracted_price ?? 0),
         url: item.url ?? item.link ?? '',
+        observedAt: item.observedAt ?? null,
         source: 'price-search',
       }));
 
@@ -88,6 +225,7 @@ export default function Comparateur() {
         merchant: obs.storeName ?? obs.storeId ?? 'Contribution citoyenne',
         price: Number(obs.price ?? 0),
         url: '',
+        observedAt: obs.observedAt ?? null,
         source: 'observation',
       }));
 
@@ -97,6 +235,7 @@ export default function Comparateur() {
         merchant: item.merchant ?? 'Web',
         price: Number(item.price ?? 0),
         url: item.url ?? '',
+        observedAt: item.observedAt ?? null,
         source: 'web',
       }));
 
@@ -113,14 +252,17 @@ export default function Comparateur() {
         })
         .map((item, index) => ({ ...item, id: item.id || `${trimmed}-${index}` }));
 
-      setResults(normalized);
-      cacheProductResults(normalized);
+      const fallback = normalized.length === 0 ? await searchLocalFallback(trimmed) : [];
+      const mergedResults = normalized.length > 0 ? normalized : fallback;
+
+      setResults(mergedResults);
+      cacheProductResults(mergedResults);
       const entry = {
         query: trimmed,
         territory,
-        resultCount: normalized.length,
-        topResult: normalized[0]
-          ? { id: normalized[0].id, name: normalized[0].title, price: normalized[0].price }
+        resultCount: mergedResults.length,
+        topResult: mergedResults[0]
+          ? { id: mergedResults[0].id, name: mergedResults[0].title, price: mergedResults[0].price }
           : undefined,
       };
       if (user) {
@@ -139,7 +281,7 @@ export default function Comparateur() {
     <div className="max-w-5xl mx-auto p-4 space-y-4">
       <h1 className="text-3xl font-bold">Comparateur Prix</h1>
       <p className="text-sm text-slate-600 dark:text-slate-300">
-        Territoire: <strong>FR</strong> · Plan: <strong>{plan}</strong> · Quota restant: <strong>{Math.max(status.remaining, 0)}</strong>
+        Territoire: <strong>{territory.toUpperCase()}</strong> · Plan: <strong>{plan}</strong> · Quota restant: <strong>{Math.max(status.remaining, 0)}</strong>
       </p>
 
       <form onSubmit={onSearch} className="flex gap-2">
@@ -170,6 +312,28 @@ export default function Comparateur() {
 
       {error && <p className="text-red-600">{error}</p>}
       {!loading && sorted.length === 0 && <p className="text-slate-500">Aucun résultat pour le moment.</p>}
+      {!loading && sorted.length === 0 && query.trim().length >= 2 && (
+        <p className="text-xs text-slate-400">
+          Astuce : essayez un terme plus générique (ex : “lait”, “riz”, “huile”) ou le code-barres.
+        </p>
+      )}
+      {comparisonInsight && (
+        <div className="rounded border border-emerald-300/50 bg-emerald-50/60 dark:bg-emerald-900/20 px-3 py-2 text-sm">
+          💡 Économie potentielle : <strong>{comparisonInsight.savings.toFixed(2)} €</strong> entre{' '}
+          <strong>{comparisonInsight.cheapest.merchant}</strong> et{' '}
+          <strong>{comparisonInsight.priciest.merchant}</strong>.
+        </div>
+      )}
+      {usesLocalFallback && (
+        <p className="text-xs text-amber-700 dark:text-amber-300">
+          Données de secours locales affichées. Vérifiez le prix en magasin avant achat.
+        </p>
+      )}
+      {staleLocalFallback && (
+        <p className="text-xs text-amber-700 dark:text-amber-300">
+          ⚠️ Les dernières observations locales datent de plus de 30 jours.
+        </p>
+      )}
 
       <ul className="space-y-2">
         {sorted.map((result) => (
@@ -178,11 +342,17 @@ export default function Comparateur() {
               <p className="font-semibold truncate">{result.title}</p>
               <div className="flex items-center gap-2 mt-0.5 flex-wrap">
                 <p className="text-sm text-slate-500">{result.merchant}</p>
+                {formatObservedAt(result.observedAt) && (
+                  <span className="text-xs text-slate-400">Vu le {formatObservedAt(result.observedAt)}</span>
+                )}
                 {result.source === 'observation' && (
                   <span className="text-xs px-1.5 py-0.5 bg-orange-100 text-orange-700 rounded">👥 Citoyen</span>
                 )}
                 {(result.source === 'web' || result.source === 'price-search') && (
                   <span className="text-xs px-1.5 py-0.5 bg-blue-100 text-blue-700 rounded">🌐 Web</span>
+                )}
+                {result.source === 'local-fallback' && (
+                  <span className="text-xs px-1.5 py-0.5 bg-emerald-100 text-emerald-700 rounded">💾 Local</span>
                 )}
               </div>
             </div>
@@ -200,6 +370,16 @@ export default function Comparateur() {
           </li>
         ))}
       </ul>
+
+      {!loading && sorted.length === 0 && (
+        <div className="rounded border border-blue-300/40 bg-blue-50/50 dark:bg-blue-900/10 px-3 py-2 text-sm">
+          Vous ne trouvez pas ce produit ?{' '}
+          <Link className="text-blue-700 dark:text-blue-300 underline" to="/signalement">
+            Signaler un prix en 30 secondes
+          </Link>
+          .
+        </div>
+      )}
 
       <div className="border rounded p-3">
         <p className="font-medium mb-2">Fonctions Pro</p>


### PR DESCRIPTION
### Motivation

- Improve search resilience when external APIs return no results by falling back to a local dataset. 
- Normalize queries, product fields and territory codes to improve matching accuracy across varied input formats. 
- Surface provenance (observations, web, local) and simple savings insights to help users compare prices quickly. 

### Description

- Added utility functions `normalize`, `scoreProductMatch`, `normalizeTerritoryCode`, `formatStoreLabel`, and `formatObservedAt` to normalize text, score candidate products, canonicalize territory codes, and pretty-print store/date values. 
- Implemented `searchLocalFallback` which loads `data/expanded-prices.json`, scores products against the query, extracts latest observations per store, and returns normalized fallback results when remote sources return none. 
- Read territory from `localStorage` via `territory` memo and pass it to backend APIs, and include `observedAt` in normalized result objects from all sources. 
- Merge and deduplicate results, use the local fallback when no remote results exist, persist `cacheProductResults`, and record history (`saveUserHistory`/`saveGuestHistory`) with the merged result metadata. 
- UI enhancements: display current territory, show observed dates and source badges, add comparison savings insight, show tips when no results, warn when local data is stale (>30 days), and add a quick link to the reporting page. 

### Testing

- No new automated tests were added for these changes and the existing test suite was not modified. 
- Verified the build and manual smoke flows for searching, local fallback activation, and UI rendering during local development.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b6d67e9c832195504c1a94d5db6b)