### PR TITLE
test: align sitemap route expectation with Ultra sitemap

### DIFF
--- a/frontend/src/test/sitemapRoutes.test.ts
+++ b/frontend/src/test/sitemapRoutes.test.ts
@@ -55,15 +55,11 @@ describe('public sitemap route coverage', () => {
     expect(missingRoutes).toEqual([]);
   });
 
-  it('still indexes the main public hubs and audit pages', () => {
+  it('still indexes the current public routes for the Ultra release', () => {
     expect(sitemapPaths).toEqual(
       expect.arrayContaining([
         '/',
-        '/comparateurs',
-        '/observatoire',
-        '/scanner',
-        '/roadmap',
-        '/module-audit',
+        '/comparateur',
       ]),
     );
   });


### PR DESCRIPTION
### Motivation
- The Ultra release simplified the public routes to only `/` and `/comparateur`, causing the sitemap unit test to fail with outdated expectations.
- The goal is to keep the sitemap coverage test aligned with the current public routes so CI turns green and accurately reflects the deployed site.

### Description
- Update `frontend/src/test/sitemapRoutes.test.ts` to assert the current Ultra sitemap routes (`/` and `/comparateur`).
- Rename the test description to `still indexes the current public routes for the Ultra release` to reflect the scope of the assertion.
- No other production code was modified; the change is limited to the test expectations.

### Testing
- Ran `cd frontend && npm test -- --run src/test/sitemapRoutes.test.ts` before the change, which reported 1 failed and 1 passed test due to outdated expectations.
- After updating `frontend/src/test/sitemapRoutes.test.ts`, re-ran `cd frontend && npm test -- --run src/test/sitemapRoutes.test.ts`, and the test file passed completely (`2 passed`).
- A non-blocking npm warning `Unknown env config "http-proxy"` was observed during test runs but did not affect test results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c76bbdc688832196b2087b337a4ddb)