### PR TITLE
fix(csp): allow GitHub attachments and YouTube thumbnails in img-src

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,7 +30,7 @@
       Content-Security-Policy (meta tag — GitHub Pages ne peut pas injecter de headers HTTP).
       • script-src : bundles 'self' + Google Identity/OAuth + GTM (Firebase Analytics) + hash du script inline SPA-redirect.
       • style-src  : 'unsafe-inline' requis pour le bloc <style> anti-flash du chargement initial.
-      • img-src    : Unsplash (images produits/héros), Google profile photos, Firebase Storage, OpenFoodFacts.
+      • img-src    : Unsplash (images produits/héros), Google profile photos, Firebase Storage, OpenFoodFacts, GitHub user attachments.
       • connect-src: tous les endpoints Firebase (Firestore, Auth, Storage, Installations) + Google APIs + OpenFoodFacts.
       • frame-src  : popup OAuth Google + domaine Firebase Auth.
       • object-src / base-uri : verrouillés à 'none'/'self'.
@@ -38,7 +38,7 @@
     -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' https://apis.google.com https://accounts.google.com https://www.googletagmanager.com https://connect.facebook.net 'sha256-mZvVvMw8+6CB9PkTzAvR40I1vF+FzuYfiM6VR3ZXeaQ='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://images.unsplash.com https://lh3.googleusercontent.com https://www.gstatic.com https://www.google.com https://firebasestorage.googleapis.com https://images.openfoodfacts.org https://www.facebook.com; connect-src 'self' https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firebase.googleapis.com https://firebaseinstallations.googleapis.com https://fcmregistrations.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://www.googleapis.com https://www.google-analytics.com https://region1.google-analytics.com https://world.openfoodfacts.org https://prices.openfoodfacts.org https://connect.facebook.net https://www.facebook.com; frame-src https://accounts.google.com https://a-ki-pri-sa-ye.firebaseapp.com; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self' https://accounts.google.com;"
+      content="default-src 'self'; script-src 'self' https://apis.google.com https://accounts.google.com https://www.googletagmanager.com https://connect.facebook.net 'sha256-mZvVvMw8+6CB9PkTzAvR40I1vF+FzuYfiM6VR3ZXeaQ='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://images.unsplash.com https://lh3.googleusercontent.com https://www.gstatic.com https://www.google.com https://firebasestorage.googleapis.com https://images.openfoodfacts.org https://www.facebook.com https://github.com https://githubusercontent.com https://i.ytimg.com; connect-src 'self' https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firebase.googleapis.com https://firebaseinstallations.googleapis.com https://fcmregistrations.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://www.googleapis.com https://www.google-analytics.com https://region1.google-analytics.com https://world.openfoodfacts.org https://prices.openfoodfacts.org https://connect.facebook.net https://www.facebook.com; frame-src https://accounts.google.com https://a-ki-pri-sa-ye.firebaseapp.com; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self' https://accounts.google.com;"
     />
 
     <!-- App -->

--- a/frontend/public/_headers
+++ b/frontend/public/_headers
@@ -4,7 +4,7 @@
   X-DNS-Prefetch-Control: on
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(self), camera=(self), microphone=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' https://www.googletagmanager.com 'sha256-mZvVvMw8+6CB9PkTzAvR40I1vF+FzuYfiM6VR3ZXeaQ=' 'sha256-dK+7CW0a5b1B24QIbYFhVhMX1NH114EFwvzzRLy/f9Q='; connect-src 'self' https:; manifest-src 'self'; worker-src 'self' blob:; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https: https://github.com https://githubusercontent.com https://i.ytimg.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' https://www.googletagmanager.com 'sha256-mZvVvMw8+6CB9PkTzAvR40I1vF+FzuYfiM6VR3ZXeaQ=' 'sha256-dK+7CW0a5b1B24QIbYFhVhMX1NH114EFwvzzRLy/f9Q='; connect-src 'self' https:; manifest-src 'self'; worker-src 'self' blob:; upgrade-insecure-requests
   Cross-Origin-Opener-Policy: same-origin-allow-popups
   Cross-Origin-Resource-Policy: same-site
   Cache-Control: public, max-age=0, must-revalidate

--- a/public/_headers
+++ b/public/_headers
@@ -4,7 +4,7 @@
   X-DNS-Prefetch-Control: on
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self'; connect-src 'self' https:; manifest-src 'self'; worker-src 'self' blob:; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https: https://github.com https://githubusercontent.com https://i.ytimg.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self'; connect-src 'self' https:; manifest-src 'self'; worker-src 'self' blob:; upgrade-insecure-requests
   Cross-Origin-Opener-Policy: same-origin-allow-popups
   Cross-Origin-Resource-Policy: same-site
 


### PR DESCRIPTION
### Motivation
- Mobile debugging showed Content-Security-Policy (CSP) violations for images hosted on GitHub user attachments and YouTube thumbnails which caused blocked images and console errors.
- The site uses a meta CSP and static `_headers` for different deployment targets, so policies needed to be aligned to avoid platform-specific breakage.

### Description
- Added `https://github.com`, `https://githubusercontent.com`, and `https://i.ytimg.com` to the `img-src` directive in the HTML meta CSP at `frontend/index.html`.
- Updated the static header CSP entries in `frontend/public/_headers` to include the same hosts for `img-src`.
- Updated the root `public/_headers` to match the same `img-src` hosts for consistent behavior across hosting environments.

### Testing
- Ran `rg -n "Content-Security-Policy|img-src" frontend/index.html frontend/public/_headers public/_headers` to verify the new hosts are present in all modified files and the command completed successfully.
- Displayed file snippets with `nl -ba frontend/index.html` and `nl -ba frontend/public/_headers` to inspect the resulting CSP lines and confirmed the updated directives.
- All automated verification commands executed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2cc76c3388321a9eb75d19511454b)