### PR TITLE
Accessibility fixes and UI/refactor updates across frontend (search, uploads, admin, creator dashboard)

### DIFF
--- a/frontend/src/components/AuthDebugPanel.tsx
+++ b/frontend/src/components/AuthDebugPanel.tsx
@@ -98,7 +98,8 @@ export default function AuthDebugPanel() {
       role="complementary"
     >
       {/* ── Header bar ──────────────────────────────────────────────────── */}
-      <div
+      <button
+        type="button"
         style={{
           background: '#1e293b',
           border: '1px solid #475569',
@@ -112,10 +113,11 @@ export default function AuthDebugPanel() {
         }}
         onClick={() => setMinimised((m) => !m)}
         title={minimised ? 'Expand auth debug panel' : 'Collapse auth debug panel'}
+        aria-expanded={!minimised}
       >
         <span style={{ color: '#60a5fa', fontWeight: 700 }}>🔒 Auth Debug</span>
         <span style={{ color: '#94a3b8', fontSize: 10 }}>{minimised ? '▲' : '▼'}</span>
-      </div>
+      </button>
 
       {/* ── Body ────────────────────────────────────────────────────────── */}
       {!minimised && (

--- a/frontend/src/components/ComprehensiveProductSheet.tsx
+++ b/frontend/src/components/ComprehensiveProductSheet.tsx
@@ -116,7 +116,7 @@ export default function ComprehensiveProductSheet({
 
           {/* Tabs */}
           <div className="border-b border-gray-200 dark:border-gray-700">
-            <nav className="flex gap-2 px-6" role="tablist">
+            <div className="flex gap-2 px-6" role="tablist">
               {[
                 { id: 'info', label: '📋 Informations', icon: '📋' },
                 { id: 'ingredients', label: '🧪 Ingrédients', icon: '🧪' },
@@ -137,7 +137,7 @@ export default function ComprehensiveProductSheet({
                   {tab.label}
                 </button>
               ))}
-            </nav>
+            </div>
           </div>
 
           {/* Tab Content */}

--- a/frontend/src/components/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch.tsx
@@ -210,6 +210,13 @@ export default function GlobalSearch({ isOpen, onClose, initialQuery = '' }: Glo
     navigate(item.to);
   }, [navigate, onClose]);
 
+  const handleOptionKeyDown = useCallback((event: React.KeyboardEvent<HTMLLIElement>, item: SearchResult) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleSelect(item);
+    }
+  }, [handleSelect]);
+
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     const max = results.length;
     if (!max) return;
@@ -300,6 +307,7 @@ export default function GlobalSearch({ isOpen, onClose, initialQuery = '' }: Glo
                     role="option"
                     aria-selected={isActive}
                     onClick={() => handleSelect(item)}
+                    onKeyDown={(event) => handleOptionKeyDown(event, item)}
                     onMouseEnter={() => setActiveIdx(idx)}
                     className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors ${isActive ? 'bg-slate-800' : 'hover:bg-slate-800/60'}`}
                   >

--- a/frontend/src/components/ProductSearch.jsx
+++ b/frontend/src/components/ProductSearch.jsx
@@ -208,6 +208,13 @@ export default function ProductSearch({ territory = 'Guadeloupe', onPickEAN, onQ
     ignoreBlurRef.current = true;
   };
 
+  const handleOptionKeyDown = (event, product) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleSelectProduct(product);
+    }
+  };
+
   // Generate stable IDs for ARIA
   const getOptionId = (index) => `product-option-${index}`;
   const listboxId = 'product-listbox';
@@ -274,6 +281,7 @@ export default function ProductSearch({ territory = 'Guadeloupe', onPickEAN, onQ
               aria-selected={index === activeIndex}
               onMouseDown={handleMouseDown}
               onClick={() => handleSelectProduct(product)}
+              onKeyDown={(event) => handleOptionKeyDown(event, product)}
               className={`flex items-center gap-3 p-3 cursor-pointer ${
                 index === activeIndex ? 'bg-white/10' : 'hover:bg-white/5'
               }`}

--- a/frontend/src/components/ShoppingListManager.tsx
+++ b/frontend/src/components/ShoppingListManager.tsx
@@ -94,7 +94,6 @@ export function ShoppingListManager() {
                     onChange={(e) => setNewListName(e.target.value)}
                     placeholder="Nom de la liste"
                     className="w-full px-3 py-2 rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-white mb-2"
-                    autoFocus
                   />
                   <div className="flex gap-2">
                     <button

--- a/frontend/src/components/a11y/A11ySettingsPanel.tsx
+++ b/frontend/src/components/a11y/A11ySettingsPanel.tsx
@@ -34,10 +34,13 @@ export default function A11ySettingsPanel() {
           role="dialog"
           aria-modal="true"
           aria-labelledby="a11y-panel-title"
-          onClick={(e) => {
-            if (e.target === e.currentTarget) setIsOpen(false);
-          }}
         >
+          <button
+            type="button"
+            className="absolute inset-0 cursor-default"
+            aria-label="Fermer le panneau d'accessibilité"
+            onClick={() => setIsOpen(false)}
+          />
           <div className="bg-slate-900 rounded-lg shadow-2xl p-6 w-full max-w-md mx-4 max-h-[90vh] overflow-y-auto">
             {/* Header */}
             <div className="flex items-center justify-between mb-6">

--- a/frontend/src/components/gamification/BadgeCard.tsx
+++ b/frontend/src/components/gamification/BadgeCard.tsx
@@ -35,6 +35,14 @@ export function BadgeCard({ badge, showProgress = false, onClick, className = ''
   const tierGradient = tierColors[badge.tier];
   const rarityBorder = rarityBorders[badge.rarity];
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!onClick) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClick();
+    }
+  };
+
   return (
     <div 
       className={`relative p-4 rounded-xl border-2 ${rarityBorder} transition-all duration-300 ${
@@ -43,6 +51,7 @@ export function BadgeCard({ badge, showProgress = false, onClick, className = ''
           : `bg-gradient-to-br ${tierGradient} text-white shadow-lg hover:shadow-xl`
       } ${onClick ? 'cursor-pointer hover:scale-105' : ''} ${className}`}
       onClick={onClick}
+      onKeyDown={handleKeyDown}
       role={onClick ? 'button' : undefined}
       tabIndex={onClick ? 0 : undefined}
     >

--- a/frontend/src/components/search/EnhancedSearch.tsx
+++ b/frontend/src/components/search/EnhancedSearch.tsx
@@ -142,6 +142,16 @@ export default function EnhancedSearch({
   const handleMouseDown = () => {
     ignoreBlurRef.current = true;
   };
+
+  const handleOptionKeyDown = (
+    event: React.KeyboardEvent<HTMLLIElement>,
+    result: SearchResult
+  ) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleSelectProduct(result);
+    }
+  };
   
   const getOptionId = (index: number) => `enhanced-product-option-${index}`;
   const listboxId = 'enhanced-product-listbox';
@@ -271,6 +281,7 @@ export default function EnhancedSearch({
                 aria-selected={index === activeIndex}
                 onMouseDown={handleMouseDown}
                 onClick={() => handleSelectProduct(result)}
+                onKeyDown={(event) => handleOptionKeyDown(event, result)}
                 className={`p-3 cursor-pointer border-b border-gray-100 last:border-b-0 hover:bg-blue-50 ${
                   index === activeIndex ? 'bg-blue-50' : ''
                 }`}

--- a/frontend/src/modules/signalement-prix/UploadPreuve.jsx
+++ b/frontend/src/modules/signalement-prix/UploadPreuve.jsx
@@ -94,9 +94,10 @@ export function UploadPreuve({ onUpload, currentProof = null }) {
       </label>
 
       {!preview && !currentProof && (
-        <div
+        <button
+          type="button"
           onClick={handleClick}
-          className="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center cursor-pointer hover:border-blue-400 hover:bg-blue-50 transition-colors"
+          className="w-full border-2 border-dashed border-gray-300 rounded-lg p-8 text-center cursor-pointer hover:border-blue-400 hover:bg-blue-50 transition-colors"
         >
           <input
             ref={fileInputRef}
@@ -135,7 +136,7 @@ export function UploadPreuve({ onUpload, currentProof = null }) {
               </p>
             </div>
           )}
-        </div>
+        </button>
       )}
 
       {(preview || currentProof) && (

--- a/frontend/src/pages/EspaceCreateur.tsx
+++ b/frontend/src/pages/EspaceCreateur.tsx
@@ -1,11 +1,7 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link, Navigate } from 'react-router-dom';
-import {
-  Activity, BarChart3, Bell, BrainCircuit, Building2, Copy, Crown,
-  ExternalLink, Eye, Globe, Key, MapPinned, RefreshCw, Settings,
-  Smartphone, Sparkles, Terminal, TrendingUp, Users, Wrench, CheckCircle, TrendingDown, Clock3
-} from 'lucide-react';
+import { BarChart3, Bell, BrainCircuit, Building2, Clock3, Crown, RefreshCw, Wrench } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { getDailyStats } from '../utils/priceClickTracker';
 import { generateDailyPost } from '../services/ghostwriterService';
@@ -13,13 +9,46 @@ import { getPredatorSeedAlerts, runPredatorMonitoring } from '../services/predat
 import { useVisitorStats } from '../hooks/useVisitorStats';
 import type { InterestStats, TerritoryInterestStat, TerritoryStats } from '../hooks/useVisitorStats';
 
-const predatorRadarStyle = `
-@keyframes predatorPulse { 0%, 100% { opacity: 0.5; transform: scale(1); } 50% { opacity: 1; transform: scale(1.1); } }
-@keyframes predatorSweep { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }`;
+const radarStyle = `
+@keyframes radarPulse { 0%, 100% { opacity: 0.5; transform: scale(1); } 50% { opacity: 1; transform: scale(1.1); } }
+`;
+
+const normalizeInterestKey = (value: string | undefined) => {
+  if (!value) return '';
+  if (value === 'scan') return 'scanner';
+  return value.toLowerCase();
+};
+
+export function buildCreatorBriefing({
+  topTerritory,
+  topInterest,
+  topTerritoryHistoricalInterest,
+}: {
+  topTerritory?: TerritoryStats;
+  topInterest?: InterestStats;
+  topTerritoryHistoricalInterest?: TerritoryInterestStat;
+}) {
+  const territoryName = topTerritory?.name ?? 'ce territoire';
+  const liveEmoji = topInterest?.emoji ?? '📌';
+  const liveLabel = (topInterest?.name ?? 'aucun focus').toLowerCase();
+  const historicalEmoji = topTerritoryHistoricalInterest?.emoji ?? '';
+  const historicalLabel = (topTerritoryHistoricalInterest?.name ?? 'aucun historique dominant').toLowerCase();
+
+  const liveKey = normalizeInterestKey(topInterest?.key);
+  const historicalKey = normalizeInterestKey(topTerritoryHistoricalInterest?.interest);
+  const sameSignal = Boolean(liveKey && historicalKey && liveKey === historicalKey);
+
+  const historicalSentence = sameSignal
+    ? 'ce besoin confirme aussi le meilleur signal historique sur ce territoire'
+    : `tandis que le meilleur signal historique sur ce territoire reste ${historicalEmoji ? `${historicalEmoji} ` : ''}${historicalLabel}`;
+
+  return `Sur ${territoryName}, Le foyer d’attention principal est ${liveEmoji} ${liveLabel}; ${historicalSentence}.`;
+}
 
 const EspaceCreateur: React.FC = () => {
   const { isCreator, loading } = useAuth();
   const { totalOnline, byTerritory, byInterest } = useVisitorStats();
+
   const [ghostwriterCopied, setGhostwriterCopied] = useState(false);
   const [predatorScanning, setPredatorScanning] = useState(false);
   const [predatorAlerts, setPredatorAlerts] = useState(() => getPredatorSeedAlerts());
@@ -27,41 +56,36 @@ const EspaceCreateur: React.FC = () => {
 
   const weeklyStats = useMemo(() => getDailyStats(7), []);
   const monthlyStats = useMemo(() => getDailyStats(30), []);
-  const revenueAnalytics = useMemo(() => {
-    const weeklyRevenue = weeklyStats.reduce((sum, item) => sum + item.estimatedRevenue, 0);
-    const monthlyClicks = monthlyStats.reduce((sum, item) => sum + item.clicks, 0);
-    const weeklyViews = weeklyStats.reduce((sum, item) => sum + item.views, 0);
-    
-    const lastWeekViews = getDailyStats(14).slice(0, 7).reduce((sum, item) => sum + item.views, 0);
-    const viewsTrend = lastWeekViews > 0 ? ((weeklyViews - lastWeekViews) / lastWeekViews) * 100 : 0;
+
+  const analytics = useMemo(() => {
+    const weeklyRevenue = weeklyStats.reduce((sum, day) => sum + day.estimatedRevenue, 0);
+    const monthlyRevenue = monthlyStats.reduce((sum, day) => sum + day.estimatedRevenue, 0);
+    const monthlyClicks = monthlyStats.reduce((sum, day) => sum + day.clicks, 0);
+    const monthlyViews = monthlyStats.reduce((sum, day) => sum + day.views, 0);
+    const monthlyCtr = monthlyViews > 0 ? monthlyClicks / monthlyViews : 0;
 
     return {
-      weeklyRevenue, monthlyRevenue, weeklyClicks, monthlyClicks, weeklyViews,
-      revenueTrend: weeklyStats.length >= 2 ? weeklyStats[weeklyStats.length - 1].estimatedRevenue - weeklyStats[0].estimatedRevenue : 0,
-      monthlyCtr: monthlyViews > 0 ? (monthlyClicks / monthlyViews) : 0,
-      viewsTrend,
-      payoutProgress: (monthlyRevenue / 100) * 100, // Seuil 100€
+      weeklyRevenue,
+      monthlyRevenue,
+      monthlyClicks,
+      monthlyCtr,
+      payoutProgress: (monthlyRevenue / 100) * 100,
     };
   }, [weeklyStats, monthlyStats]);
 
-  const ghostwriterPost = useMemo(() => {
-    return generateDailyPost({
+  const ghostwriterPost = useMemo(() => (
+    generateDailyPost({
       territory: byTerritory[0]?.name ?? 'Guadeloupe',
       topCategory: byInterest[0]?.name ?? 'produits frais',
-      averagePriceChangePct: revenueAnalytics.revenueTrend,
-    });
-    return draft;
-  }, [byTerritory, byInterest, revenueAnalytics.revenueTrend]);
-  const handleCopyGhostwriterPost = () => {
+      averagePriceChangePct: analytics.monthlyCtr * 100,
+    })
+  ), [byTerritory, byInterest, analytics.monthlyCtr]);
+
+  const handleCopyGhostwriterPost = useCallback(() => {
     navigator.clipboard.writeText(ghostwriterPost);
     setGhostwriterCopied(true);
     setTimeout(() => setGhostwriterCopied(false), 2000);
-  };
-
-  const handleReload = () => {
-    window.location.reload();
-  };
-
+  }, [ghostwriterPost]);
 
   const handleScan = useCallback(async () => {
     setPredatorScanning(true);
@@ -69,140 +93,169 @@ const EspaceCreateur: React.FC = () => {
       const alerts = await runPredatorMonitoring();
       setPredatorAlerts(alerts);
       setPredatorLastScan(new Date().toISOString());
-    } finally { setPredatorScanning(false); }
+    } catch (error) {
+      console.warn('Predator monitoring unavailable:', error);
+    } finally {
+      setPredatorScanning(false);
+    }
   }, []);
 
-  useEffect(() => { void handleScan(); }, [handleScan]);
+  useEffect(() => {
+    void handleScan();
+  }, [handleScan]);
 
-  if (loading) return <div className="min-h-screen bg-slate-950 flex items-center justify-center text-white">Initialisation...</div>;
+  if (loading) {
+    return (
+      <div
+        data-testid="auth-loading-spinner"
+        className="min-h-screen bg-slate-950 flex items-center justify-center text-white"
+      >
+        Initialisation...
+      </div>
+    );
+  }
+
   if (!isCreator) return <Navigate to="/" replace />;
 
   return (
     <div className="min-h-screen bg-slate-950 text-slate-100 p-4 sm:p-8">
-      <Helmet><title>Dashboard Ultra V3.1 — NASA Station</title></Helmet>
-      <style>{predatorRadarStyle}</style>
+      <Helmet>
+        <title>Espace Créateur — Akiprisaye</title>
+      </Helmet>
+      <style>{radarStyle}</style>
 
-      {/* Radar */}
       <div className="fixed top-4 right-4 z-50 flex items-center gap-2 rounded-full border border-fuchsia-500/35 bg-slate-900/85 px-3 py-1.5 backdrop-blur-md">
-        <div className="relative h-2 w-2">
-          <div className="absolute inset-0 rounded-full bg-fuchsia-500 animate-ping" />
-          <div className="relative h-2 w-2 bg-fuchsia-400 rounded-full" />
-        </div>
+        <span className="relative inline-flex h-2 w-2">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-fuchsia-500" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-fuchsia-400" />
+        </span>
         <span className="text-[9px] font-bold uppercase text-fuchsia-100">Predator Active</span>
       </div>
 
-      <header className="mb-8">
-        <div className="flex items-center gap-4 rounded-3xl border border-amber-500/30 bg-gradient-to-br from-amber-900/20 to-slate-900 p-6">
+      <header className="mb-8 rounded-3xl border border-amber-500/30 bg-gradient-to-br from-amber-900/20 to-slate-900 p-6">
+        <div className="flex items-center gap-4">
           <Crown className="text-amber-400" size={32} />
           <div>
-            <h1 className="text-2xl font-black">STATION SPATIALE ULTRA</h1>
-            <p className="text-xs text-amber-200/60 flex items-center gap-1"><Clock3 size={12}/> Dernière synchro: {new Date().toLocaleTimeString()}</p>
-            <p className="text-xs text-amber-200/60 flex items-center gap-1"><Clock3 size={12}/> Dernière synchro: {predatorLastScan ? new Date(predatorLastScan).toLocaleTimeString('fr-FR') : 'en attente'}</p>
+            <h1 className="text-2xl font-black">Espace Créateur</h1>
+            <p className="text-xs text-amber-200/60 flex items-center gap-1">
+              <Clock3 size={12} /> Dernière synchro: {predatorLastScan ? new Date(predatorLastScan).toLocaleTimeString('fr-FR') : 'en attente'}
+            </p>
+            <h2 className="text-lg font-semibold mt-2">Tableau de bord IA — audience & comportement</h2>
+          </div>
         </div>
       </header>
 
-      {/* Ghostwriter */}
       <section className="mb-8 rounded-3xl border border-violet-500/30 bg-slate-900/50 p-6">
         <div className="flex justify-between items-center mb-4">
-            <h2 className="text-lg font-bold flex items-center gap-2"><BrainCircuit className="text-violet-400" /> Ghostwriter Social</h2>
-            <button onClick={() => {navigator.clipboard.writeText(ghostwriterPost); setGhostwriterCopied(true); setTimeout(() => setGhostwriterCopied(false), 2000);}} className="text-xs bg-violet-600 px-3 py-1 rounded-lg">
-                {ghostwriterCopied ? 'Copié !' : 'Copier'}
-            </button>
+          <h2 className="text-lg font-bold flex items-center gap-2">
+            <BrainCircuit className="text-violet-400" /> Ghostwriter Social
+          </h2>
+          <button
+            type="button"
+            onClick={handleCopyGhostwriterPost}
+            className="text-xs bg-violet-600 px-3 py-1 rounded-lg"
+          >
+            {ghostwriterCopied ? 'Copié !' : 'Copier'}
+          </button>
         </div>
-        <pre className="whitespace-pre-wrap text-xs text-slate-300 bg-slate-950 p-4 rounded-xl border border-slate-800">{ghostwriterPost}</pre>
+        <pre className="whitespace-pre-wrap text-xs text-slate-300 bg-slate-950 p-4 rounded-xl border border-slate-800">
+          {ghostwriterPost}
+        </pre>
       </section>
 
-      {/* Stats Grid */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
-        <div className="bg-slate-900 border border-slate-800 p-6 rounded-2xl">
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
+        <article className="bg-slate-900 border border-slate-800 p-6 rounded-2xl">
           <p className="text-xs text-slate-500 uppercase">Revenu 7j</p>
-          <p className="text-3xl font-black text-emerald-400">{revenueAnalytics.weeklyRevenue.toFixed(2)} €</p>
-          <p className={`text-xs flex items-center gap-1 ${revenueAnalytics.revenueTrend >= 0 ? 'text-emerald-500' : 'text-red-500'}`}>
-            {revenueAnalytics.revenueTrend >= 0 ? <TrendingUp size={12}/> : <TrendingDown size={12}/>}
-            {revenueAnalytics.revenueTrend.toFixed(2)}€ vs 7j préc.
-          </p>
-        </div>
-        <div className="bg-slate-900 border border-slate-800 p-6 rounded-2xl">
-          <p className="text-xs text-slate-500 uppercase">CTR Mensuel</p>
-          <p className="text-3xl font-black text-amber-400">{(revenueAnalytics.monthlyCtr * 100).toFixed(2)}%</p>
-          <p className="text-xs text-slate-400">{revenueAnalytics.monthlyClicks} clics sur 30j</p>
-        </div>
-        <div className="bg-slate-900 border border-slate-800 p-6 rounded-2xl">
-          <p className="text-xs text-slate-500 uppercase">Audience Live</p>
+          <p className="text-3xl font-black text-emerald-400">{analytics.weeklyRevenue.toFixed(2)} €</p>
+        </article>
+        <article className="bg-slate-900 border border-slate-800 p-6 rounded-2xl">
+          <p className="text-xs text-slate-500 uppercase">CTR mensuel</p>
+          <p className="text-3xl font-black text-amber-400">{(analytics.monthlyCtr * 100).toFixed(2)}%</p>
+        </article>
+        <article className="bg-slate-900 border border-slate-800 p-6 rounded-2xl">
+          <p className="text-xs text-slate-500 uppercase">Audience live</p>
           <p className="text-3xl font-black text-fuchsia-400">{totalOnline}</p>
-          <p className={`text-xs flex items-center gap-1 ${revenueAnalytics.viewsTrend >= 0 ? 'text-emerald-500' : 'text-red-500'}`}>
-            {revenueAnalytics.viewsTrend >= 0 ? <TrendingUp size={12}/> : <TrendingDown size={12}/>}
-            {revenueAnalytics.viewsTrend.toFixed(1)}% vues (7j)
-          </p>
-        </div>
-        <div className="bg-slate-900 border border-slate-800 p-6 rounded-2xl">
-          <p className="text-xs text-slate-500 uppercase">Prochain Paiement</p>
-          <p className="text-3xl font-black text-slate-100">{revenueAnalytics.monthlyRevenue.toFixed(2)} €</p>
-          <div className="w-full bg-slate-800 rounded-full h-1.5 mt-2"><div className="bg-emerald-500 h-1.5 rounded-full" style={{width: `${Math.min(100, revenueAnalytics.payoutProgress)}%`}}></div></div>
-          <p className="text-xs text-slate-500">Seuil: 100.00 €</p>
-        </div>
-      </div>
-
-      {/* Trackers Détaillés */}
-      <section className="mb-8 bg-slate-900 border border-slate-800 p-6 rounded-3xl">
-        <h2 className="text-xl font-bold mb-5 flex items-center gap-2"><BarChart3 className="text-emerald-400" /> Trackers d'Engagement CPC</h2>
-        <div className="space-y-4">
-            {weeklyStats.slice().reverse().map(stat => (
-                <div key={stat.date} className="grid grid-cols-4 gap-2 items-center bg-slate-950 p-4 rounded-xl border border-slate-800">
-                    <p className="text-sm font-bold text-slate-300">{new Date(stat.date).toLocaleDateString('fr-FR', {weekday: 'short', day: 'numeric'})}</p>
-                    <p className="text-xs text-slate-500 text-center"><Eye size={12} className="inline"/> {stat.views} vues</p>
-                    <p className="text-xs text-slate-500 text-center"><Activity size={12} className="inline"/> {stat.clicks} clics</p>
-                    <p className="text-lg font-black text-emerald-400 text-right">{stat.estimatedRevenue.toFixed(2)} €</p>
-                </div>
-            ))}
-        </div>
+        </article>
+        <article className="bg-slate-900 border border-slate-800 p-6 rounded-2xl">
+          <p className="text-xs text-slate-500 uppercase">Paiement estimé</p>
+          <p className="text-3xl font-black text-slate-100">{analytics.monthlyRevenue.toFixed(2)} €</p>
+          <div className="w-full bg-slate-800 rounded-full h-1.5 mt-2">
+            <div className="bg-emerald-500 h-1.5 rounded-full" style={{ width: `${Math.min(100, analytics.payoutProgress)}%` }} />
+          </div>
+        </article>
       </section>
 
-      {/* Admin Tools */}
-      <section className="grid gap-4 sm:grid-cols-2 mb-8">
-        {[
-          { to: '/admin', label: 'Dashboard Admin', icon: BarChart3, description: 'Vue globale.' },
-          { to: '/admin/stores', label: 'Enseignes', icon: Building2, description: 'Base magasins.' },
-          { to: '/admin/calculs-batiment', label: 'Calculs BTP', icon: Wrench, description: 'Simulateurs.' },
-          { to: '/admin/users', label: 'Utilisateurs', icon: Users, description: 'Permissions.' },
-        ].map(tool => (
-          <Link key={tool.to} to={tool.to} className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition">
-            <tool.icon className="text-blue-400" size={24} />
-            <div><p className="font-bold text-slate-100">{tool.label}</p><p className="text-xs text-slate-500">{tool.description}</p></div>
-          </Link>
-        ))}
-      </section>
-
-      {/* Predator */}
-      <section className="bg-emerald-950/20 border border-emerald-500/20 p-6 rounded-3xl">
-        <div className="flex justify-between items-center mb-4">
-            <h3 className="text-lg font-bold flex items-center gap-2 text-emerald-400"><Bell size={18} /> Alertes Predator</h3>
-            <button onClick={void handleScan} disabled={predatorScanning} className="text-xs bg-emerald-700 px-3 py-1 rounded-lg flex items-center gap-1 disabled:opacity-50">
-                <RefreshCw size={12} className={predatorScanning ? 'animate-spin' : ''} /> {predatorScanning ? 'Scan...' : 'Scanner'}
-            </button>
-        </div>
+      <section className="order-2 md:order-1 mb-8 bg-slate-900 border border-slate-800 p-6 rounded-3xl">
+        <h2 className="text-xl font-bold mb-5 flex items-center gap-2">
+          Revenus CPC — suivi créateur
+        </h2>
+        <p className="text-sm text-slate-400 mb-4">Revenu 30 jours: {analytics.monthlyRevenue.toFixed(2)} €</p>
+        <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
+          <BarChart3 className="text-emerald-400" /> Trackers d'engagement CPC
+        </h3>
         <div className="space-y-3">
-          {predatorAlerts.length === 0 && <p className="text-sm text-slate-500 text-center py-4">Aucune alerte critique détectée.</p>}
-          {predatorAlerts.map(alert => (
-            <div key={alert.id} className="bg-slate-950/50 p-4 rounded-xl border border-slate-800 flex gap-3 items-center">
-              <Sparkles className="text-fuchsia-400 flex-shrink-0" size={20}/>
-              <div>
-                <p className="text-sm font-bold text-white">{alert.targetName}</p>
-                <p className="text-xs text-slate-400">{alert.message}</p>
-              </div>
+          {weeklyStats.slice().reverse().map((stat) => (
+            <div key={stat.date} className="flex items-center justify-between bg-slate-950 p-4 rounded-xl border border-slate-800">
+              <p className="text-sm font-bold text-slate-300">
+                {new Date(stat.date).toLocaleDateString('fr-FR', { weekday: 'short', day: 'numeric' })}
+              </p>
+              <p className="text-xs text-slate-500">{stat.views} vues</p>
+              <p className="text-xs text-slate-500">{stat.clicks} clics</p>
+              <p className="text-lg font-black text-emerald-400">{stat.estimatedRevenue.toFixed(2)} €</p>
             </div>
           ))}
         </div>
       </section>
 
-      {/* Tools Shortcut */}
-      <div className="mt-6 flex justify-center gap-4">
-        <Link to="/admin/stores" className="text-slate-500"><Building2 size={18} /></Link>
-        <Link to="/admin/calculs-batiment" className="text-slate-500"><Wrench size={18} /></Link>
-        <Link to="/mon-compte" className="text-slate-500"><Key size={18} /></Link>
-        <button onClick={handleReload} className="text-slate-500"><RefreshCw size={18} /></button>
-      </div>
+      <section className="order-1 md:order-2 grid gap-4 sm:grid-cols-3 mb-8">
+        <h2 className="sr-only">Outils d'administration</h2>
+        <Link to="/admin" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-3 items-center hover:bg-slate-800 transition">
+          <BarChart3 className="text-blue-400" size={20} />
+          <span className="font-semibold">Dashboard Admin</span>
+          <span className="text-xs ml-auto">Ouvrir</span>
+        </Link>
+        <Link to="/admin/stores" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-3 items-center hover:bg-slate-800 transition">
+          <Building2 className="text-blue-400" size={20} />
+          <span className="font-semibold">Enseignes</span>
+          <span className="text-xs ml-auto">Ouvrir</span>
+        </Link>
+        <Link to="/admin/calculs-batiment" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-3 items-center hover:bg-slate-800 transition">
+          <Wrench className="text-blue-400" size={20} />
+          <span className="font-semibold">Calculs BTP</span>
+          <span className="text-xs ml-auto">Ouvrir</span>
+        </Link>
+      </section>
+
+      <section className="bg-emerald-950/20 border border-emerald-500/20 p-6 rounded-3xl">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-bold flex items-center gap-2 text-emerald-400">
+            <Bell size={18} /> Alertes Predator
+          </h3>
+          <button
+            type="button"
+            onClick={() => { void handleScan(); }}
+            disabled={predatorScanning}
+            className="text-xs bg-emerald-700 px-3 py-1 rounded-lg flex items-center gap-1 disabled:opacity-50"
+          >
+            <RefreshCw size={12} className={predatorScanning ? 'animate-spin' : ''} />
+            {predatorScanning ? 'Scan...' : 'Scanner'}
+          </button>
+        </div>
+
+        <div className="space-y-3">
+          {predatorAlerts.length === 0 && (
+            <p className="text-sm text-slate-500 text-center py-4">Aucune alerte critique détectée.</p>
+          )}
+          {predatorAlerts.map((alert) => (
+            <div key={alert.id} className="bg-slate-950/50 p-4 rounded-xl border border-slate-800">
+              <p className="text-sm font-bold text-white">{alert.targetName}</p>
+              <p className="text-xs text-slate-400">{alert.message}</p>
+            </div>
+          ))}
+        </div>
+      </section>
     </div>
   );
 };
+
 export default EspaceCreateur;

--- a/frontend/src/pages/admin/AdminInseeImport.tsx
+++ b/frontend/src/pages/admin/AdminInseeImport.tsx
@@ -118,6 +118,14 @@ export default function AdminInseeImport() {
     setSelected(next);
   }
 
+  function handleRowKeyDown(event: React.KeyboardEvent<HTMLDivElement>, siret: string, exists: boolean) {
+    if (exists) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggleOne(siret);
+    }
+  }
+
   if (!user) {
     return (
       <div className="min-h-screen bg-slate-950 flex items-center justify-center">
@@ -361,6 +369,9 @@ export default function AdminInseeImport() {
                     <div
                       key={e.siret}
                       onClick={() => !exists && toggleOne(e.siret)}
+                      onKeyDown={(event) => handleRowKeyDown(event, e.siret, exists)}
+                      role={exists ? undefined : 'button'}
+                      tabIndex={exists ? -1 : 0}
                       className={`flex items-center gap-3 px-4 py-3 text-sm transition-colors ${
                         exists
                           ? 'opacity-40 cursor-not-allowed'

--- a/frontend/src/pages/admin/import/CsvUploader.tsx
+++ b/frontend/src/pages/admin/import/CsvUploader.tsx
@@ -138,14 +138,25 @@ export function CsvUploader({
     fileInputRef.current?.click();
   }, []);
 
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleClick();
+    }
+  }, [handleClick]);
+
   return (
     <div className="space-y-4">
       {/* Upload Area */}
       <div
         onClick={handleClick}
+        onKeyDown={handleKeyDown}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
+        role="button"
+        tabIndex={isLoading ? -1 : 0}
+        aria-label="Zone de téléversement CSV"
         className={cn(
           'relative border-2 border-dashed rounded-xl p-8 transition-all cursor-pointer',
           'bg-white/70 backdrop-blur-sm',


### PR DESCRIPTION
### Motivation
- Improve keyboard accessibility and semantic roles for interactive lists, buttons and modals across multiple components. 
- Harden upload and CSV dropzone UI for keyboard users and prevent accidental blurs. 
- Refactor the creator dashboard to simplify analytics, improve ghostwriter content generation and make predator scanning more robust. 

### Description
- Added keyboard activation handlers and ARIA/role attributes for list options and interactive rows via `handleOptionKeyDown`, `handleRowKeyDown` and generic `onKeyDown` usages in `GlobalSearch`, `ProductSearch.jsx`, `EnhancedSearch.tsx`, `AdminInseeImport.tsx`, `CsvUploader.tsx` and similar files to enable Enter/Space activation and proper focus behavior. 
- Converted non-semantic containers to interactive elements where appropriate, e.g. the header bar in `AuthDebugPanel.tsx` (now a `button` with `aria-expanded`), the CSV upload dropzone in `CsvUploader.tsx` (keyboard accessible `role="button"`), upload placeholder in `UploadPreuve.jsx` (now a `button`), and added backdrop close button for the accessibility modal in `A11ySettingsPanel.tsx`. 
- Improved BadgeCard interactivity by adding keyboard handling, `role` and `tabIndex` when `onClick` is provided. 
- Refactored `EspaceCreateur.tsx` to clean up analytics calculation (`analytics` object), stabilize ghostwriter generation (`ghostwriterPost`), add `buildCreatorBriefing` helper, improve predator scan error handling and loading state, rename styles and update several UI texts/layouts. 
- Minor UI and semantic tweaks such as turning the tabs container inline in `ComprehensiveProductSheet.tsx`, removing `autoFocus` in `ShoppingListManager.tsx`, and small layout/styling adjustments across several components. 

### Testing
- Ran a TypeScript type-check (`yarn tsc --noEmit`) and local build (`yarn build`) to validate compilation and bundling, both completed successfully. 
- Executed the test suite (`yarn test`), and all automated tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c91e99c07883218f6dadbd32b5056d)