### PR TITLE
Improve readability and harmonize admin Product & CSV import UIs

### DIFF
--- a/frontend/src/pages/admin/import/CsvUploader.tsx
+++ b/frontend/src/pages/admin/import/CsvUploader.tsx
@@ -148,10 +148,10 @@ export function CsvUploader({
         onDrop={handleDrop}
         className={cn(
           'relative border-2 border-dashed rounded-xl p-8 transition-all cursor-pointer',
-          'bg-white/5 backdrop-blur-sm',
+          'bg-white/70 backdrop-blur-sm',
           isDragging
             ? 'border-blue-400 bg-blue-500/10'
-            : 'border-white/20 hover:border-white/40 hover:bg-white/10',
+            : 'border-slate-300 hover:border-slate-400 hover:bg-white',
           isLoading && 'opacity-50 cursor-not-allowed'
         )}
       >
@@ -167,24 +167,24 @@ export function CsvUploader({
         <div className="flex flex-col items-center justify-center space-y-4">
           <div className={cn(
             'p-4 rounded-full transition-colors',
-            isDragging ? 'bg-blue-500/20' : 'bg-white/10'
+            isDragging ? 'bg-blue-500/20' : 'bg-slate-100'
           )}>
             <Upload className={cn(
               'w-12 h-12 transition-colors',
-              isDragging ? 'text-blue-400' : 'text-white/60'
+              isDragging ? 'text-blue-500' : 'text-slate-500'
             )} />
           </div>
 
           <div className="text-center">
-            <p className="text-lg font-medium text-white/90 mb-1">
+            <p className="mb-1 text-lg font-medium text-slate-900">
               {isDragging ? 'Déposez le fichier ici' : 'Glissez-déposez votre fichier'}
             </p>
-            <p className="text-sm text-white/60">
+            <p className="text-sm text-slate-600">
               ou cliquez pour parcourir
             </p>
           </div>
 
-          <div className="text-xs text-white/50 text-center">
+          <div className="text-center text-xs text-slate-500">
             <p>Formats acceptés: {acceptedTypes.join(', ')}</p>
             <p>Taille maximale: {maxSize}MB</p>
           </div>
@@ -202,24 +202,24 @@ export function CsvUploader({
 
       {/* Selected File Info */}
       {selectedFile && !isLoading && (
-        <div className="flex items-center justify-between p-4 bg-white/5 backdrop-blur-sm border border-white/20 rounded-lg">
+        <div className="flex items-center justify-between rounded-lg border border-slate-300 bg-white p-4 backdrop-blur-sm">
           <div className="flex items-center space-x-3">
             <div className="p-2 bg-green-500/20 rounded-lg">
               <FileSpreadsheet className="w-5 h-5 text-green-400" />
             </div>
             <div>
-              <p className="text-sm font-medium text-white/90">{selectedFile.name}</p>
-              <p className="text-xs text-white/60">
+              <p className="text-sm font-medium text-slate-900">{selectedFile.name}</p>
+              <p className="text-xs text-slate-600">
                 {(selectedFile.size / 1024).toFixed(1)} KB
               </p>
             </div>
           </div>
           <button
             onClick={handleRemoveFile}
-            className="p-2 hover:bg-white/10 rounded-lg transition-colors"
+            className="rounded-lg p-2 transition-colors hover:bg-slate-100"
             aria-label="Supprimer le fichier"
           >
-            <X className="w-5 h-5 text-white/60 hover:text-white/90" />
+            <X className="h-5 w-5 text-slate-500 hover:text-slate-900" />
           </button>
         </div>
       )}

--- a/frontend/src/pages/admin/import/ImportPage.tsx
+++ b/frontend/src/pages/admin/import/ImportPage.tsx
@@ -264,10 +264,10 @@ export function ImportPage() {
     <div className="container mx-auto px-4 py-8 max-w-6xl">
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-white/90 mb-2">
+        <h1 className="mb-2 text-3xl font-bold text-slate-900">
           Import CSV
         </h1>
-        <p className="text-white/60">
+        <p className="text-slate-600">
           Importez vos données d'enseignes, produits ou prix depuis des fichiers CSV
         </p>
       </div>
@@ -285,8 +285,8 @@ export function ImportPage() {
               className={cn(
                 'flex items-center space-x-2 px-6 py-3 rounded-lg font-medium transition-all whitespace-nowrap',
                 isActive
-                  ? 'bg-white/20 text-white border-2 border-white/40'
-                  : 'bg-white/5 text-white/70 border border-white/20 hover:bg-white/10 hover:text-white/90'
+                  ? 'border-2 border-blue-500/60 bg-blue-100 text-blue-800'
+                  : 'border border-slate-300 bg-white text-slate-700 hover:bg-slate-100 hover:text-slate-900'
               )}
             >
               <Icon className="w-5 h-5" />
@@ -304,12 +304,12 @@ export function ImportPage() {
             <div className="flex items-start space-x-3 mb-4">
               <Info className="w-5 h-5 text-blue-400 flex-shrink-0 mt-1" />
               <div className="flex-1">
-                <h3 className="text-lg font-semibold text-white/90 mb-2">
+                <h3 className="mb-2 text-lg font-semibold text-slate-900">
                   Instructions d'import
                 </h3>
-                <ul className="space-y-1 text-sm text-white/70">
+                <ul className="space-y-1 text-sm text-slate-700">
                   {currentTab.instructions.map((instruction, index) => (
-                    <li key={instruction} className={index === 0 ? 'font-medium text-white/80' : ''}>
+                    <li key={instruction} className={index === 0 ? 'font-medium text-slate-800' : ''}>
                       {instruction}
                     </li>
                   ))}
@@ -318,10 +318,10 @@ export function ImportPage() {
             </div>
 
             {/* Download Template Button */}
-            <div className="mt-4 pt-4 border-t border-white/20">
+            <div className="mt-4 border-t border-slate-200 pt-4">
               <button
                 onClick={handleDownloadTemplate}
-                className="flex items-center space-x-2 px-4 py-2 bg-white/10 hover:bg-white/20 border border-white/30 text-white rounded-lg transition-colors"
+                className="flex items-center space-x-2 rounded-lg border border-slate-300 bg-white px-4 py-2 text-slate-700 transition-colors hover:bg-slate-100"
               >
                 <Download className="w-4 h-4" />
                 <span>Télécharger le modèle CSV</span>
@@ -333,7 +333,7 @@ export function ImportPage() {
         {/* Upload */}
         {step === 'upload' && (
           <GlassCard>
-            <h3 className="text-lg font-semibold text-white/90 mb-4">
+            <h3 className="mb-4 text-lg font-semibold text-slate-900">
               Sélectionner un fichier
             </h3>
             <CsvUploader
@@ -349,7 +349,7 @@ export function ImportPage() {
         {step === 'preview' && (
           <>
             <GlassCard>
-              <h3 className="text-lg font-semibold text-white/90 mb-4">
+              <h3 className="mb-4 text-lg font-semibold text-slate-900">
                 Aperçu des données
               </h3>
               <ImportPreview
@@ -366,7 +366,7 @@ export function ImportPage() {
             <div className="flex items-center justify-between">
               <button
                 onClick={handleReset}
-                className="px-6 py-3 bg-white/5 hover:bg-white/10 border border-white/20 text-white rounded-lg transition-colors"
+                className="rounded-lg border border-slate-300 bg-white px-6 py-3 text-slate-700 transition-colors hover:bg-slate-100"
               >
                 Annuler
               </button>
@@ -377,7 +377,7 @@ export function ImportPage() {
                   'flex items-center space-x-2 px-6 py-3 rounded-lg font-medium transition-all',
                   canImport
                     ? 'bg-blue-600 hover:bg-blue-700 text-white'
-                    : 'bg-white/10 text-white/40 cursor-not-allowed'
+                    : 'cursor-not-allowed bg-slate-200 text-slate-400'
                 )}
               >
                 <Upload className="w-5 h-5" />
@@ -397,18 +397,18 @@ export function ImportPage() {
               <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-blue-500/20 mb-4">
                 <div className="w-8 h-8 border-4 border-blue-400/30 border-t-blue-400 rounded-full animate-spin" />
               </div>
-              <h3 className="text-xl font-semibold text-white/90 mb-2">
+              <h3 className="mb-2 text-xl font-semibold text-slate-900">
                 Import en cours...
               </h3>
-              <p className="text-white/60 mb-4">
+              <p className="mb-4 text-slate-600">
                 Veuillez patienter pendant l'import des données
               </p>
               <div className="max-w-md mx-auto">
-                <div className="flex items-center justify-between text-sm text-white/70 mb-2">
+                <div className="mb-2 flex items-center justify-between text-sm text-slate-700">
                   <span>Progression</span>
                   <span>{importProgress}%</span>
                 </div>
-                <div className="h-2 bg-white/10 rounded-full overflow-hidden">
+                <div className="h-2 overflow-hidden rounded-full bg-slate-200">
                   <div
                     className="h-full bg-blue-500 transition-all duration-300 rounded-full"
                     style={{ width: `${importProgress}%` }}

--- a/frontend/src/pages/admin/import/ImportPreview.tsx
+++ b/frontend/src/pages/admin/import/ImportPreview.tsx
@@ -97,7 +97,7 @@ export function ImportPreview({
 
   if (data.length === 0) {
     return (
-      <div className="text-center py-8 text-white/60">
+      <div className="py-8 text-center text-slate-600">
         Aucune donnée à afficher
       </div>
     );
@@ -107,23 +107,23 @@ export function ImportPreview({
     <div className="space-y-4">
       {/* Statistics */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="p-4 bg-white/5 backdrop-blur-sm border border-white/20 rounded-lg">
-          <div className="text-2xl font-bold text-white/90">{data.length}</div>
-          <div className="text-sm text-white/60">Total de lignes</div>
+        <div className="rounded-lg border border-slate-300 bg-white p-4 backdrop-blur-sm">
+          <div className="text-2xl font-bold text-slate-900">{data.length}</div>
+          <div className="text-sm text-slate-600">Total de lignes</div>
         </div>
         <div className="p-4 bg-green-500/10 backdrop-blur-sm border border-green-500/30 rounded-lg">
           <div className="flex items-center space-x-2">
             <CheckCircle className="w-5 h-5 text-green-400" />
             <div className="text-2xl font-bold text-green-400">{validRows}</div>
           </div>
-          <div className="text-sm text-white/60">Lignes valides</div>
+          <div className="text-sm text-slate-600">Lignes valides</div>
         </div>
         <div className="p-4 bg-red-500/10 backdrop-blur-sm border border-red-500/30 rounded-lg">
           <div className="flex items-center space-x-2">
             <AlertTriangle className="w-5 h-5 text-red-400" />
             <div className="text-2xl font-bold text-red-400">{errorRows}</div>
           </div>
-          <div className="text-sm text-white/60">Lignes avec erreurs</div>
+          <div className="text-sm text-slate-600">Lignes avec erreurs</div>
         </div>
       </div>
 
@@ -136,7 +136,7 @@ export function ImportPreview({
               <p className="text-sm font-medium text-yellow-400 mb-1">
                 Attention: {errorRows} ligne{errorRows > 1 ? 's' : ''} contient{errorRows > 1 ? '' : ''} des erreurs
               </p>
-              <p className="text-xs text-white/70">
+              <p className="text-xs text-slate-700">
                 Les lignes avec erreurs seront ignorées lors de l'import. Survolez les champs en rouge pour voir les détails des erreurs.
               </p>
             </div>
@@ -145,18 +145,18 @@ export function ImportPreview({
       )}
 
       {/* Preview Table */}
-      <div className="overflow-x-auto rounded-lg border border-white/20">
+      <div className="overflow-x-auto rounded-lg border border-slate-300">
         <table className="w-full text-sm">
           <thead>
             {table.getHeaderGroups().map((headerGroup) => (
-              <tr key={headerGroup.id} className="border-b border-white/20 bg-white/5">
-                <th className="px-4 py-3 text-left text-xs font-medium text-white/70 uppercase tracking-wider">
+              <tr key={headerGroup.id} className="border-b border-slate-200 bg-slate-50">
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-slate-700">
                   #
                 </th>
                 {headerGroup.headers.map((header) => (
                   <th
                     key={header.id}
-                    className="px-4 py-3 text-left text-xs font-medium text-white/70 uppercase tracking-wider"
+                    className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-slate-700"
                   >
                     {flexRender(
                       header.column.columnDef.header,
@@ -167,7 +167,7 @@ export function ImportPreview({
               </tr>
             ))}
           </thead>
-          <tbody className="divide-y divide-white/10">
+          <tbody className="divide-y divide-slate-100">
             {table.getRowModel().rows.map((row) => {
               const rowNumber = row.index + 2;
               const hasError = errorsByRow.has(rowNumber);
@@ -179,16 +179,16 @@ export function ImportPreview({
                     'transition-colors',
                     hasError
                       ? 'bg-red-500/5 hover:bg-red-500/10'
-                      : 'hover:bg-white/5'
+                      : 'hover:bg-slate-50'
                   )}
                 >
-                  <td className="px-4 py-3 text-white/60 font-mono text-xs">
+                  <td className="px-4 py-3 font-mono text-xs text-slate-500">
                     {rowNumber}
                   </td>
                   {row.getVisibleCells().map((cell) => (
                     <td
                       key={cell.id}
-                      className="px-4 py-3 text-white/80"
+                      className="px-4 py-3 text-slate-800"
                     >
                       {flexRender(
                         cell.column.columnDef.cell,
@@ -204,7 +204,7 @@ export function ImportPreview({
       </div>
 
       {data.length > maxRows && (
-        <div className="text-center py-2 text-sm text-white/60">
+        <div className="py-2 text-center text-sm text-slate-600">
           Affichage de {maxRows} lignes sur {data.length}
         </div>
       )}
@@ -212,7 +212,7 @@ export function ImportPreview({
       {/* Detailed Error List */}
       {errors.length > 0 && (
         <details className="mt-4">
-          <summary className="cursor-pointer text-sm font-medium text-white/70 hover:text-white/90 mb-2">
+          <summary className="mb-2 cursor-pointer text-sm font-medium text-slate-700 hover:text-slate-900">
             Voir la liste détaillée des erreurs ({errors.length})
           </summary>
           <div className="mt-2 space-y-2 max-h-64 overflow-y-auto">
@@ -226,14 +226,14 @@ export function ImportPreview({
                     Ligne {error.row}
                   </span>
                   {error.field && (
-                    <span className="text-white/50 text-xs">
+                    <span className="text-xs text-slate-500">
                       · Champ: {error.field}
                     </span>
                   )}
                 </div>
-                <p className="text-white/80 mt-1">{error.message}</p>
+                <p className="mt-1 text-slate-800">{error.message}</p>
                 {error.value && (
-                  <p className="text-white/50 text-xs mt-1">
+                  <p className="mt-1 text-xs text-slate-500">
                     Valeur: "{error.value}"
                   </p>
                 )}

--- a/frontend/src/pages/admin/import/ImportReport.tsx
+++ b/frontend/src/pages/admin/import/ImportReport.tsx
@@ -51,10 +51,10 @@ export function ImportReport({ result, onReset, entityType }: ImportReportProps)
             <AlertTriangle className="w-8 h-8 text-yellow-400" />
           )}
         </div>
-        <h3 className="text-2xl font-bold text-white/90 mb-2">
+        <h3 className="mb-2 text-2xl font-bold text-slate-900">
           {result.success ? 'Import réussi !' : 'Import terminé avec des erreurs'}
         </h3>
-        <p className="text-white/60">
+        <p className="text-slate-600">
           {result.success
             ? `Tous les ${entityType} ont été importés avec succès`
             : `Certains ${entityType} n'ont pas pu être importés`}
@@ -63,9 +63,9 @@ export function ImportReport({ result, onReset, entityType }: ImportReportProps)
 
       {/* Statistics Cards */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="p-4 bg-white/5 backdrop-blur-sm border border-white/20 rounded-lg text-center">
-          <div className="text-3xl font-bold text-white/90 mb-1">{result.total}</div>
-          <div className="text-sm text-white/60">Total de lignes</div>
+        <div className="rounded-lg border border-slate-300 bg-white p-4 text-center backdrop-blur-sm">
+          <div className="mb-1 text-3xl font-bold text-slate-900">{result.total}</div>
+          <div className="text-sm text-slate-600">Total de lignes</div>
         </div>
         
         <div className="p-4 bg-green-500/10 backdrop-blur-sm border border-green-500/30 rounded-lg text-center">
@@ -73,7 +73,7 @@ export function ImportReport({ result, onReset, entityType }: ImportReportProps)
             <CheckCircle className="w-5 h-5 text-green-400" />
             <div className="text-3xl font-bold text-green-400">{result.successful}</div>
           </div>
-          <div className="text-sm text-white/60">Importés</div>
+          <div className="text-sm text-slate-600">Importés</div>
         </div>
         
         <div className="p-4 bg-red-500/10 backdrop-blur-sm border border-red-500/30 rounded-lg text-center">
@@ -81,14 +81,14 @@ export function ImportReport({ result, onReset, entityType }: ImportReportProps)
             <XCircle className="w-5 h-5 text-red-400" />
             <div className="text-3xl font-bold text-red-400">{result.failed}</div>
           </div>
-          <div className="text-sm text-white/60">Échecs</div>
+          <div className="text-sm text-slate-600">Échecs</div>
         </div>
       </div>
 
       {/* Success Rate Bar */}
       <div className="space-y-2">
         <div className="flex items-center justify-between text-sm">
-          <span className="text-white/70">Taux de réussite</span>
+          <span className="text-slate-700">Taux de réussite</span>
           <span className={cn(
             'font-semibold',
             successRate === 100 ? 'text-green-400' :
@@ -98,7 +98,7 @@ export function ImportReport({ result, onReset, entityType }: ImportReportProps)
             {successRate.toFixed(1)}%
           </span>
         </div>
-        <div className="h-2 bg-white/10 rounded-full overflow-hidden">
+        <div className="h-2 overflow-hidden rounded-full bg-slate-200">
           <div
             className={cn(
               'h-full transition-all duration-500 rounded-full',
@@ -115,13 +115,13 @@ export function ImportReport({ result, onReset, entityType }: ImportReportProps)
       {result.errors.length > 0 && (
         <div className="space-y-3">
           <div className="flex items-center justify-between">
-            <h4 className="text-sm font-semibold text-white/90 flex items-center space-x-2">
+            <h4 className="flex items-center space-x-2 text-sm font-semibold text-slate-900">
               <XCircle className="w-4 h-4 text-red-400" />
               <span>Erreurs détectées ({result.errors.length})</span>
             </h4>
             <button
               onClick={downloadErrorReport}
-              className="flex items-center space-x-2 px-3 py-1.5 text-xs font-medium text-white/80 hover:text-white bg-white/5 hover:bg-white/10 border border-white/20 rounded-lg transition-colors"
+              className="flex items-center space-x-2 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition-colors hover:bg-slate-100 hover:text-slate-900"
             >
               <Download className="w-3.5 h-3.5" />
               <span>Télécharger le rapport</span>
@@ -140,13 +140,13 @@ export function ImportReport({ result, onReset, entityType }: ImportReportProps)
                   </div>
                   <div className="flex-1 min-w-0">
                     {error.field && (
-                      <div className="text-xs text-white/50 mb-1">
-                        Champ: <span className="font-medium text-white/70">{error.field}</span>
+                      <div className="mb-1 text-xs text-slate-500">
+                        Champ: <span className="font-medium text-slate-700">{error.field}</span>
                       </div>
                     )}
-                    <p className="text-sm text-white/80">{error.message}</p>
+                    <p className="text-sm text-slate-800">{error.message}</p>
                     {error.value && (
-                      <p className="text-xs text-white/50 mt-1 truncate">
+                      <p className="mt-1 truncate text-xs text-slate-500">
                         Valeur: "{error.value}"
                       </p>
                     )}
@@ -155,7 +155,7 @@ export function ImportReport({ result, onReset, entityType }: ImportReportProps)
               </div>
             ))}
             {result.errors.length > 20 && (
-              <div className="text-center text-sm text-white/60 py-2">
+              <div className="py-2 text-center text-sm text-slate-600">
                 ... et {result.errors.length - 20} autres erreurs
               </div>
             )}
@@ -172,7 +172,7 @@ export function ImportReport({ result, onReset, entityType }: ImportReportProps)
               <p className="text-sm font-medium text-green-400 mb-1">
                 Import terminé avec succès
               </p>
-              <p className="text-xs text-white/70">
+              <p className="text-xs text-slate-700">
                 {result.successful} {entityType} ont été importés dans la base de données.
               </p>
             </div>
@@ -184,7 +184,7 @@ export function ImportReport({ result, onReset, entityType }: ImportReportProps)
       <div className="flex items-center justify-center pt-4">
         <button
           onClick={onReset}
-          className="flex items-center space-x-2 px-6 py-3 bg-white/10 hover:bg-white/20 border border-white/30 text-white font-medium rounded-lg transition-colors"
+          className="flex items-center space-x-2 rounded-lg border border-slate-300 bg-white px-6 py-3 font-medium text-slate-800 transition-colors hover:bg-slate-100"
         >
           <RefreshCw className="w-5 h-5" />
           <span>Importer un autre fichier</span>

--- a/frontend/src/pages/admin/products/ProductForm.tsx
+++ b/frontend/src/pages/admin/products/ProductForm.tsx
@@ -214,7 +214,7 @@ export function ProductForm() {
         <GlassCard>
           <div className="text-center py-12">
             <div className="inline-block w-8 h-8 border-4 border-white/20 border-t-blue-500 rounded-full animate-spin" />
-            <p className="mt-4 text-white/60">Chargement...</p>
+            <p className="mt-4 text-slate-600">Chargement...</p>
           </div>
         </GlassCard>
       </div>
@@ -224,7 +224,7 @@ export function ProductForm() {
   return (
     <div className="container mx-auto px-4 py-8 max-w-3xl">
       <div className="mb-6">
-        <h1 className="text-3xl font-bold text-white/90 flex items-center gap-3">
+        <h1 className="text-3xl font-bold text-slate-900 flex items-center gap-3">
           <Package className="w-8 h-8" />
           {isEditMode ? 'Modifier le produit' : 'Nouveau produit'}
         </h1>
@@ -234,7 +234,7 @@ export function ProductForm() {
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
           {/* Name */}
           <div>
-            <label htmlFor="pf-nom-produit" className="block text-sm font-medium text-white/70 mb-2">
+            <label htmlFor="pf-nom-produit" className="mb-2 block text-sm font-medium text-slate-700">
               Nom du produit <span className="text-red-400">*</span>
             </label>
             <input
@@ -242,7 +242,7 @@ export function ProductForm() {
               id="pf-nom-produit"
               type="text"
               {...register('name')}
-              className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-lg text-white/90 placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full rounded-lg border border-slate-300 bg-white px-4 py-3 text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
               placeholder="Ex: Lait demi-écrémé"
             />
             {errors.name && (
@@ -252,7 +252,7 @@ export function ProductForm() {
 
           {/* Brand */}
           <div>
-            <label htmlFor="pf-marque" className="block text-sm font-medium text-white/70 mb-2">
+            <label htmlFor="pf-marque" className="mb-2 block text-sm font-medium text-slate-700">
               Marque
             </label>
             <input
@@ -260,21 +260,21 @@ export function ProductForm() {
               id="pf-marque"
               type="text"
               {...register('brand')}
-              className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-lg text-white/90 placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full rounded-lg border border-slate-300 bg-white px-4 py-3 text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
               placeholder="Ex: Lactel"
             />
           </div>
 
           {/* Category */}
           <div>
-            <label htmlFor="pf-categorie" className="block text-sm font-medium text-white/70 mb-2">
+            <label htmlFor="pf-categorie" className="mb-2 block text-sm font-medium text-slate-700">
               Catégorie <span className="text-red-400">*</span>
             </label>
             <select
               
               id="pf-categorie"
               {...register('category')}
-              className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-lg text-white/90 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full rounded-lg border border-slate-300 bg-white px-4 py-3 text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
             >
               {PRODUCT_CATEGORIES.map((cat) => (
                 <option key={cat} value={cat}>
@@ -289,7 +289,7 @@ export function ProductForm() {
 
           {/* EAN with OpenFoodFacts search */}
           <div>
-            <label htmlFor="pf-ean" className="block text-sm font-medium text-white/70 mb-2">
+            <label htmlFor="pf-ean" className="mb-2 block text-sm font-medium text-slate-700">
               Code EAN (8 ou 13 chiffres)
             </label>
             <div className="flex gap-2">
@@ -298,7 +298,7 @@ export function ProductForm() {
                  
                 type="text"
                 {...register('ean')}
-                className="flex-1 px-4 py-3 bg-white/5 border border-white/10 rounded-lg text-white/90 placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono"
+                className="flex-1 rounded-lg border border-slate-300 bg-white px-4 py-3 font-mono text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 placeholder="Ex: 3760074380329"
                 maxLength={13}
               />
@@ -325,7 +325,7 @@ export function ProductForm() {
 
           {/* Description */}
           <div>
-            <label htmlFor="pf-description" className="block text-sm font-medium text-white/70 mb-2">
+            <label htmlFor="pf-description" className="mb-2 block text-sm font-medium text-slate-700">
               Description
             </label>
             <textarea
@@ -333,7 +333,7 @@ export function ProductForm() {
               id="pf-description"
               {...register('description')}
               rows={3}
-              className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-lg text-white/90 placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              className="w-full resize-none rounded-lg border border-slate-300 bg-white px-4 py-3 text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
               placeholder="Description du produit..."
             />
           </div>
@@ -341,14 +341,14 @@ export function ProductForm() {
           {/* Unit and Quantity */}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
-              <label htmlFor="pf-unite" className="block text-sm font-medium text-white/70 mb-2">
+              <label htmlFor="pf-unite" className="mb-2 block text-sm font-medium text-slate-700">
               Unité <span className="text-red-400">*</span>
               </label>
               <select
                 
               id="pf-unite"
               {...register('unit')}
-                className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-lg text-white/90 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full rounded-lg border border-slate-300 bg-white px-4 py-3 text-slate-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
               >
                 {UNITS.map((unit) => (
                   <option key={unit} value={unit}>
@@ -362,7 +362,7 @@ export function ProductForm() {
             </div>
 
             <div>
-              <label htmlFor="pf-quantite" className="block text-sm font-medium text-white/70 mb-2">
+              <label htmlFor="pf-quantite" className="mb-2 block text-sm font-medium text-slate-700">
               Quantité <span className="text-red-400">*</span>
               </label>
               <input
@@ -371,7 +371,7 @@ export function ProductForm() {
               type="number"
                 step="0.01"
                 {...register('quantity', { valueAsNumber: true })}
-                className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-lg text-white/90 placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full rounded-lg border border-slate-300 bg-white px-4 py-3 text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 placeholder="Ex: 500"
               />
               {errors.quantity && (
@@ -382,7 +382,7 @@ export function ProductForm() {
 
           {/* Image URL */}
           <div>
-            <label htmlFor="pf-image-url" className="block text-sm font-medium text-white/70 mb-2">
+            <label htmlFor="pf-image-url" className="mb-2 block text-sm font-medium text-slate-700">
               URL de l'image
             </label>
             <input
@@ -390,7 +390,7 @@ export function ProductForm() {
               id="pf-image-url"
               type="url"
               {...register('imageUrl')}
-              className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-lg text-white/90 placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full rounded-lg border border-slate-300 bg-white px-4 py-3 text-slate-900 placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
               placeholder="https://example.com/image.jpg"
             />
             {errors.imageUrl && (
@@ -420,7 +420,7 @@ export function ProductForm() {
             <button
               type="button"
               onClick={() => navigate('/admin/products')}
-              className="px-6 py-3 bg-white/5 hover:bg-white/10 text-white rounded-lg transition-colors font-medium flex items-center gap-2"
+              className="flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-6 py-3 font-medium text-slate-700 transition-colors hover:bg-slate-100"
             >
               <X className="w-5 h-5" />
               Annuler


### PR DESCRIPTION
### Motivation
- Admin product and CSV import pages used low-contrast translucent white styles which made text and form fields hard to read, especially on mobile, so the UI needs improved contrast and consistent visual hierarchy.

### Description
- Updated `ProductForm` to use higher-contrast slate-on-white styles for headings, labels and inputs and adjusted loading text color for improved legibility.
- Harmonized `ImportPage` tabs, buttons and instruction blocks to consistent borders, backgrounds and text colors (replacing `text-white/..` and `bg-white/..` variants with `text-slate-*`, `bg-white`, `border-slate-*` where appropriate). 
- Revised `CsvUploader`, `ImportPreview` and `ImportReport` components to match the new card/toolbar/table styling, improving borders, backgrounds, hover states and typography for previews, error lists and action buttons.
- Changes are CSS-class-only (Tailwind utility swaps) and preserve existing component behavior and data flow.

### Testing
- Ran lint for the frontend on the changed files with `npm --prefix frontend run lint` which completed and reported existing repo-wide warnings but no new errors on the modified files. 
- Attempted a TypeScript check with `npm --prefix frontend run typecheck` in this environment but it did not complete within the session, so full typecheck was not verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c31e1df7b08321879d5e52cfd94e40)