### PR TITLE
Use CSS tokens for global colors, centralize a11y, add design governance doc

### DIFF
--- a/docs/DESIGN_GOVERNANCE.md
+++ b/docs/DESIGN_GOVERNANCE.md
@@ -1,0 +1,42 @@
+# Design Governance — A KI PRI SA YÉ
+
+Ce document définit les règles minimales pour garantir une interface cohérente, accessible et maintenable.
+
+## 1) Source de vérité visuelle
+
+- Les couleurs, rayons, espacements et timings d’animation doivent venir des tokens globaux (`frontend/src/styles/globals.css`).
+- Les valeurs hardcodées dans les composants/pages sont à éviter, sauf exception justifiée en commentaire.
+
+## 2) Thèmes
+
+- Le thème est piloté par tokens CSS (`:root`, `[data-theme="dark"]`, `prefers-color-scheme`).
+- Les layouts de base ne doivent pas imposer un fond/texte non tokenisé.
+
+## 3) Accessibilité (RGAA / WCAG)
+
+- Un seul fichier maître pour les règles transverses a11y : `frontend/src/styles/a11y.css`.
+- Toute règle locale qui duplique `skip-link`, `focus-visible`, ou `touch target` est interdite.
+- Touch target minimum : 44x44.
+- Navigation clavier obligatoire pour menus, modales, dropdowns.
+
+## 4) Qualité UX
+
+- Prioriser l’action principale au-dessus de la ligne de flottaison (1 promesse, 1 CTA principal, 1 preuve).
+- Éviter les doublons de navigation et intitulés ambigus.
+- Les liens footer doivent être uniques et orientés par intention.
+
+## 5) Performance & SEO
+
+- Respecter les budgets Lighthouse (`lighthouserc.json`).
+- Tout écran majeur doit définir ses métadonnées via `SEOHead` (titre, description, canonical, JSON-LD si nécessaire).
+- Les blocs non critiques doivent rester lazy-loadés.
+
+## 6) Checklist PR (UI)
+
+Avant merge:
+
+1. Pas de couleur hardcodée non justifiée.
+2. Pas de duplication de règles a11y globales.
+3. Focus clavier vérifié sur les éléments interactifs.
+4. Aucune régression des chemins de navigation principaux.
+5. Lighthouse accessibilité maintenu >= 0.90.

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -70,7 +70,7 @@ export default function Layout() {
   }, []);
 
   return (
-    <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
+    <div className="flex min-h-screen flex-col bg-[rgb(var(--bg-main))] text-[rgb(var(--text-main))]">
       <SkipLinks />
       <Header />
       <AlertEvaluatorSideEffect />

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -118,7 +118,7 @@ export default function Footer() {
               <li><Link to="/licence-institution" className="text-slate-400 hover:text-white transition-colors">Licence institution</Link></li>
               <li><Link to="/pricing#partners" className="text-slate-400 hover:text-white transition-colors">Partenariats</Link></li>
               <li><Link to="/contact#pro" className="text-slate-400 hover:text-white transition-colors">Parler à l’équipe</Link></li>
-              <li><Link to="/contact" className="text-slate-400 hover:text-white transition-colors">Parler à l’équipe</Link></li>
+              <li><Link to="/gouvernance" className="text-slate-400 hover:text-white transition-colors">Gouvernance</Link></li>
             </ul>
           </div>
 

--- a/frontend/src/styles/home-v5.css
+++ b/frontend/src/styles/home-v5.css
@@ -12,24 +12,7 @@
 /* ============================================
    ACCESSIBILITY
    ============================================ */
-
-.skip-link {
-  position: absolute;
-  top: -40px;
-  left: 0;
-  background: #1d4ed8;
-  color: white;
-  padding: 8px 16px;
-  text-decoration: none;
-  border-radius: 0 0 4px 0;
-  z-index: 100;
-}
-
-.skip-link:focus {
-  top: 0;
-  outline: 3px solid #60a5fa;
-  outline-offset: 2px;
-}
+/* Skip-link styles are centralized in styles/a11y.css to avoid cascade conflicts. */
 
 /* Enhanced focus indicators */
 .home-v5 a:focus,


### PR DESCRIPTION
### Motivation
- Move visual values to global tokens and avoid hardcoded colors in components for consistent theming.
- Centralize accessibility rules to prevent duplicated/ conflicting styles across components.
- Provide a short design governance reference for UX, accessibility, performance and PR checklist.
- Fix a duplicate/incorrect footer link to point to the new governance page.

### Description
- Add `docs/DESIGN_GOVERNANCE.md` containing rules for tokens, themes, accessibility, UX, performance and a UI PR checklist (French). 
- Update `frontend/src/components/Layout.jsx` to replace hardcoded Tailwind color classes with token-based classes (`bg-[rgb(var(--bg-main))]` and `text-[rgb(var(--text-main))]`).
- Update `frontend/src/components/layout/Footer.tsx` to replace a duplicate contact link with a link to `/gouvernance`.
- Remove local `.skip-link` definitions from `frontend/src/styles/home-v5.css` and add a note that skip-link styles are centralized in `styles/a11y.css`, while keeping enhanced focus indicator rules.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2dd2d1a00832195d62dbb9152b80b)