### PR TITLE
comparateur: add filters, favorites, basket and UI improvements

### DIFF
--- a/frontend/src/pages/Comparateur.jsx
+++ b/frontend/src/pages/Comparateur.jsx
@@ -6,10 +6,18 @@ import { useQuota } from '../hooks/useQuota';
 import { usePlan } from '../hooks/usePlan';
 import { cacheProductResults, saveGuestHistory, saveUserHistory } from '../services/freemium';
 
-const sortResults = (items, sortBy) => {
-  if (sortBy === 'price_desc') return [...items].sort((a, b) => Number(b.price) - Number(a.price));
-  if (sortBy === 'merchant') return [...items].sort((a, b) => String(a.merchant).localeCompare(String(b.merchant)));
-  return [...items].sort((a, b) => Number(a.price) - Number(b.price));
+const sortResults = (items, sortBy, favoriteMerchants = new Set()) => {
+  const sorted = [...items].sort((a, b) => {
+    if (sortBy === 'price_desc') return Number(b.price) - Number(a.price);
+    if (sortBy === 'merchant') return String(a.merchant).localeCompare(String(b.merchant));
+    return Number(a.price) - Number(b.price);
+  });
+  return sorted.sort((a, b) => {
+    const aFav = favoriteMerchants.has(String(a.merchant || '').toLowerCase());
+    const bFav = favoriteMerchants.has(String(b.merchant || '').toLowerCase());
+    if (aFav === bFav) return 0;
+    return aFav ? -1 : 1;
+  });
 };
 
 const normalize = (value) =>
@@ -61,6 +69,18 @@ const formatObservedAt = (value) => {
     year: 'numeric',
   }).format(date);
 };
