### PR TITLE
EspaceCreateur: UI revamp, layout tweaks, new admin links and predator UI polish

### DIFF
--- a/frontend/src/pages/EspaceCreateur.tsx
+++ b/frontend/src/pages/EspaceCreateur.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link, Navigate } from 'react-router-dom';
-import { BarChart3, Bell, BrainCircuit, Building2, Clock3, Crown, RefreshCw, Wrench } from 'lucide-react';
+import { BarChart3, Bell, BrainCircuit, Building2, Clock3, Crown, RefreshCw, Wrench, Users, Key } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { getDailyStats } from '../utils/priceClickTracker';
 import { generateDailyPost } from '../services/ghostwriterService';
@@ -132,12 +132,12 @@ const EspaceCreateur: React.FC = () => {
         <span className="text-[9px] font-bold uppercase text-fuchsia-100">Predator Active</span>
       </div>
 
-      <header className="mb-8 rounded-3xl border border-amber-500/30 bg-gradient-to-br from-amber-900/20 to-slate-900 p-6">
+      <header className="mb-8 rounded-3xl border border-amber-500/30 bg-gradient-to-br from-amber-900/20 to-slate-900 p-6 shadow-lg">
         <div className="flex items-center gap-4">
           <Crown className="text-amber-400" size={32} />
           <div>
-            <h1 className="text-2xl font-black">Espace Créateur</h1>
-            <p className="text-xs text-amber-200/60 flex items-center gap-1">
+            <h1 className="text-2xl font-black">Espace Créateur V3.1</h1>
+            <p className="text-xs text-amber-200/60 flex items-center gap-1 mt-1">
               <Clock3 size={12} /> Dernière synchro: {predatorLastScan ? new Date(predatorLastScan).toLocaleTimeString('fr-FR') : 'en attente'}
             </p>
             <h2 className="text-lg font-semibold mt-2">Tableau de bord IA — audience & comportement</h2>
@@ -153,80 +153,92 @@ const EspaceCreateur: React.FC = () => {
           <button
             type="button"
             onClick={handleCopyGhostwriterPost}
-            className="text-xs bg-violet-600 px-3 py-1 rounded-lg"
+            className="text-xs bg-violet-600 px-3 py-2 rounded-lg font-bold hover:bg-violet-500 transition"
           >
-            {ghostwriterCopied ? 'Copié !' : 'Copier'}
+            {ghostwriterCopied ? 'Copié !' : 'Copier le texte'}
           </button>
         </div>
-        <pre className="whitespace-pre-wrap text-xs text-slate-300 bg-slate-950 p-4 rounded-xl border border-slate-800">
+        <pre className="whitespace-pre-wrap text-sm text-slate-300 bg-slate-950 p-5 rounded-xl border border-slate-800">
           {ghostwriterPost}
         </pre>
       </section>
 
       <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
-        <article className="bg-slate-900 border border-slate-800 p-6 rounded-2xl">
-          <p className="text-xs text-slate-500 uppercase">Revenu 7j</p>
-          <p className="text-3xl font-black text-emerald-400">{analytics.weeklyRevenue.toFixed(2)} €</p>
+        <article className="bg-slate-900 border border-slate-800 p-6 rounded-2xl shadow-md">
+          <p className="text-xs text-slate-500 uppercase font-bold tracking-wider">Revenu 7j</p>
+          <p className="text-3xl font-black text-emerald-400 mt-2">{analytics.weeklyRevenue.toFixed(2)} €</p>
         </article>
-        <article className="bg-slate-900 border border-slate-800 p-6 rounded-2xl">
-          <p className="text-xs text-slate-500 uppercase">CTR mensuel</p>
-          <p className="text-3xl font-black text-amber-400">{(analytics.monthlyCtr * 100).toFixed(2)}%</p>
+        <article className="bg-slate-900 border border-slate-800 p-6 rounded-2xl shadow-md">
+          <p className="text-xs text-slate-500 uppercase font-bold tracking-wider">CTR mensuel</p>
+          <p className="text-3xl font-black text-amber-400 mt-2">{(analytics.monthlyCtr * 100).toFixed(2)}%</p>
         </article>
-        <article className="bg-slate-900 border border-slate-800 p-6 rounded-2xl">
-          <p className="text-xs text-slate-500 uppercase">Audience live</p>
-          <p className="text-3xl font-black text-fuchsia-400">{totalOnline}</p>
+        <article className="bg-slate-900 border border-slate-800 p-6 rounded-2xl shadow-md">
+          <p className="text-xs text-slate-500 uppercase font-bold tracking-wider">Audience live</p>
+          <p className="text-3xl font-black text-fuchsia-400 mt-2">{totalOnline}</p>
         </article>
-        <article className="bg-slate-900 border border-slate-800 p-6 rounded-2xl">
-          <p className="text-xs text-slate-500 uppercase">Paiement estimé</p>
-          <p className="text-3xl font-black text-slate-100">{analytics.monthlyRevenue.toFixed(2)} €</p>
-          <div className="w-full bg-slate-800 rounded-full h-1.5 mt-2">
+        <article className="bg-slate-900 border border-slate-800 p-6 rounded-2xl shadow-md">
+          <p className="text-xs text-slate-500 uppercase font-bold tracking-wider">Paiement estimé</p>
+          <p className="text-3xl font-black text-slate-100 mt-2">{analytics.monthlyRevenue.toFixed(2)} €</p>
+          <div className="w-full bg-slate-800 rounded-full h-1.5 mt-4">
             <div className="bg-emerald-500 h-1.5 rounded-full" style={{ width: `${Math.min(100, analytics.payoutProgress)}%` }} />
           </div>
         </article>
       </section>
 
       <section className="order-2 md:order-1 mb-8 bg-slate-900 border border-slate-800 p-6 rounded-3xl">
-        <h2 className="text-xl font-bold mb-5 flex items-center gap-2">
-          Revenus CPC — suivi créateur
-        </h2>
-        <p className="text-sm text-slate-400 mb-4">Revenu 30 jours: {analytics.monthlyRevenue.toFixed(2)} €</p>
+        <div className="flex justify-between items-end mb-6">
+          <div>
+            <h2 className="text-xl font-bold flex items-center gap-2">
+              Revenus CPC — suivi créateur
+            </h2>
+            <p className="text-sm text-slate-400 mt-1">Revenu 30 jours: {analytics.monthlyRevenue.toFixed(2)} €</p>
+          </div>
+        </div>
         <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
           <BarChart3 className="text-emerald-400" /> Trackers d'engagement CPC
         </h3>
+
         <div className="space-y-3">
           {weeklyStats.slice().reverse().map((stat) => (
-            <div key={stat.date} className="flex items-center justify-between bg-slate-950 p-4 rounded-xl border border-slate-800">
-              <p className="text-sm font-bold text-slate-300">
+            <div key={stat.date} className="flex items-center justify-between bg-slate-950 p-4 rounded-xl border border-slate-800 hover:border-slate-700 transition">
+              <p className="text-sm font-bold text-slate-300 w-24">
                 {new Date(stat.date).toLocaleDateString('fr-FR', { weekday: 'short', day: 'numeric' })}
               </p>
-              <p className="text-xs text-slate-500">{stat.views} vues</p>
-              <p className="text-xs text-slate-500">{stat.clicks} clics</p>
-              <p className="text-lg font-black text-emerald-400">{stat.estimatedRevenue.toFixed(2)} €</p>
+              <div className="flex gap-4 text-xs text-slate-500">
+                <span className="w-16 text-right">{stat.views} vues</span>
+                <span className="w-16 text-right">{stat.clicks} clics</span>
+              </div>
+              <p className="text-lg font-black text-emerald-400 w-20 text-right">{stat.estimatedRevenue.toFixed(2)} €</p>
             </div>
           ))}
         </div>
       </section>
 
-      <section className="order-1 md:order-2 grid gap-4 sm:grid-cols-3 mb-8">
+      <section className="order-1 md:order-2 grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
         <h2 className="sr-only">Outils d'administration</h2>
-        <Link to="/admin" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-3 items-center hover:bg-slate-800 transition">
-          <BarChart3 className="text-blue-400" size={20} />
-          <span className="font-semibold">Dashboard Admin</span>
+        <Link to="/admin" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition shadow-sm">
+          <BarChart3 className="text-blue-400" size={24} />
+          <span className="font-bold">Dashboard Admin</span>
           <span className="text-xs ml-auto">Ouvrir</span>
         </Link>
-        <Link to="/admin/stores" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-3 items-center hover:bg-slate-800 transition">
-          <Building2 className="text-blue-400" size={20} />
-          <span className="font-semibold">Enseignes</span>
+        <Link to="/admin/stores" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition shadow-sm">
+          <Building2 className="text-emerald-400" size={24} />
+          <span className="font-bold">Enseignes</span>
           <span className="text-xs ml-auto">Ouvrir</span>
         </Link>
-        <Link to="/admin/calculs-batiment" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-3 items-center hover:bg-slate-800 transition">
-          <Wrench className="text-blue-400" size={20} />
-          <span className="font-semibold">Calculs BTP</span>
+        <Link to="/admin/calculs-batiment" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition shadow-sm">
+          <Wrench className="text-amber-400" size={24} />
+          <span className="font-bold">Calculs BTP</span>
+          <span className="text-xs ml-auto">Ouvrir</span>
+        </Link>
+        <Link to="/admin/users" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition shadow-sm">
+          <Users className="text-purple-400" size={24} />
+          <span className="font-bold">Utilisateurs</span>
           <span className="text-xs ml-auto">Ouvrir</span>
         </Link>
       </section>
 
-      <section className="bg-emerald-950/20 border border-emerald-500/20 p-6 rounded-3xl">
+      <section className="bg-emerald-950/20 border border-emerald-500/20 p-6 rounded-3xl mb-8">
         <div className="flex justify-between items-center mb-4">
           <h3 className="text-lg font-bold flex items-center gap-2 text-emerald-400">
             <Bell size={18} /> Alertes Predator
@@ -235,25 +247,40 @@ const EspaceCreateur: React.FC = () => {
             type="button"
             onClick={() => { void handleScan(); }}
             disabled={predatorScanning}
-            className="text-xs bg-emerald-700 px-3 py-1 rounded-lg flex items-center gap-1 disabled:opacity-50"
+            className="text-xs bg-emerald-700 px-4 py-2 rounded-lg font-bold flex items-center gap-2 disabled:opacity-50 hover:bg-emerald-600 transition"
           >
-            <RefreshCw size={12} className={predatorScanning ? 'animate-spin' : ''} />
-            {predatorScanning ? 'Scan...' : 'Scanner'}
+            <RefreshCw size={14} className={predatorScanning ? 'animate-spin' : ''} />
+            {predatorScanning ? 'Analyse en cours...' : 'Scanner le marché'}
           </button>
         </div>
 
         <div className="space-y-3">
           {predatorAlerts.length === 0 && (
-            <p className="text-sm text-slate-500 text-center py-4">Aucune alerte critique détectée.</p>
+            <p className="text-sm text-slate-500 text-center py-6 border border-dashed border-slate-800 rounded-xl">Aucune alerte critique détectée sur le marché.</p>
           )}
           {predatorAlerts.map((alert) => (
-            <div key={alert.id} className="bg-slate-950/50 p-4 rounded-xl border border-slate-800">
+            <div key={alert.id} className="bg-slate-950/80 p-4 rounded-xl border border-slate-800 flex flex-col sm:flex-row sm:items-center justify-between gap-2">
               <p className="text-sm font-bold text-white">{alert.targetName}</p>
               <p className="text-xs text-slate-400">{alert.message}</p>
             </div>
           ))}
         </div>
       </section>
+
+      <div className="flex justify-center gap-8 mt-4 pt-6 border-t border-slate-800/50 pb-8">
+        <Link to="/admin/stores" className="text-slate-500 hover:text-slate-300 hover:scale-110 transition-transform" aria-label="Gestion des enseignes">
+          <Building2 size={22} />
+        </Link>
+        <Link to="/admin/calculs-batiment" className="text-slate-500 hover:text-slate-300 hover:scale-110 transition-transform" aria-label="Outils BTP">
+          <Wrench size={22} />
+        </Link>
+        <Link to="/mon-compte" className="text-slate-500 hover:text-slate-300 hover:scale-110 transition-transform" aria-label="Mon compte">
+          <Key size={22} />
+        </Link>
+        <button onClick={() => window.location.reload()} className="text-slate-500 hover:text-slate-300 hover:scale-110 transition-transform" aria-label="Rafraîchir la page">
+          <RefreshCw size={22} />
+        </button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
### Motivation
- Refresh the creator dashboard visuals and improve usability of admin tools and market alerts display.
- Surface important actions and quick links for creators to manage stores, BTP tools and account access directly from the dashboard.

### Description
- Updated `EspaceCreateur.tsx` to refine layout, spacing and typography and to add shadows and hover transitions for cards and links.
- Added icon imports (`Users`, `Key`) and new quick-links for `Enseignes`, `Calculs BTP`, `Utilisateurs` and account access, plus a footer action bar with shortcuts and a reload button.
- Improved Ghostwriter section button text and sizing, increased readability of the generated post block, and reworded predator scan button and no-alert placeholder text.
- Reworked KPI and weekly stats cards for better alignment and responsive layout, and added small UX touches like badge text changes (`Espace Créateur V3.1`) and progress bar spacing.

### Testing
- Performed a TypeScript type-check via `tsc --noEmit`, which succeeded.
- Built the frontend with the project build command (`npm run build` / `yarn build`) and verified the app compiles successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c934f4f3fc8321a5f76396b338deac)