### PR TITLE
Resolve deployment URL in GH workflows and stabilize antiCrisis tests

### DIFF
--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -37,6 +37,14 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
 
+      - name: Resolve lighthouse target URL
+        run: |
+          LHCI_TARGET="${{ needs.deploy.outputs.deployment_url }}"
+          if [ -z "$LHCI_TARGET" ]; then
+            LHCI_TARGET="${{ env.DEFAULT_PREVIEW_URL }}"
+          fi
+          echo "LHCI_URL=$LHCI_TARGET" >> "$GITHUB_ENV"
+
       - name: Validate Firebase API key secret (fail-fast before build)
         run: |
           WRONG_PART_A="AIzaSyDf_mB8z"
@@ -79,9 +87,16 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      SITE_URL: ${{ needs.deploy.outputs.deployment_url || env.DEFAULT_PREVIEW_URL }}
     steps:
+      - name: Resolve site URL
+        id: resolve_site_url
+        run: |
+          SITE_URL="${{ needs.deploy.outputs.deployment_url }}"
+          if [ -z "$SITE_URL" ]; then
+            SITE_URL="${{ env.DEFAULT_PREVIEW_URL }}"
+          fi
+          echo "site_url=$SITE_URL" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -91,7 +106,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Validation round 1/3
-        run: node scripts/validate-deployment.mjs "$SITE_URL"
+        run: node scripts/validate-deployment.mjs "${{ steps.resolve_site_url.outputs.site_url }}"
 
       - name: Wait before round 2
         run: |
@@ -99,7 +114,7 @@ jobs:
           sleep 15
 
       - name: Validation round 2/3
-        run: node scripts/validate-deployment.mjs "$SITE_URL"
+        run: node scripts/validate-deployment.mjs "${{ steps.resolve_site_url.outputs.site_url }}"
 
       - name: Wait before round 3
         run: |
@@ -107,7 +122,7 @@ jobs:
           sleep 15
 
       - name: Validation round 3/3
-        run: node scripts/validate-deployment.mjs "$SITE_URL"
+        run: node scripts/validate-deployment.mjs "${{ steps.resolve_site_url.outputs.site_url }}"
 
       - name: Final proof — 3/3 validations passed ✅
         run: |
@@ -127,7 +142,6 @@ jobs:
       pull-requests: write
     env:
       DEPLOY_URL: ${{ needs.deploy.outputs.deployment_url }}
-      LHCI_URL: ${{ needs.deploy.outputs.deployment_url || env.DEFAULT_PREVIEW_URL }}
     defaults:
       run:
         working-directory: frontend
@@ -144,6 +158,14 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
+
+      - name: Resolve lighthouse target URL
+        run: |
+          LHCI_TARGET="${{ needs.deploy.outputs.deployment_url }}"
+          if [ -z "$LHCI_TARGET" ]; then
+            LHCI_TARGET="${{ env.DEFAULT_PREVIEW_URL }}"
+          fi
+          echo "LHCI_URL=$LHCI_TARGET" >> "$GITHUB_ENV"
 
       - name: Prepare lighthouse target URL
         run: node scripts/prepare-lighthouse-config.mjs

--- a/backend/src/services/anticrisis/__tests__/antiCrisisBasketService.test.ts
+++ b/backend/src/services/anticrisis/__tests__/antiCrisisBasketService.test.ts
@@ -20,6 +20,15 @@ import { priceObservationsMultiTerritories } from './priceObservations.multiTerr
 import { priceObservationsLarge } from './priceObservations.large.mock.js';
 
 describe('AntiCrisisBasketService', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-02-15T00:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   let service: AntiCrisisBasketService;
 
   beforeEach(() => {


### PR DESCRIPTION
### Motivation

- Make the CI workflows robust when the deployment URL is not available by falling back to a default preview URL and ensuring the correct URL is passed to validation and Lighthouse CI steps.
- Avoid unsupported inline conditional expressions for job-level env resolution and instead compute values in explicit steps so downstream steps can reliably consume them.
- Eliminate time-dependent flakiness in the `AntiCrisisBasketService` unit tests by freezing system time during the tests.

### Description

- Added `Resolve lighthouse target URL` steps that write `LHCI_URL` to `GITHUB_ENV` when a deployment URL is missing, and removed the previous conditional `LHCI_URL` job env usage.
- Replaced the previous `SITE_URL` job-level env expression in the `validate` job with an explicit `resolve_site_url` step that sets a step output and updated the three validation runs to use that step output.
- Updated the Lighthouse job to compute the target URL in a step and to use the prepared config for `lhci autorun` as before.
- Stabilized `backend/src/services/anticrisis/__tests__/antiCrisisBasketService.test.ts` by adding `beforeAll`/`afterAll` hooks to call `jest.useFakeTimers()` and `jest.setSystemTime(...)`, and restoring real timers after tests.

### Testing

- Ran the backend unit tests with Jest for the modified `antiCrisis` spec (`npm test`) and the tests passed.
- Verified that the validation script invocation now receives the resolved site URL via the step output by running the validation job locally in CI simulation, and it completed successfully.
- Confirmed Lighthouse CI preparation and `lhci autorun` execute with the resolved `LHCI_URL` set in `GITHUB_ENV` during a CI run (workflow validation executed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf285b7ad8832185e7e5a094b95810)