+const freshnessLabel = (value) => {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  const diffDays = Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60 * 24));
+  if (diffDays <= 0) return "mis à jour aujourd'hui";
+  if (diffDays === 1) return 'mis à jour hier';
+  if (diffDays < 7) return `mis à jour il y a ${diffDays} jours`;
+  return 'donnée ancienne';
+};
+
+const defaultSearchSuggestions = ['lait', 'riz', 'huile', 'pâtes', 'yaourt', '3274080005003'];
 
 const searchLocalFallback = async (query) => {
   try {
@@ -126,6 +146,37 @@ export default function Comparateur() {
   const [error, setError] = useState('');
   const [results, setResults] = useState([]);
   const [sortBy, setSortBy] = useState('price_asc');
+  const [maxPriceFilter, setMaxPriceFilter] = useState(false);
+  const [citizenOnlyFilter, setCitizenOnlyFilter] = useState(false);
+  const [recentOnlyFilter, setRecentOnlyFilter] = useState(false);
+  const [favoriteMerchants, setFavoriteMerchants] = useState(() => {
+    if (typeof window === 'undefined') return new Set();
+    try {
+      const stored = JSON.parse(window.localStorage.getItem('comparateur-favorite-merchants') || '[]');
+      return new Set(Array.isArray(stored) ? stored : []);
+    } catch {
+      return new Set();
+    }
+  });
+  const [searchSuggestions, setSearchSuggestions] = useState(() => {
+    if (typeof window === 'undefined') return defaultSearchSuggestions;
+    try {
+      const stored = JSON.parse(window.localStorage.getItem('comparateur-search-suggestions') || '[]');
+      const merged = [...new Set([...defaultSearchSuggestions, ...(Array.isArray(stored) ? stored : [])])];
+      return merged.slice(0, 20);
+    } catch {
+      return defaultSearchSuggestions;
+    }
+  });
+  const [basketItems, setBasketItems] = useState(() => {
+    if (typeof window === 'undefined') return [];
+    try {
+      const stored = JSON.parse(window.localStorage.getItem('comparateur-basket-items') || '[]');
+      return Array.isArray(stored) ? stored.slice(0, 20) : [];
+    } catch {
+      return [];
+    }
+  });
   const [paywall, setPaywall] = useState(null);
   const territory = useMemo(() => {
     if (typeof window === 'undefined') return 'gp';
@@ -135,7 +186,24 @@ export default function Comparateur() {
     return normalizeTerritoryCode(stored);
   }, []);
 
-  const sorted = useMemo(() => sortResults(results, sortBy), [results, sortBy]);
+  const filteredResults = useMemo(() => {
+    return results.filter((item) => {
+      if (maxPriceFilter && Number(item.price) >= 5) return false;
+      if (citizenOnlyFilter && !['observation', 'local-fallback'].includes(item.source)) return false;
+      if (recentOnlyFilter) {
+        if (!item.observedAt) return false;
+        const observedAt = new Date(item.observedAt);
+        if (Number.isNaN(observedAt.getTime())) return false;
+        const diffDays = (Date.now() - observedAt.getTime()) / (1000 * 60 * 60 * 24);
+        if (diffDays > 7) return false;
+      }
+      return true;
+    });
+  }, [results, maxPriceFilter, citizenOnlyFilter, recentOnlyFilter]);
+  const sorted = useMemo(
+    () => sortResults(filteredResults, sortBy, favoriteMerchants),
+    [filteredResults, sortBy, favoriteMerchants],
+  );
   const comparisonInsight = useMemo(() => {
     if (sorted.length < 2) return null;
     const cheapest = sorted[0];
@@ -161,6 +229,12 @@ export default function Comparateur() {
     const daysOld = (Date.now() - newest.getTime()) / (1000 * 60 * 60 * 24);
     return daysOld > 30;
   }, [sorted]);
+  const averagePrice = useMemo(() => {
+    if (!sorted.length) return null;
+    const total = sorted.reduce((sum, item) => sum + Number(item.price || 0), 0);
+    return total / sorted.length;
+  }, [sorted]);
+  const bestPrice = sorted[0] ?? null;
 
   const onSearch = async (event) => {
     event.preventDefault();
@@ -256,6 +330,11 @@ export default function Comparateur() {
       const mergedResults = normalized.length > 0 ? normalized : fallback;
 
       setResults(mergedResults);
+      if (typeof window !== 'undefined') {
+        const nextSuggestions = [...new Set([trimmed, ...searchSuggestions])].slice(0, 20);
+        setSearchSuggestions(nextSuggestions);
+        window.localStorage.setItem('comparateur-search-suggestions', JSON.stringify(nextSuggestions));
+      }
       cacheProductResults(mergedResults);
       const entry = {
         query: trimmed,
@@ -276,39 +355,148 @@ export default function Comparateur() {
       setLoading(false);
     }
   };
+  const toggleFavoriteMerchant = (merchant) => {
+    const key = String(merchant || '').toLowerCase();
+    if (!key) return;
+    setFavoriteMerchants((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem('comparateur-favorite-merchants', JSON.stringify(Array.from(next)));
+      }
+      return next;
+    });
+  };
+  const addToBasket = (result) => {
+    setBasketItems((prev) => {
+      const exists = prev.some((item) => item.id === result.id);
+      if (exists || prev.length >= 20) return prev;
+      const next = [...prev, {
+        id: result.id,
+        title: result.title,
+        merchant: result.merchant,
+        price: Number(result.price),
+      }];
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem('comparateur-basket-items', JSON.stringify(next));
+      }
+      return next;
+    });
+  };
+  const removeFromBasket = (id) => {
+    setBasketItems((prev) => {
+      const next = prev.filter((item) => item.id !== id);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem('comparateur-basket-items', JSON.stringify(next));
+      }
+      return next;
+    });
+  };
+  const basketTotalsByMerchant = useMemo(() => {
+    const totals = new Map();
+    for (const item of basketItems) {
+      const key = String(item.merchant || 'Inconnu');
+      totals.set(key, (totals.get(key) || 0) + Number(item.price || 0));
+    }
+    return Array.from(totals.entries())
+      .map(([merchant, total]) => ({ merchant, total }))
+      .sort((a, b) => a.total - b.total);
+  }, [basketItems]);
 
   return (
-    <div className="max-w-5xl mx-auto p-4 space-y-4">
-      <h1 className="text-3xl font-bold">Comparateur Prix</h1>
-      <p className="text-sm text-slate-600 dark:text-slate-300">
-        Territoire: <strong>{territory.toUpperCase()}</strong> · Plan: <strong>{plan}</strong> · Quota restant: <strong>{Math.max(status.remaining, 0)}</strong>
-      </p>
+    <div className="max-w-5xl mx-auto p-4 pr-20 sm:pr-4 pb-28 sm:pb-6 space-y-4">
+      <header className="rounded-2xl border border-slate-700/40 bg-slate-900/40 p-4 sm:p-5">
+        <h1 className="text-3xl font-bold">Comparateur Prix</h1>
+        <p className="mt-2 text-sm text-slate-300">
+          Comparez rapidement les prix par enseigne et repérez le meilleur tarif avant d’acheter.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2 text-xs">
+          <span className="px-2 py-1 rounded-full border border-slate-600 text-slate-200">
+            Territoire: <strong>{territory.toUpperCase()}</strong>
+          </span>
+          <span className="px-2 py-1 rounded-full border border-slate-600 text-slate-200">
+            Plan: <strong>{plan}</strong>
+          </span>
+          <span className="px-2 py-1 rounded-full border border-slate-600 text-slate-200">
+            Quota restant: <strong>{Math.max(status.remaining, 0)}</strong>
+          </span>
+        </div>
+      </header>
 
-      <form onSubmit={onSearch} className="flex gap-2">
-        <input
-          id="comp-query"
-          name="query"
-          className="flex-1 min-w-0 border rounded px-3 py-2"
-          value={query}
-          placeholder="Nom, marque ou code-barres"
-          onChange={(e) => setQuery(e.target.value)}
-          aria-label="Rechercher un produit par nom, marque ou code-barres"
-        />
-        <button type="submit" className="flex-shrink-0 px-4 py-2 rounded bg-blue-600 text-white whitespace-nowrap" disabled={loading}>
-          {loading ? 'Recherche…' : 'Rechercher'}
-        </button>
-      </form>
+      <section className="rounded-2xl border border-slate-700/40 bg-slate-900/30 p-3 sm:p-4 space-y-3">
+        <form onSubmit={onSearch} className="flex flex-col sm:flex-row gap-2">
+          <input
+            id="comp-query"
+            name="query"
+            className="flex-1 min-w-0 border border-slate-700 rounded-lg px-3 py-2.5 bg-slate-900/40"
+            value={query}
+            placeholder="Nom, marque ou code-barres"
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label="Rechercher un produit par nom, marque ou code-barres"
+            list="comparateur-query-suggestions"
+          />
+          <datalist id="comparateur-query-suggestions">
+            {searchSuggestions.map((suggestion) => (
+              <option key={suggestion} value={suggestion} />
+            ))}
+          </datalist>
+          <button
+            type="submit"
+            className="w-full sm:w-auto flex-shrink-0 px-4 py-2.5 rounded-lg bg-blue-600 text-white font-medium whitespace-nowrap disabled:opacity-60"
+            disabled={loading}
+          >
+            {loading ? 'Recherche…' : 'Rechercher'}
+          </button>
+        </form>
 
-      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2">
-        <label htmlFor="comp-sort" className="text-sm">Tri:&nbsp;
-          <select id="comp-sort" name="sort" className="ml-2 border rounded px-2 py-1" value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
-            <option value="price_asc">Prix croissant</option>
-            <option value="price_desc">Prix décroissant</option>
-            <option value="merchant">Source</option>
-          </select>
-        </label>
-        <Link className="text-blue-600 text-sm" to="/historique">Voir historique</Link>
-      </div>
+        <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2">
+          <label htmlFor="comp-sort" className="text-sm">Tri:&nbsp;
+            <select id="comp-sort" name="sort" className="ml-2 border border-slate-700 rounded px-2 py-1 bg-slate-900/40" value={sortBy} onChange={(e) => setSortBy(e.target.value)}>
+              <option value="price_asc">Prix croissant</option>
+              <option value="price_desc">Prix décroissant</option>
+              <option value="merchant">Source</option>
+            </select>
+          </label>
+          <div className="flex items-center gap-3">
+            <span className="text-xs text-slate-400">
+              {sorted.length} résultat{sorted.length > 1 ? 's' : ''}
+            </span>
+            <Link className="text-blue-400 text-sm hover:underline" to="/historique">Voir historique</Link>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2 pt-1">
+          <button type="button" onClick={() => setMaxPriceFilter((v) => !v)} className={`px-2.5 py-1 rounded-full text-xs border ${maxPriceFilter ? 'bg-blue-600 text-white border-blue-500' : 'border-slate-600 text-slate-300'}`}>
+            {maxPriceFilter ? '✓ ' : ''}Moins de 5€
+          </button>
+          <button type="button" onClick={() => setCitizenOnlyFilter((v) => !v)} className={`px-2.5 py-1 rounded-full text-xs border ${citizenOnlyFilter ? 'bg-blue-600 text-white border-blue-500' : 'border-slate-600 text-slate-300'}`}>
+            {citizenOnlyFilter ? '✓ ' : ''}Sources citoyennes uniquement
+          </button>
+          <button type="button" onClick={() => setRecentOnlyFilter((v) => !v)} className={`px-2.5 py-1 rounded-full text-xs border ${recentOnlyFilter ? 'bg-blue-600 text-white border-blue-500' : 'border-slate-600 text-slate-300'}`}>
+            {recentOnlyFilter ? '✓ ' : ''}Vu &lt; 7 jours
+          </button>
+        </div>
+      </section>
+
+      {sorted.length > 0 && (
+        <section className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+          <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 px-3 py-2">
+            <p className="text-xs text-emerald-200">Meilleur prix</p>
+            <p className="text-lg font-semibold text-white">{Number(bestPrice?.price || 0).toFixed(2)} €</p>
+            <p className="text-xs text-emerald-100 truncate">{bestPrice?.merchant || '—'}</p>
+          </div>
+          <div className="rounded-xl border border-slate-600/50 bg-slate-900/30 px-3 py-2">
+            <p className="text-xs text-slate-400">Prix moyen</p>
+            <p className="text-lg font-semibold text-white">{Number(averagePrice || 0).toFixed(2)} €</p>
+            <p className="text-xs text-slate-400">sur {sorted.length} offre{sorted.length > 1 ? 's' : ''}</p>
+          </div>
+          <div className="rounded-xl border border-blue-500/30 bg-blue-500/10 px-3 py-2">
+            <p className="text-xs text-blue-200">Économie max</p>
+            <p className="text-lg font-semibold text-white">{comparisonInsight ? `${comparisonInsight.savings.toFixed(2)} €` : '0.00 €'}</p>
+            <p className="text-xs text-blue-100">entre l’offre la plus chère et la moins chère</p>
+          </div>
+        </section>
+      )}
 
       {error && <p className="text-red-600">{error}</p>}
       {!loading && sorted.length === 0 && <p className="text-slate-500">Aucun résultat pour le moment.</p>}
@@ -337,13 +525,23 @@ export default function Comparateur() {
 
       <ul className="space-y-2">
         {sorted.map((result) => (
-          <li key={result.id} className="border rounded p-3 flex justify-between items-center gap-4">
+          <li key={result.id} className="border border-slate-700/60 bg-slate-900/20 rounded-xl p-3 flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 sm:gap-4">
             <div className="min-w-0">
               <p className="font-semibold truncate">{result.title}</p>
               <div className="flex items-center gap-2 mt-0.5 flex-wrap">
                 <p className="text-sm text-slate-500">{result.merchant}</p>
+                <button
+                  type="button"
+                  onClick={() => toggleFavoriteMerchant(result.merchant)}
+                  className="text-xs px-1.5 py-0.5 rounded border border-amber-300/50 text-amber-300"
+                >
+                  {favoriteMerchants.has(String(result.merchant || '').toLowerCase()) ? '★ Favori' : '☆ Favori'}
+                </button>
                 {formatObservedAt(result.observedAt) && (
                   <span className="text-xs text-slate-400">Vu le {formatObservedAt(result.observedAt)}</span>
+                )}
+                {freshnessLabel(result.observedAt) && (
+                  <span className="text-xs px-1.5 py-0.5 bg-slate-700/70 text-slate-200 rounded">{freshnessLabel(result.observedAt)}</span>
                 )}
                 {result.source === 'observation' && (
                   <span className="text-xs px-1.5 py-0.5 bg-orange-100 text-orange-700 rounded">👥 Citoyen</span>
@@ -356,14 +554,17 @@ export default function Comparateur() {
                 )}
               </div>
             </div>
-            <div className="text-right flex-shrink-0">
+            <div className="text-left sm:text-right w-full sm:w-auto flex-shrink-0">
               <p className="font-bold text-lg">{Number(result.price).toFixed(2)} €</p>
-              <div className="flex gap-2 justify-end mt-0.5">
+              <div className="flex gap-2 sm:justify-end mt-0.5">
                 {result.url && (
                   <a href={result.url} target="_blank" rel="noopener noreferrer" className="text-xs text-blue-600 hover:underline">
                     Voir →
                   </a>
                 )}
+                <button type="button" className="text-xs text-emerald-300 hover:underline" onClick={() => addToBasket(result)}>
+                  + Panier
+                </button>
                 <Link to={`/produit/${encodeURIComponent(result.id)}`} className="text-xs text-slate-400 hover:text-blue-600">Fiche</Link>
               </div>
             </div>
@@ -371,8 +572,39 @@ export default function Comparateur() {
         ))}
       </ul>
 
+      <section className="rounded-xl border border-violet-500/30 bg-violet-500/10 px-3 py-3">
+        <div className="flex items-center justify-between gap-2">
+          <p className="font-medium">Mode comparatif panier (1 à 20 produits)</p>
+          <span className="text-xs text-violet-100">{basketItems.length}/20</span>
+        </div>
+        {!basketItems.length && (
+          <p className="text-sm text-violet-100 mt-2">Ajoutez des produits via “+ Panier” pour comparer le total par enseigne.</p>
+        )}
+        {basketItems.length > 0 && (
+          <div className="mt-2 space-y-2">
+            <ul className="space-y-1">
+              {basketItems.map((item) => (
+                <li key={item.id} className="flex items-center justify-between text-sm gap-2">
+                  <span className="truncate">{item.title} · {item.merchant}</span>
+                  <button type="button" onClick={() => removeFromBasket(item.id)} className="text-xs text-red-300 hover:underline">Retirer</button>
+                </li>
+              ))}
+            </ul>
+            <div className="border-t border-violet-400/30 pt-2 space-y-1">
+              {basketTotalsByMerchant.map((row) => (
+                <p key={row.merchant} className="text-sm flex justify-between">
+                  <span>{row.merchant}</span>
+                  <strong>{row.total.toFixed(2)} €</strong>
+                </p>
+              ))}
+            </div>
+          </div>
+        )}
+      </section>
+
       {!loading && sorted.length === 0 && (
-        <div className="rounded border border-blue-300/40 bg-blue-50/50 dark:bg-blue-900/10 px-3 py-2 text-sm">
+        <div className="rounded-xl border border-blue-300/40 bg-blue-50/50 dark:bg-blue-900/10 px-3 py-3 text-sm">
+          <p className="font-medium mb-1">Aucun prix trouvé pour l’instant.</p>
           Vous ne trouvez pas ce produit ?{' '}
           <Link className="text-blue-700 dark:text-blue-300 underline" to="/signalement">
             Signaler un prix en 30 secondes


### PR DESCRIPTION
### Motivation
- Improve the product comparator UX by adding filtering options, merchant favorites, and a lightweight basket mode to compare totals per merchant.
- Surface data freshness and provide better search suggestions and local fallback handling for offline or empty results.
- Persist user preferences and temporary state (favorites, suggestions, basket) in `localStorage` so the interface is more convenient across sessions.

### Description
- Extended sorting logic by updating `sortResults` to accept `favoriteMerchants` and promote favorite merchants to the top while preserving the chosen sort order.
- Added `freshnessLabel`, `defaultSearchSuggestions` and persisted `searchSuggestions`, `comparateur-favorite-merchants`, and `comparateur-basket-items` to `localStorage` with initialization hooks in `Comparateur.jsx`.
- Implemented UI and state for three new filters (`maxPriceFilter`, `citizenOnlyFilter`, `recentOnlyFilter`), client-side `filteredResults` memoization, and new metrics `averagePrice` and `bestPrice` derived from results.
- Added merchant favorite toggle (`toggleFavoriteMerchant`), basket actions (`addToBasket`, `removeFromBasket`) and aggregated totals per merchant (`basketTotalsByMerchant`), and updated the UI to show badges, datalist search suggestions, header/summary cards, and a basket comparison panel.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d251edf88321bd7f1ded35a11071)