### PR TITLE
Restrict admin tools in creator dashboard and route OpenFoodFacts via proxy

### DIFF
--- a/frontend/src/pages/EspaceCreateur.tsx
+++ b/frontend/src/pages/EspaceCreateur.tsx
@@ -46,7 +46,7 @@ export function buildCreatorBriefing({
 }
 
 const EspaceCreateur: React.FC = () => {
-  const { isCreator, loading } = useAuth();
+  const { isCreator, isAdmin, loading } = useAuth();
   const { totalOnline, byTerritory, byInterest } = useVisitorStats();
 
   const [ghostwriterCopied, setGhostwriterCopied] = useState(false);
@@ -214,22 +214,54 @@ const EspaceCreateur: React.FC = () => {
 
       <section className="order-1 md:order-2 grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
         <h2 className="sr-only">Outils d'administration</h2>
-        <Link to="/admin" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition shadow-sm">
-          <BarChart3 className="text-blue-400" size={24} />
-          <span className="font-bold">Admin Global</span>
-        </Link>
-        <Link to="/admin/stores" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition shadow-sm">
-          <Building2 className="text-emerald-400" size={24} />
-          <span className="font-bold">Enseignes</span>
-        </Link>
-        <Link to="/admin/calculs-batiment" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition shadow-sm">
-          <Wrench className="text-amber-400" size={24} />
-          <span className="font-bold">Calculs BTP</span>
-        </Link>
-        <Link to="/admin/users" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition shadow-sm">
-          <Users className="text-purple-400" size={24} />
-          <span className="font-bold">Utilisateurs</span>
-        </Link>
+        {isAdmin ? (
+          <>
+            <Link to="/admin" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition shadow-sm">
+              <BarChart3 className="text-blue-400" size={24} />
+              <span className="font-bold">Admin Global</span>
+            </Link>
+            <Link to="/admin/stores" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition shadow-sm">
+              <Building2 className="text-emerald-400" size={24} />
+              <span className="font-bold">Enseignes</span>
+            </Link>
+            <Link to="/admin/calculs-batiment" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition shadow-sm">
+              <Wrench className="text-amber-400" size={24} />
+              <span className="font-bold">Calculs BTP</span>
+            </Link>
+            <Link to="/admin/users" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition shadow-sm">
+              <Users className="text-purple-400" size={24} />
+              <span className="font-bold">Utilisateurs</span>
+            </Link>
+          </>
+        ) : (
+          <>
+            <div className="bg-slate-900/80 border border-slate-800 p-5 rounded-2xl flex flex-col gap-2 shadow-sm opacity-80">
+              <div className="flex gap-4 items-center">
+                <BarChart3 className="text-blue-400" size={24} />
+                <span className="font-bold">Admin Global</span>
+              </div>
+              <p className="text-xs text-amber-300">Admin requis</p>
+            </div>
+            <div className="bg-slate-900/80 border border-slate-800 p-5 rounded-2xl flex flex-col gap-2 shadow-sm opacity-80">
+              <div className="flex gap-4 items-center">
+                <Building2 className="text-emerald-400" size={24} />
+                <span className="font-bold">Enseignes</span>
+              </div>
+              <p className="text-xs text-amber-300">Admin requis</p>
+            </div>
+            <div className="bg-slate-900/80 border border-slate-800 p-5 rounded-2xl flex flex-col gap-2 shadow-sm opacity-80">
+              <div className="flex gap-4 items-center">
+                <Wrench className="text-amber-400" size={24} />
+                <span className="font-bold">Calculs BTP</span>
+              </div>
+              <p className="text-xs text-amber-300">Admin requis</p>
+            </div>
+            <Link to="/mon-compte" className="bg-slate-900 border border-slate-800 p-5 rounded-2xl flex gap-4 items-center hover:bg-slate-800 transition shadow-sm">
+              <Users className="text-purple-400" size={24} />
+              <span className="font-bold">Mon compte créateur</span>
+            </Link>
+          </>
+        )}
       </section>
 
       <section className="bg-emerald-950/20 border border-emerald-500/20 p-6 rounded-3xl mb-8">
@@ -254,10 +286,18 @@ const EspaceCreateur: React.FC = () => {
       </section>
 
       <div className="flex justify-center gap-8 mt-4 pt-6 border-t border-slate-800/50 pb-8">
-        <Link to="/admin/stores" className="text-slate-500 hover:text-slate-300 hover:scale-110 transition-transform" aria-label="Gestion des enseignes">
+        <Link
+          to={isAdmin ? '/admin/stores' : '/mon-compte'}
+          className="text-slate-500 hover:text-slate-300 hover:scale-110 transition-transform"
+          aria-label={isAdmin ? 'Gestion des enseignes' : 'Mon compte'}
+        >
           <Building2 size={22} />
         </Link>
-        <Link to="/admin/calculs-batiment" className="text-slate-500 hover:text-slate-300 hover:scale-110 transition-transform" aria-label="Outils BTP">
+        <Link
+          to={isAdmin ? '/admin/calculs-batiment' : '/mon-compte'}
+          className="text-slate-500 hover:text-slate-300 hover:scale-110 transition-transform"
+          aria-label={isAdmin ? 'Outils BTP' : 'Mon compte'}
+        >
           <Wrench size={22} />
         </Link>
         <Link to="/mon-compte" className="text-slate-500 hover:text-slate-300 hover:scale-110 transition-transform" aria-label="Mon compte">

--- a/frontend/src/providers/index.ts
+++ b/frontend/src/providers/index.ts
@@ -20,7 +20,8 @@ import { seedProvider } from './seedProvider';
 import { supecoGuyaneProvider } from './supecoGuyaneProvider';
 import type { PriceProvider, ProviderResult } from './types';
 
-const OPEN_FOOD_FACTS_ENDPOINT = 'https://world.openfoodfacts.org';
+const OFF_PROXY_PRODUCT_ENDPOINT = '/api/off/product';
+const OFF_PROXY_SEARCH_ENDPOINT = '/api/off/search';
 
 const parseFlag = (value: string | boolean | undefined, fallback: boolean): boolean => {
   if (typeof value === 'boolean') return value;
@@ -45,37 +46,37 @@ const openFoodFactsProvider: PriceProvider = {
 
     try {
       if (input.barcode) {
-        const url = `${OPEN_FOOD_FACTS_ENDPOINT}/api/v2/product/${encodeURIComponent(input.barcode)}.json`;
+        const url = `${OFF_PROXY_PRODUCT_ENDPOINT}?barcode=${encodeURIComponent(input.barcode)}`;
         const response = await fetch(url, { signal });
         if (!response.ok) {
           return { source: 'open_food_facts', status: 'UNAVAILABLE', observations: [], warnings: [] };
         }
         const data = (await response.json()) as {
-          product?: { product_name?: string; brands?: string };
+          data?: { productName?: string };
         };
 
         return {
           source: 'open_food_facts',
-          status: data.product ? 'OK' : 'NO_DATA',
+          status: data.data ? 'OK' : 'NO_DATA',
           observations: [],
           warnings: [],
-          productName: data.product?.product_name,
+          productName: data.data?.productName,
         };
       }
 
       const query = encodeURIComponent(normalizeText(input.query));
-      const url = `${OPEN_FOOD_FACTS_ENDPOINT}/cgi/search.pl?search_terms=${query}&search_simple=1&action=process&json=1&page_size=1`;
+      const url = `${OFF_PROXY_SEARCH_ENDPOINT}?q=${query}&page=1&pageSize=1`;
       const response = await fetch(url, { signal });
       if (!response.ok) {
         return { source: 'open_food_facts', status: 'UNAVAILABLE', observations: [], warnings: [] };
       }
-      const data = (await response.json()) as { products?: Array<{ product_name?: string }> };
+      const data = (await response.json()) as { products?: Array<{ productName?: string }> };
       return {
         source: 'open_food_facts',
         status: data.products?.length ? 'OK' : 'NO_DATA',
         observations: [],
         warnings: [],
-        productName: data.products?.[0]?.product_name,
+        productName: data.products?.[0]?.productName,
       };
     } catch {
       return { source: 'open_food_facts', status: 'UNAVAILABLE', observations: [], warnings: [] };

--- a/frontend/src/services/priceSearch/priceProviders.ts
+++ b/frontend/src/services/priceSearch/priceProviders.ts
@@ -15,7 +15,8 @@ export interface PriceProvider {
   search: (input: PriceSearchInput, signal: AbortSignal) => Promise<PriceProviderResult>;
 }
 
-const OPEN_FOOD_FACTS_ENDPOINT = 'https://world.openfoodfacts.org';
+const OFF_PROXY_PRODUCT_ENDPOINT = '/api/off/product';
+const OFF_PROXY_SEARCH_ENDPOINT = '/api/off/search';
 const OPEN_PRICES_ENDPOINT = 'https://prices.openfoodfacts.org/api/v1';
 
 async function fetchJson<T>(url: string, signal: AbortSignal): Promise<T> {
@@ -38,8 +39,8 @@ const openFoodFactsProvider: PriceProvider = {
 
     try {
       if (input.barcode) {
-        const url = `${OPEN_FOOD_FACTS_ENDPOINT}/api/v2/product/${encodeURIComponent(input.barcode)}.json`;
-        const data = await fetchJson<{ product?: { product_name?: string; brands?: string } }>(
+        const url = `${OFF_PROXY_PRODUCT_ENDPOINT}?barcode=${encodeURIComponent(input.barcode)}`;
+        const data = await fetchJson<{ data?: { productName?: string } }>(
           url,
           signal
         );
@@ -47,18 +48,18 @@ const openFoodFactsProvider: PriceProvider = {
           observations: [],
           warnings,
           provider: 'open_food_facts',
-          productName: data.product?.product_name,
+          productName: data.data?.productName,
         };
       }
 
       const query = encodeURIComponent(input.query ?? '');
-      const url = `${OPEN_FOOD_FACTS_ENDPOINT}/cgi/search.pl?search_terms=${query}&search_simple=1&action=process&json=1&page_size=1`;
-      const data = await fetchJson<{ products?: { product_name?: string }[] }>(url, signal);
+      const url = `${OFF_PROXY_SEARCH_ENDPOINT}?q=${query}&page=1&pageSize=1`;
+      const data = await fetchJson<{ products?: { productName?: string }[] }>(url, signal);
       return {
         observations: [],
         warnings,
         provider: 'open_food_facts',
-        productName: data.products?.[0]?.product_name,
+        productName: data.products?.[0]?.productName,
       };
     } catch (error) {
       warnings.push('Open Food Facts indisponible pour le moment.');

--- a/frontend/src/test/creatorGuard.test.tsx
+++ b/frontend/src/test/creatorGuard.test.tsx
@@ -217,7 +217,7 @@ describe('EspaceCreateur creator guard', () => {
     expect(screen.getByRole('heading', { name: /Espace Créateur V3.1/i })).toBeTruthy();
   });
 
-  it('shows admin tools as open for creator users', () => {
+  it('shows admin tools as locked for creator users', () => {
     const fakeUser = { uid: 'creator-uid', email: 'creator@example.com', displayName: 'Créateur', photoURL: null };
     authState = makeAuthMock({
       loading: false,
@@ -234,7 +234,7 @@ describe('EspaceCreateur creator guard', () => {
 
     renderCreateur();
 
-    expect(screen.queryByText(/Admin requis/i)).toBeNull();
+    expect(screen.getAllByText(/Admin requis/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Admin Global/i)).toBeTruthy();
   });
 


### PR DESCRIPTION
### Motivation

- Prevent non-admin creators from accessing global admin pages directly and make the UI clearly indicate admin-only tools. 
- Route Open Food Facts requests through local proxy endpoints to avoid direct client-side calls and adapt to the new response payload shape.

### Description

- Updated the creator dashboard (`frontend/src/pages/EspaceCreateur.tsx`) to read `isAdmin` from `useAuth` and conditionally render admin tool links; non-admins now see locked cards with the label `Admin requis` and a fallback `Mon compte` link for the users tool. 
- Adjusted footer/action icons in `EspaceCreateur.tsx` to navigate to admin routes only when `isAdmin` is true and otherwise point to `'/mon-compte'` with appropriate `aria-label`s. 
- Replaced direct Open Food Facts endpoints with proxy endpoints (`/api/off/product` and `/api/off/search`) in `frontend/src/providers/index.ts` and `frontend/src/services/priceSearch/priceProviders.ts`, and updated expected response properties from `product/product_name` to `data.productName` / `productName`. 
- Updated the creator guard unit test (`frontend/src/test/creatorGuard.test.tsx`) to assert that admin tools are shown as locked for creator-role users and that admin users can access the creator dashboard.

### Testing

- Ran the frontend unit tests including `creatorGuard.test.tsx` which verifies admin and creator behaviors, and the updated tests passed. 
- Ran the project test suite with `yarn test` (or `npm test`) for the frontend and no regressions were reported in the affected tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce9534cf58832181a2b023e8eb4d69)