### PR TITLE
Improve route snapshot reporting, add UI/content updates and robust RSS fetching

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,7 @@
 {
+  "frontend/src/App.tsx": [
+    "npm --prefix frontend run snapshot:routes"
+  ],
   "frontend/src/**/*.{ts,tsx,js,jsx}": [
     "npm --prefix frontend run lint"
   ]

--- a/frontend/scripts/public-routes-snapshot.mjs
+++ b/frontend/scripts/public-routes-snapshot.mjs
@@ -27,6 +27,37 @@ const generated = [
 
 const mode = process.argv.includes('--write') ? 'write' : 'check';
 
+function extractRoutesFromSnapshot(content) {
+  return content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+function printDriftDetails(existingContent) {
+  const existingRoutes = new Set(extractRoutesFromSnapshot(existingContent));
+  const generatedRoutes = new Set(routes);
+
+  const missingInSnapshot = routes.filter((route) => !existingRoutes.has(route));
+  const extraInSnapshot = [...existingRoutes].filter((route) => !generatedRoutes.has(route)).sort((a, b) => a.localeCompare(b));
+
+  const preview = (label, list) => {
+    if (list.length === 0) return;
+    const max = 20;
+    const shown = list.slice(0, max);
+    console.error(`   ${label} (${list.length}) :`);
+    for (const item of shown) {
+      console.error(`   - ${item}`);
+    }
+    if (list.length > max) {
+      console.error(`   … +${list.length - max} autre(s)`);
+    }
+  };
+
+  preview('Routes manquantes dans le snapshot', missingInSnapshot);
+  preview('Routes en trop dans le snapshot', extraInSnapshot);
+}
+
 if (mode === 'write') {
   writeFileSync(SNAPSHOT_PATH, generated, 'utf8');
   console.log(`✅ Snapshot écrit: ${path.relative(ROOT, SNAPSHOT_PATH)} (${routes.length} routes).`);
@@ -41,6 +72,7 @@ if (!existsSync(SNAPSHOT_PATH)) {
 const existing = readFileSync(SNAPSHOT_PATH, 'utf8');
 if (existing !== generated) {
   console.error('❌ Snapshot des routes obsolète. Exécutez: npm run snapshot:routes');
+  printDriftDetails(existing);
   process.exit(1);
 }
 

--- a/frontend/scripts/public-routes.snapshot.txt
+++ b/frontend/scripts/public-routes.snapshot.txt
@@ -192,12 +192,15 @@
 /parametres
 /perimetre
 /petits-commerces
+/plan
 /planificateur-repas
+/plans
 /populaires
 /portail-affilies
 /portail-api
 /portail-developpeurs
 /predictions
+/premium
 /presse
 /pricing
 /privacy

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -318,6 +318,9 @@ const LEGACY_ALIAS_ROUTES = (
     <Route path="offres" element={<Navigate to="/pricing" replace />} />
     <Route path="tarifs" element={<Navigate to="/pricing" replace />} />
     <Route path="abonnements" element={<Navigate to="/pricing" replace />} />
+    <Route path="premium" element={<Navigate to="/pricing" replace />} />
+    <Route path="plans" element={<Navigate to="/pricing" replace />} />
+    <Route path="plan" element={<Navigate to="/pricing" replace />} />
     <Route path="Login" element={<Navigate to="/login" replace />} />
     <Route path="auth/login" element={<Navigate to="/login" replace />} />
     <Route path="signin" element={<Navigate to="/login" replace />} />

--- a/frontend/src/components/home/AppDemoShowcase.tsx
+++ b/frontend/src/components/home/AppDemoShowcase.tsx
@@ -38,7 +38,7 @@ const SCREENS = ['scan', 'compare', 'territoire'] as const;
 type Screen = (typeof SCREENS)[number];
 
 const SCREEN_LABELS: Record<Screen, string> = {
-  scan: '📷 Scan EAN',
+  scan: '📷 Scanner',
   compare: '📊 Comparer',
   territoire: '🗺️ Territoire',
 };
@@ -73,7 +73,7 @@ function ScanScreen() {
           <span className="demo-scan-emoji">🥛</span>
           <div>
             <p className="demo-scan-product-name">Lait demi-écrémé UHT 1L</p>
-            <p className="demo-scan-ean">EAN : 3560070123456</p>
+            <p className="demo-scan-ean">Code-barres : 3560070123456</p>
           </div>
         </div>
         <div className="demo-scan-price-row">
@@ -200,7 +200,7 @@ export default function AppDemoShowcase() {
               <span className="app-demo-feat-icon">📷</span>
               <div>
                 <strong>Scan instantané</strong>
-                <span> — visez le code-barres, obtenez le prix juste</span>
+                <span> — visez le code-barres, obtenez le bon prix</span>
               </div>
             </li>
             <li>

--- a/frontend/src/components/home/ConseilBudgetDuJour.tsx
+++ b/frontend/src/components/home/ConseilBudgetDuJour.tsx
@@ -40,7 +40,7 @@ const CONSEILS: Conseil[] = [
   { emoji: '🌾', categorie: 'local', texte: "Les producteurs locaux peuvent vous vendre directement. Cherchez les AMAP ou groupements de producteurs de votre île." },
   { emoji: '🧾', categorie: 'economie', texte: "Gardez vos tickets de caisse et comparez vos dépenses mois après mois. Identifier une hausse de 5 % peut vous faire économiser 200 €/an." },
   { emoji: '♻️', categorie: 'economie', texte: "Les promotions de fin de semaine sur les produits frais permettent d'économiser jusqu'à 40 % sur la viande et le poisson." },
-  { emoji: '🚗', categorie: 'transport', texte: "Comparez le prix du carburant entre les stations avant de faire le plein. Les stations-service offrent parfois des réductions fidélité.", lien: { to: '/comparateur', label: 'Comparateurs' } },
+  { emoji: '🚗', categorie: 'transport', texte: "Regroupez vos déplacements et comparez les options de transport pour réduire vos dépenses chaque semaine.", lien: { to: '/comparateurs', label: 'Plus de services' } },
   { emoji: '📦', categorie: 'alimentation', texte: "Achetez certains produits secs (riz, pâtes, légumineuses) en grande quantité. Le prix au kilo baisse fortement à partir de 5 kg." },
   { emoji: '🔍', categorie: 'numerique', texte: "Avant tout achat important, consultez l'historique des prix. Un produit à prix cassé n'est pas toujours une vraie promo !", lien: { to: '/historique-prix', label: 'Historique des prix' } },
   { emoji: '🌴', categorie: 'local', texte: "Faites pousser quelques herbes aromatiques sur votre balcon (ciboulette, persil, thym). Un plant à 2 € vous évitera des achats pendant des mois." },

--- a/frontend/src/components/home/TerritorySignal.tsx
+++ b/frontend/src/components/home/TerritorySignal.tsx
@@ -64,7 +64,7 @@ export function TerritorySignal() {
         type: 'increase',
         severity: 'high',
         title: '3 hausses importantes détectées cette semaine',
-        description: 'Produits laitiers, fruits frais et carburant en hausse moyenne de +8.5%',
+        description: 'Produits laitiers et fruits frais en hausse moyenne de +8.5%',
         productsAffected: 3,
         dateDetected: '2026-01-07',
         icon: '📈'

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -95,7 +95,7 @@ export default function Footer() {
               <li><Link to="/search" className="text-slate-400 hover:text-white transition-colors">Recherche</Link></li>
               <li><Link to="/scanner" className="text-slate-400 hover:text-white transition-colors">Scanner</Link></li>
               <li><Link to="/liste" className="text-slate-400 hover:text-white transition-colors">Liste de courses</Link></li>
-              <li><Link to="/pricing" className="text-slate-400 hover:text-white transition-colors">Offres</Link></li>
+              <li><Link to="/pricing" className="text-slate-400 hover:text-white transition-colors">Offres payantes</Link></li>
             </ul>
           </div>
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useState, useRef, useEffect } from 'react';
+import React, { lazy, Suspense, useState, useRef, useEffect, useMemo } from 'react';
 import { Search, PlayCircle, Package, RefreshCw, ChevronRight, Share2, MessageCircle, Facebook, Twitter, Link2, Check } from 'lucide-react';
 import { useNavigate, Link } from 'react-router-dom';
 import { useApp } from '../context/AppContext';
@@ -273,6 +273,28 @@ const Home = () => {
   const navigate = useNavigate();
   const { products, loading, error, reloadProducts } = useApp();
   const pageRef = useRef<HTMLDivElement>(null);
+  const dailyStar = useMemo(() => {
+    const fallback = {
+      name: "Huile de tournesol 1L",
+      store: "votre magasin local",
+      price: 2.10,
+      territory: activeTerritoryCode ? TERRITORY_DISPLAY[activeTerritoryCode]?.name ?? 'votre territoire' : 'votre territoire',
+    };
+
+    if (!products || products.length === 0) return fallback;
+
+    const source = products.filter((p) => /huile/i.test(p.name) && /tournesol/i.test(p.name));
+    const pool = source.length > 0 ? source : products;
+    const cheapest = [...pool].sort((a, b) => Number(a.price) - Number(b.price))[0];
+    if (!cheapest) return fallback;
+
+    return {
+      name: cheapest.name,
+      store: cheapest.store || fallback.store,
+      price: Number(cheapest.price) || fallback.price,
+      territory: activeTerritoryCode ? TERRITORY_DISPLAY[activeTerritoryCode]?.name ?? 'votre territoire' : 'votre territoire',
+    };
+  }, [products, activeTerritoryCode]);
 
   // Load dynamic stats from JSON (updated by scraping pipeline)
   useEffect(() => {
@@ -418,6 +440,50 @@ const Home = () => {
           <PlayCircle size={16} />
           Scanner un code-barres
         </button>
+      </div>
+
+      {/* ── STAR DU JOUR : UNE INFO MAJEURE ───────────────────────── */}
+      <div className="px-6 mb-8">
+        <div className="rounded-3xl border border-amber-500/30 bg-gradient-to-br from-amber-500/15 to-slate-900 p-5">
+          <p className="text-[10px] font-black uppercase tracking-widest text-amber-300 mb-2">La star du jour</p>
+          <p className="text-xl sm:text-2xl font-black leading-tight">
+            Aujourd&apos;hui, <span className="text-amber-300">{dailyStar.name.toLowerCase()}</span> est au prix le plus bas
+            chez <span className="text-emerald-300">{dailyStar.store}</span> ({dailyStar.price.toFixed(2)}€).
+          </p>
+          <p className="text-xs text-slate-400 mt-2">
+            Information simple et utile pour {dailyStar.territory}. Mise à jour quotidienne.
+          </p>
+        </div>
+      </div>
+
+      {/* ── SERVICES : VOLS/CARBURANT DÉPORTÉS ────────────────────── */}
+      <div className="px-6 mb-8">
+        <button
+          type="button"
+          onClick={() => navigate('/comparateurs')}
+          className="w-full rounded-2xl border border-slate-700 bg-slate-900/70 px-4 py-3 text-left hover:border-blue-400/60 transition-colors"
+        >
+          <p className="text-sm font-bold text-slate-200">Plus de services</p>
+          <p className="text-xs text-slate-400">Vols, carburant, fret et autres comparateurs sont disponibles dans ce menu.</p>
+        </button>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
+          <button
+            type="button"
+            onClick={() => navigate('/suggestions?type=bug_report')}
+            className="rounded-2xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-left hover:border-red-400/60 transition-colors"
+          >
+            <p className="text-sm font-bold text-red-200">🐛 Signaler un bug</p>
+            <p className="text-xs text-slate-300">Aidez-nous à corriger un problème technique rapidement.</p>
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate('/suggestions?type=feature_request')}
+            className="rounded-2xl border border-purple-500/30 bg-purple-500/10 px-4 py-3 text-left hover:border-purple-400/60 transition-colors"
+          >
+            <p className="text-sm font-bold text-purple-200">✨ Demander une fonctionnalité</p>
+            <p className="text-xs text-slate-300">Proposez une amélioration utile pour tous les utilisateurs.</p>
+          </button>
+        </div>
       </div>
       {/* ── ACTUALITÉS (TEASER) ────────────────────────────────────── */}
       <Suspense fallback={<div className="px-6 mb-6 h-24" />}>

--- a/frontend/src/pages/ProducteursLocaux.tsx
+++ b/frontend/src/pages/ProducteursLocaux.tsx
@@ -11,6 +11,8 @@ import { Link } from 'react-router-dom';
 import {
   Leaf, MapPin, Search, Phone, Clock,
   Star, ChevronRight, ArrowLeft, ShoppingBag,
+  BarChart3, ShieldCheck, Truck, Store,
+  Database, ClipboardList, AlertTriangle, Target,
 } from 'lucide-react';
 import { HeroImage } from '../components/ui/HeroImage';
 import { PAGE_HERO_IMAGES } from '../config/imageAssets';
@@ -28,158 +30,190 @@ interface Producteur {
   certification: string;
   modeVente: string[];
   jours: string;
-  note: number;
-  nbAvis: number;
+  note?: number;
+  nbAvis?: number;
   paniers: { label: string; prix: number; prixHabituel: number }[];
   image: string;
+  source: string;
 }
 
 /* ─── Données ─────────────────────────────────────────────────────────────── */
 
 const PRODUCTEURS: Producteur[] = [
   {
-    id: 'prod-tijardin-gp',
-    nom: 'Ferme Ti Jardin',
+    id: 'op-caraibes-melonniers',
+    nom: 'Association Caraïbes Melonniers',
     territoire: 'Guadeloupe',
-    ville: 'Capesterre-Belle-Eau',
-    telephone: '0590 12 34 56',
-    description: 'Maraîchage diversifié en agriculture biologique depuis 2003. Légumes de saison, herbes aromatiques et plantes médicinales tropicales.',
-    specialites: ['Légumes racine', 'Salades', 'Herbes aromatiques', 'Giraumon', 'Patate douce'],
-    certification: '🌿 BIO AB',
-    modeVente: ['Vente directe à la ferme', 'Marché de Capesterre', 'Livraison Pointe-à-Pitre'],
-    jours: 'Ven–Sam sur place · Marché Mar & Sam',
-    note: 4.8, nbAvis: 92,
-    paniers: [
-      { label: 'Panier Fond de Cuisine 🥗 (5 kg légumes saison)', prix: 15.00, prixHabituel: 22.50 },
-      { label: 'Panier Herbes & Épices (assortiment)', prix: 8.00, prixHabituel: 12.00 },
-    ],
+    ville: 'Le Moule',
+    description: 'Organisation de producteurs fruits et légumes en Guadeloupe. Fiche intégrée pour mise en relation locale et qualification terrain.',
+    specialites: ['Fruits', 'Légumes', 'Organisation de producteurs'],
+    certification: '🧾 OP 971FL2402',
+    modeVente: ['Contact via organisation'],
+    jours: 'À confirmer',
+    paniers: [],
     image: 'https://images.unsplash.com/photo-1500651230702-0e2d8a49d4e6?auto=format&fm=webp&fit=crop&w=800&q=80',
+    source: 'https://www.agroberichtenbuitenland.nl/',
   },
   {
-    id: 'prod-manioc-gp',
-    nom: 'GAEC Manioc des Grands-Fonds',
+    id: 'op-sicapag',
+    nom: 'SARL SICAPAG',
     territoire: 'Guadeloupe',
-    ville: 'Grands-Fonds',
-    telephone: '0590 93 48 21',
-    description: 'Producteur de manioc et de dérivés (farine, couac, gâteau). Transformation artisanale sur place.',
-    specialites: ['Manioc frais', 'Farine de manioc', 'Couac', 'Gâteau manioc'],
-    certification: '🏡 Agriculture locale',
-    modeVente: ['Vente directe', 'Marché du Gosier'],
-    jours: 'Mar · Sam matin',
-    note: 4.6, nbAvis: 53,
-    paniers: [
-      { label: 'Colis Manioc (3 kg frais + 1 kg couac)', prix: 12.00, prixHabituel: 18.00 },
-    ],
+    ville: 'Lamentin',
+    description: 'Organisation de producteurs référencée sur la filière fruits et légumes. Données en cours de vérification locale.',
+    specialites: ['Fruits', 'Légumes', 'Approvisionnement local'],
+    certification: '🧾 OP 971FL2424',
+    modeVente: ['Contact via organisation'],
+    jours: 'À confirmer',
+    paniers: [],
     image: 'https://images.unsplash.com/photo-1566385101042-1a0aa0c1268c?auto=format&fm=webp&fit=crop&w=800&q=80',
+    source: 'https://www.agroberichtenbuitenland.nl/',
   },
   {
-    id: 'prod-cooppeyi-mq',
-    nom: 'Coopérative Péyi Martinique',
+    id: 'op-sicacfrel',
+    nom: 'SAS SICACFEL',
+    territoire: 'Guadeloupe',
+    ville: 'Saint-François',
+    description: 'Structure OP fruits et légumes. Acteur de regroupement pour améliorer la distribution locale.',
+    specialites: ['Fruits', 'Légumes', 'Coopération agricole'],
+    certification: '🧾 OP 971FL2449',
+    modeVente: ['Contact via organisation'],
+    jours: 'À confirmer',
+    paniers: [],
+    image: 'https://images.unsplash.com/photo-1488459716781-31db52582fe9?auto=format&fm=webp&fit=crop&w=800&q=80',
+    source: 'https://www.agroberichtenbuitenland.nl/',
+  },
+  {
+    id: 'op-gie-mhm',
+    nom: 'GIE Maraîcher et Horticole de Martinique',
     territoire: 'Martinique',
-    ville: 'Le Lamentin',
-    telephone: '0596 77 88 99',
-    description: 'Regroupement de 12 producteurs martiniquais pour la souveraineté alimentaire. Bannanes, ananas, épices et produits transformés locaux.',
-    specialites: ['Bananes Cavendish', 'Ananas Victoria', 'Épices créoles', 'Piment confit', 'Sirop de canne'],
-    certification: '✅ Zéro Chlordécone certifié',
-    modeVente: ['Marché du Lamentin', 'Drive fermier', 'Livraison Fort-de-France'],
-    jours: 'Lun–Sam — commandes en ligne 24h/7j',
-    note: 4.7, nbAvis: 134,
-    paniers: [
-      { label: 'Pack Fraîcheur Fruits 🍍 (assortiment tropical)', prix: 10.00, prixHabituel: 16.00 },
-      { label: 'Colis Épices Péyi (5 bocaux assortis)', prix: 18.00, prixHabituel: 26.00 },
-    ],
+    ville: 'Saint-Joseph',
+    description: 'Organisation de producteurs martiniquais pour les filières maraîchères et horticoles.',
+    specialites: ['Maraîchage', 'Horticulture', 'Fruits et légumes'],
+    certification: '🧾 OP 972FL2425',
+    modeVente: ['Contact via organisation'],
+    jours: 'À confirmer',
+    paniers: [],
     image: 'https://images.unsplash.com/photo-1490885578174-acda8905c2c6?auto=format&fm=webp&fit=crop&w=800&q=80',
+    source: 'https://www.agroberichtenbuitenland.nl/',
   },
   {
-    id: 'prod-cacao-mq',
-    nom: 'Plantation Cacao Madinina',
+    id: 'op-ananas-mq',
+    nom: 'SCA Ananas Martinique',
     territoire: 'Martinique',
-    ville: 'Ajoupa-Bouillon',
-    telephone: '0596 53 31 04',
-    description: 'L\'une des dernières plantations de cacao de la Martinique. Chocolat artisanal bean-to-bar, visites possibles.',
-    specialites: ['Fèves de cacao Trinitario', 'Chocolat noir 70%', 'Cacao en poudre', 'Beurre de cacao'],
-    certification: '🍫 Artisanal · AOP en cours',
-    modeVente: ['Boutique sur place', 'Marché de Saint-Pierre', 'Commande en ligne'],
-    jours: 'Mer–Dim 9h–16h30',
-    note: 4.9, nbAvis: 78,
-    paniers: [
-      { label: 'Coffret Chocolat Martinique (4 tablettes artisanales)', prix: 22.00, prixHabituel: 32.00 },
-    ],
-    image: 'https://images.unsplash.com/photo-1511381939415-e44f12a5fa73?auto=format&fm=webp&fit=crop&w=800&q=80',
+    ville: 'Le Lorrain',
+    description: 'Coopérative ananas en Martinique, acteur structurant de la filière fruits.',
+    specialites: ['Ananas', 'Fruits tropicaux', 'Coopérative'],
+    certification: '🧾 OP 972FL2437',
+    modeVente: ['Contact via organisation'],
+    jours: 'À confirmer',
+    paniers: [],
+    image: 'https://images.unsplash.com/photo-1464965911861-746a04b4bca6?auto=format&fm=webp&fit=crop&w=800&q=80',
+    source: 'https://www.agroberichtenbuitenland.nl/',
   },
   {
-    id: 'prod-vanilla-re',
-    nom: 'Domaine Vanille Bourbon Péi',
+    id: 'op-sica2m',
+    nom: 'SICA des Maraîchers de Martinique (SICA2M)',
+    territoire: 'Martinique',
+    ville: 'Ducos',
+    description: 'Organisation de producteurs maraîchers dédiée au renforcement de l’approvisionnement local.',
+    specialites: ['Maraîchage', 'Légumes', 'Approvisionnement territorial'],
+    certification: '🧾 OP 972FL2448',
+    modeVente: ['Contact via organisation'],
+    jours: 'À confirmer',
+    paniers: [],
+    image: 'https://images.unsplash.com/photo-1518977676601-b53f82aba655?auto=format&fm=webp&fit=crop&w=800&q=80',
+    source: 'https://www.agroberichtenbuitenland.nl/',
+  },
+  {
+    id: 'chambre-reunion',
+    nom: 'Chambre d’agriculture de La Réunion',
     territoire: 'La Réunion',
-    ville: 'Sainte-Suzanne',
-    telephone: '0262 52 18 73',
-    description: 'Producteur familial de vanille Bourbon de La Réunion. Gousses charnues, séchage traditionnel. Export et vente directe.',
-    specialites: ['Vanille Bourbon gousse', 'Extrait de vanille', 'Sucre vanillé artisanal'],
-    certification: '🌿 Indication Géographique Protégée',
-    modeVente: ['Vente directe', 'Marché forain Saint-Denis', 'E-shop'],
-    jours: 'Sur RDV · Marché Sam Saint-Denis',
-    note: 4.9, nbAvis: 167,
-    paniers: [
-      { label: 'Sachet 5 gousses Bourbon IGP', prix: 9.50, prixHabituel: 15.00 },
-      { label: 'Pack cadeau Vanille (gousses + extrait)', prix: 24.00, prixHabituel: 36.00 },
-    ],
+    ville: 'Saint-Denis',
+    description: 'Point d’entrée institutionnel pour identifier producteurs, coopératives et filières réunionnaises.',
+    specialites: ['Annuaire filières', 'Accompagnement', 'Production locale'],
+    certification: '🏛️ Source institutionnelle',
+    modeVente: ['Orientation vers les filières'],
+    jours: 'Consulter le site',
+    paniers: [],
     image: 'https://images.unsplash.com/photo-1612444332120-2b06a35b5f89?auto=format&fm=webp&fit=crop&w=800&q=80',
+    source: 'https://reunion.chambre-agriculture.fr/',
   },
   {
-    id: 'prod-lentilles-re',
-    nom: 'CUMA Lentilles de Cilaos',
-    territoire: 'La Réunion',
-    ville: 'Cilaos',
-    telephone: '0262 31 74 00',
-    description: 'Lentilles de Cilaos, produites dans le cirque volcanique à 1 200 m d\'altitude. Produit emblématique réunionnais, IGP.',
-    specialites: ['Lentilles blondes Cilaos IGP', 'Lentilles brunes', 'Farines légumineuses'],
-    certification: '🏔️ IGP Lentilles de Cilaos',
-    modeVente: ['Marchés de La Réunion', 'Grands supermarchés locaux', 'Vente directe cirque'],
-    jours: 'Disponibles en saison (mai–sept) · Stock limité',
-    note: 4.7, nbAvis: 215,
-    paniers: [
-      { label: 'Sac Lentilles Cilaos IGP 1 kg', prix: 5.50, prixHabituel: 8.00 },
-    ],
-    image: 'https://images.unsplash.com/photo-1586201375761-83865001e31c?auto=format&fm=webp&fit=crop&w=800&q=80',
-  },
-  {
-    id: 'prod-pêche-gf',
-    nom: 'Coopérative Pêche Cayenne',
+    id: 'daaf-guyane',
+    nom: 'DAAF Guyane — Filières agricoles',
     territoire: 'Guyane',
     ville: 'Cayenne',
-    telephone: '0594 25 11 08',
-    description: 'Pêcheurs artisanaux guyanais. Poissons et crustacés pêchés le matin même, vendus à l\'arrivée des pirogues.',
-    specialites: ['Acoupa', 'Vivaneau', 'Crevettes géantes', 'Coulirou fumé', 'Matoutou'],
-    certification: '🎣 Pêche artisanale durable',
-    modeVente: ['Port de pêche Cayenne', 'Marché central', 'Abonnement hebdomadaire'],
-    jours: 'Mar–Sam dès 6h (arrivage) · stock limité',
-    note: 4.6, nbAvis: 89,
-    paniers: [
-      { label: 'Colis Poissons frais (3 kg assortis)', prix: 18.00, prixHabituel: 26.00 },
-      { label: 'Crevettes géantes 1 kg (fraîches)', prix: 14.00, prixHabituel: 20.00 },
-    ],
+    description: 'Source publique pour identifier les acteurs agricoles et les filières en Guyane.',
+    specialites: ['Filières locales', 'Maraîchage', 'Agriculture vivrière'],
+    certification: '🏛️ Source institutionnelle',
+    modeVente: ['Orientation vers les acteurs'],
+    jours: 'Consulter le site',
+    paniers: [],
     image: 'https://images.unsplash.com/photo-1534483509719-3feaee7c30da?auto=format&fm=webp&fit=crop&w=800&q=80',
+    source: 'https://daaf.guyane.agriculture.gouv.fr/',
   },
   {
-    id: 'prod-ylang-yt',
-    nom: 'Distillerie Ylang Maweni',
+    id: 'daaf-mayotte',
+    nom: 'DAAF Mayotte — Acteurs agricoles',
     territoire: 'Mayotte',
-    ville: 'Kani-Kéli',
-    telephone: '0269 62 05 18',
-    description: 'Distillation artisanale d\'ylang-ylang de Mayotte. Huile essentielle d\'exception, utilisée par les grandes parfumeries.',
-    specialites: ['Huile essentielle ylang-ylang', 'Eau florale ylang', 'Savon artisanal Coco-Ylang'],
-    certification: '🌸 Production Mahoraise',
-    modeVente: ['Vente directe distillerie', 'Marchés de Mamoudzou'],
-    jours: 'Lun–Sam sur RDV',
-    note: 4.8, nbAvis: 41,
-    paniers: [
-      { label: 'Flacon HE Ylang-Ylang Mayotte 10 ml', prix: 12.00, prixHabituel: 18.00 },
-    ],
+    ville: 'Mamoudzou',
+    description: 'Point de départ pour recenser maraîchers, agriculteurs et structures de filière à Mayotte.',
+    specialites: ['Réseaux agricoles', 'Filières locales', 'Structures d’appui'],
+    certification: '🏛️ Source institutionnelle',
+    modeVente: ['Orientation vers les acteurs'],
+    jours: 'Consulter le site',
+    paniers: [],
     image: 'https://images.unsplash.com/photo-1595535873420-a599195b3f4a?auto=format&fm=webp&fit=crop&w=800&q=80',
+    source: 'https://daaf.mayotte.agriculture.gouv.fr/',
   },
 ];
 
 const TERRITOIRES = ['Tous', 'Guadeloupe', 'Martinique', 'La Réunion', 'Guyane', 'Mayotte'];
+
+const TERRITOIRES_AUDIT = [
+  'Guadeloupe (971)',
+  'Martinique (972)',
+  'Guyane (973)',
+  'La Réunion (974)',
+  'Mayotte (976)',
+  'Saint-Martin (978)',
+  'Saint-Barthélemy (977)',
+  'Saint-Pierre-et-Miquelon (975)',
+  'Polynésie française',
+  'Nouvelle-Calédonie',
+  'Wallis-et-Futuna',
+];
+
+const AXES_AUDIT = [
+  {
+    icon: Database,
+    titre: 'Cartographie de l’offre locale',
+    description: 'Recensement exhaustif des maraîchers, agriculteurs, coopératives, transformateurs et logisticiens.',
+  },
+  {
+    icon: Truck,
+    titre: 'Logistique et distribution',
+    description: 'Analyse des goulets d’étranglement : chaîne du froid, transport inter-îles, ruptures et délais.',
+  },
+  {
+    icon: Store,
+    titre: 'Demande et débouchés',
+    description: 'Qualification des besoins des cantines, hôpitaux, commerces de proximité et marchés communaux.',
+  },
+  {
+    icon: ShieldCheck,
+    titre: 'Fiabilité et gouvernance data',
+    description: 'Validation croisée des données via sources institutionnelles, appels de contrôle et mise à jour trimestrielle.',
+  },
+];
+
+const INDICATEURS_CLES = [
+  ['Taux de couverture locale', '% des besoins alimentaires couverts localement', '≥ 35% (phase 1)'],
+  ['Risque de rupture', 'Nombre de produits critiques en tension / mois', '≤ 5 produits critiques'],
+  ['Capacité logistique', 'Part des acteurs disposant transport + stockage', '≥ 60% des acteurs'],
+  ['Qualité de la donnée', 'Fiches vérifiées sur les 90 derniers jours', '≥ 85%'],
+  ['Réactivité filière', 'Délai moyen commande → livraison', '< 72h en intra-territoire'],
+];
 
 /* ─── Panier économie badge ────────────────────────────────────────────── */
 
@@ -213,13 +247,17 @@ function ProducteurCard({ p }: { p: Producteur }) {
 
       <div className="p-4">
         {/* Rating */}
-        <div className="flex items-center gap-2 mb-2">
-          {[1, 2, 3, 4, 5].map(i => (
-            <Star key={i} className={`w-3 h-3 ${i <= Math.round(p.note) ? 'text-amber-400 fill-amber-400' : 'text-slate-600'}`} />
-          ))}
-          <span className="text-amber-400 font-bold text-sm">{p.note.toFixed(1)}</span>
-          <span className="text-slate-500 text-xs">({p.nbAvis})</span>
-        </div>
+        {typeof p.note === 'number' ? (
+          <div className="flex items-center gap-2 mb-2">
+            {[1, 2, 3, 4, 5].map(i => (
+              <Star key={i} className={`w-3 h-3 ${i <= Math.round(p.note ?? 0) ? 'text-amber-400 fill-amber-400' : 'text-slate-600'}`} />
+            ))}
+            <span className="text-amber-400 font-bold text-sm">{p.note.toFixed(1)}</span>
+            <span className="text-slate-500 text-xs">({p.nbAvis ?? 0})</span>
+          </div>
+        ) : (
+          <p className="text-xs text-slate-400 mb-2">Donnée en qualification terrain</p>
+        )}
 
         <p className="text-xs text-slate-300 leading-relaxed mb-3">{p.description}</p>
 
@@ -276,6 +314,14 @@ function ProducteurCard({ p }: { p: Producteur }) {
             <Phone className="w-3.5 h-3.5" />{p.telephone}
           </a>
         )}
+        <a
+          href={p.source}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-2 block text-xs text-blue-300 hover:text-blue-200 underline underline-offset-2"
+        >
+          Source institutionnelle
+        </a>
       </div>
     </div>
   );
@@ -344,21 +390,121 @@ const ProducteursLocaux: React.FC = () => {
               </span>
             </div>
             <h1 className="text-2xl sm:text-4xl font-black text-white drop-shadow leading-tight">
-              🌾 Producteurs locaux
+              🌾 Souveraineté alimentaire ultramarine
             </h1>
             <p className="text-green-100 text-sm mt-2 drop-shadow max-w-2xl">
-              Achetez directement aux producteurs des DOM. Paniers fraîcheur, prix circuit court.
+              Annuaire des maraîchers, agriculteurs et coopératives pour produire local, distribuer local et nourrir local.
             </p>
             <div className="flex flex-wrap gap-2 mt-3">
               <span className="px-2 py-1 bg-green-500/20 border border-green-500/40 rounded-full text-xs text-green-300">
                 {PRODUCTEURS.length} producteurs répertoriés
               </span>
               <span className="px-2 py-1 bg-amber-500/20 border border-amber-500/40 rounded-full text-xs text-amber-300">
-                🧺 {PRODUCTEURS.reduce((n, p) => n + p.paniers.length, 0)} paniers disponibles
+                🧭 Base de qualification en cours
               </span>
             </div>
           </HeroImage>
         </div>
+
+        <section className="mb-6 bg-slate-900/60 border border-slate-800 rounded-2xl p-4 sm:p-5">
+          <h2 className="text-lg sm:text-xl font-bold mb-2">Pourquoi cette page ?</h2>
+          <p className="text-sm text-slate-300 leading-relaxed">
+            Cette page structure les acteurs clés de la souveraineté alimentaire dans les territoires ultramarins français :
+            maraîchers, agriculteurs, coopératives, transformateurs et acheteurs. Chaque fiche est enrichie puis validée
+            avec des sources institutionnelles et la qualification terrain.
+          </p>
+        </section>
+
+        <section className="mb-6 bg-gradient-to-br from-emerald-900/30 to-slate-900 border border-emerald-700/30 rounded-2xl p-4 sm:p-6">
+          <div className="flex items-center gap-2 mb-3">
+            <ClipboardList className="w-5 h-5 text-emerald-300" />
+            <h2 className="text-lg sm:text-xl font-bold">Audit complet DOM-TOM — Enquête souveraineté alimentaire</h2>
+          </div>
+          <p className="text-sm text-slate-300 leading-relaxed mb-4">
+            Cette enquête approfondie suit une méthode unique sur l’ensemble des territoires ultramarins français :
+            collecte terrain, validation institutionnelle, scoring logistique, suivi des risques de rupture et pilotage des
+            actions correctives. L’objectif est de produire une photographie opérationnelle et régulièrement mise à jour.
+          </p>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+            {AXES_AUDIT.map(({ icon: Icon, titre, description }) => (
+              <article key={titre} className="bg-slate-900/70 border border-slate-700/60 rounded-xl p-3">
+                <Icon className="w-4 h-4 text-emerald-300 mb-2" />
+                <h3 className="font-semibold text-sm mb-1">{titre}</h3>
+                <p className="text-xs text-slate-400 leading-relaxed">{description}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="mb-6 bg-slate-900/60 border border-slate-800 rounded-2xl p-4 sm:p-5">
+          <div className="flex items-center gap-2 mb-3">
+            <Target className="w-5 h-5 text-sky-300" />
+            <h2 className="text-lg sm:text-xl font-bold">Protocole d’enquête (illustration opérationnelle)</h2>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div className="bg-slate-950/60 border border-slate-700/60 rounded-xl p-3">
+              <p className="text-xs font-semibold text-sky-300 mb-1">Étape 1 — Sourcing</p>
+              <p className="text-xs text-slate-400">DAAF, Chambres d’agriculture, ODEADOM, annuaires professionnels, coopératives.</p>
+            </div>
+            <div className="bg-slate-950/60 border border-slate-700/60 rounded-xl p-3">
+              <p className="text-xs font-semibold text-sky-300 mb-1">Étape 2 — Qualification terrain</p>
+              <p className="text-xs text-slate-400">Appels, WhatsApp, visite marché/atelier, vérification activité réelle et saisonnalité.</p>
+            </div>
+            <div className="bg-slate-950/60 border border-slate-700/60 rounded-xl p-3">
+              <p className="text-xs font-semibold text-sky-300 mb-1">Étape 3 — Scoring</p>
+              <p className="text-xs text-slate-400">Score fiabilité, score logistique, score couverture locale, score risque rupture.</p>
+            </div>
+            <div className="bg-slate-950/60 border border-slate-700/60 rounded-xl p-3">
+              <p className="text-xs font-semibold text-sky-300 mb-1">Étape 4 — Plan d’action</p>
+              <p className="text-xs text-slate-400">Mise en relation acheteurs/producteurs, priorisation filières et alertes mensuelles.</p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-6 bg-slate-900/60 border border-slate-800 rounded-2xl p-4 sm:p-5">
+          <div className="flex items-center gap-2 mb-3">
+            <BarChart3 className="w-5 h-5 text-amber-300" />
+            <h2 className="text-lg sm:text-xl font-bold">Indicateurs clés de l’audit</h2>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-slate-300 border-b border-slate-700">
+                  <th className="py-2 pr-3">Indicateur</th>
+                  <th className="py-2 pr-3">Définition</th>
+                  <th className="py-2">Objectif pilote</th>
+                </tr>
+              </thead>
+              <tbody>
+                {INDICATEURS_CLES.map(([nom, definition, objectif]) => (
+                  <tr key={nom} className="border-b border-slate-800">
+                    <td className="py-2 pr-3 text-white font-medium">{nom}</td>
+                    <td className="py-2 pr-3 text-slate-400">{definition}</td>
+                    <td className="py-2 text-emerald-300">{objectif}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section className="mb-6 bg-slate-900/60 border border-slate-800 rounded-2xl p-4 sm:p-5">
+          <div className="flex items-center gap-2 mb-3">
+            <AlertTriangle className="w-5 h-5 text-orange-300" />
+            <h2 className="text-lg sm:text-xl font-bold">Périmètre DOM-TOM couvert par l’enquête</h2>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {TERRITOIRES_AUDIT.map((territoireAudit) => (
+              <span
+                key={territoireAudit}
+                className="px-2.5 py-1 rounded-full text-xs bg-slate-800 border border-slate-700 text-slate-300"
+              >
+                {territoireAudit}
+              </span>
+            ))}
+          </div>
+        </section>
 
         {/* Search + filters */}
         <div className="bg-slate-800/60 border border-slate-700/50 rounded-2xl p-4 mb-6 space-y-3">
@@ -411,7 +557,7 @@ const ProducteursLocaux: React.FC = () => {
           <div className="flex-1">
             <p className="font-semibold text-green-300 mb-1">🌱 Vous êtes producteur local ?</p>
             <p className="text-sm text-gray-400">
-              Inscrivez votre exploitation dans l'annuaire citoyen. Rejoignez l'économie de proximité des DOM.
+              Inscrivez votre exploitation dans l'annuaire citoyen. Rejoignez la dynamique de souveraineté alimentaire ultramarine.
             </p>
           </div>
           <Link to="/contribuer-prix"
@@ -420,6 +566,19 @@ const ProducteursLocaux: React.FC = () => {
             Référencer mon exploitation
           </Link>
         </div>
+
+        <section className="mt-6 bg-slate-900/60 border border-slate-800 rounded-2xl p-4 sm:p-5">
+          <h2 className="text-lg sm:text-xl font-bold mb-3">Sources officielles à consulter</h2>
+          <ul className="space-y-2 text-sm text-slate-300 list-disc pl-5">
+            <li><a className="text-blue-300 hover:text-blue-200 underline" href="https://chambres-agriculture.fr/" target="_blank" rel="noreferrer">Réseau des Chambres d’agriculture</a></li>
+            <li><a className="text-blue-300 hover:text-blue-200 underline" href="https://daaf.guadeloupe.agriculture.gouv.fr/" target="_blank" rel="noreferrer">DAAF Guadeloupe</a></li>
+            <li><a className="text-blue-300 hover:text-blue-200 underline" href="https://daaf.martinique.agriculture.gouv.fr/" target="_blank" rel="noreferrer">DAAF Martinique</a></li>
+            <li><a className="text-blue-300 hover:text-blue-200 underline" href="https://daaf.guyane.agriculture.gouv.fr/" target="_blank" rel="noreferrer">DAAF Guyane</a></li>
+            <li><a className="text-blue-300 hover:text-blue-200 underline" href="https://daaf.reunion.agriculture.gouv.fr/" target="_blank" rel="noreferrer">DAAF La Réunion</a></li>
+            <li><a className="text-blue-300 hover:text-blue-200 underline" href="https://daaf.mayotte.agriculture.gouv.fr/" target="_blank" rel="noreferrer">DAAF Mayotte</a></li>
+            <li><a className="text-blue-300 hover:text-blue-200 underline" href="https://www.odeadom.fr/" target="_blank" rel="noreferrer">ODEADOM</a></li>
+          </ul>
+        </section>
 
         {/* Bottom nav */}
         <div className="mt-6 grid grid-cols-1 sm:grid-cols-3 gap-3">

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -78,7 +78,7 @@ const SearchPage: React.FC = () => {
   }, [query, catalogue]);
 
   return (
-    <div className="w-full max-w-md mx-auto min-h-screen bg-white flex flex-col font-sans">
+    <div className="w-full max-w-md mx-auto min-h-screen bg-slate-950 text-white flex flex-col font-sans">
       <div className="p-4 border-b border-slate-100 sticky top-0 bg-white/90 backdrop-blur-xl z-20">
         <div className="relative">
           <span className="absolute left-4 top-1/2 -translate-y-1/2 text-xl opacity-40">🔍</span>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -32,7 +32,7 @@ const SearchPage: React.FC = () => {
   useEffect(() => {
     let mounted = true;
 
-    fetch('/data/catalogue.json')
+    fetch(`${import.meta.env.BASE_URL}data/catalogue.json`)
       .then((res) => res.json())
       .then((data: RawCatalogueItem[]) => {
         if (!mounted || !Array.isArray(data)) return;

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,5 +1,135 @@
-import RecherchePrix from './RecherchePrix';
+import React, { useEffect, useMemo, useState } from 'react';
 
-export default function SearchPage() {
-  return <RecherchePrix />;
+interface Product {
+  id: string | number;
+  name: string;
+  brand: string;
+  price: number;
+  store: string;
+  tags?: string[];
 }
+
+interface RawCatalogueItem {
+  id?: string | number;
+  name?: string;
+  brand?: string;
+  price?: number | string;
+  store?: string;
+  category?: string;
+  tags?: string[];
+}
+
+const normalize = (value: string): string =>
+  value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+
+const SearchPage: React.FC = () => {
+  const [query, setQuery] = useState('');
+  const [catalogue, setCatalogue] = useState<Product[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    fetch('/data/catalogue.json')
+      .then((res) => res.json())
+      .then((data: RawCatalogueItem[]) => {
+        if (!mounted || !Array.isArray(data)) return;
+
+        const normalizedCatalogue: Product[] = data
+          .filter((item) => typeof item?.name === 'string')
+          .map((item, index) => ({
+            id: item.id ?? `catalogue-${index}`,
+            name: item.name ?? 'Produit',
+            brand: item.brand ?? item.category ?? 'Sans marque',
+            price: typeof item.price === 'number' ? item.price : Number(item.price) || 0,
+            store: item.store ?? 'Magasin non précisé',
+            tags: item.tags ?? [],
+          }));
+
+        setCatalogue(normalizedCatalogue);
+      })
+      .catch((err) => {
+        console.error('Erreur gisement :', err);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const results = useMemo(() => {
+    if (!query.trim()) return [];
+
+    const normalizedQuery = normalize(query.trim());
+
+    return catalogue
+      .filter((item) => {
+        const searchContent = normalize(`${item.name} ${item.brand} ${item.store}`);
+        return searchContent.includes(normalizedQuery);
+      })
+      .sort((a, b) => {
+        const aSouverain = a.tags?.includes('SOUVERAIN') ? 1 : 0;
+        const bSouverain = b.tags?.includes('SOUVERAIN') ? 1 : 0;
+        if (aSouverain !== bSouverain) return bSouverain - aSouverain;
+        return a.price - b.price;
+      });
+  }, [query, catalogue]);
+
+  return (
+    <div className="w-full max-w-md mx-auto min-h-screen bg-white flex flex-col font-sans">
+      <div className="p-4 border-b border-slate-100 sticky top-0 bg-white/90 backdrop-blur-xl z-20">
+        <div className="relative">
+          <span className="absolute left-4 top-1/2 -translate-y-1/2 text-xl opacity-40">🔍</span>
+          <input
+            type="text"
+            placeholder="Farine, Huile, Riz..."
+            className="w-full bg-slate-100 border-none rounded-2xl py-4 pl-12 pr-4 text-lg font-medium focus:ring-2 focus:ring-sky-500 outline-none transition-all"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 p-4 space-y-3">
+        {results.length > 0 ? (
+          results.map((item) => (
+            <div
+              key={item.id}
+              className="flex items-center justify-between p-4 rounded-3xl border border-slate-50 bg-white shadow-sm active:scale-[0.97] transition-all"
+            >
+              <div className="flex flex-col flex-1 pr-4">
+                <span className="text-[9px] font-black text-slate-400 uppercase tracking-widest">{item.brand}</span>
+                <span className="text-base font-black text-slate-900 leading-tight truncate">{item.name}</span>
+                <span className="text-[11px] text-slate-500 mt-1 flex items-center">
+                  <span className="mr-1">📍</span> {item.store}
+                </span>
+              </div>
+
+              <div className="text-right flex flex-col items-end">
+                <span className="text-xl font-black text-slate-900">{item.price.toFixed(2)}€</span>
+                {item.tags?.includes('SOUVERAIN') && (
+                  <span className="text-[8px] font-black px-2 py-0.5 rounded bg-amber-100 text-amber-700 mt-1 uppercase">
+                    🇬🇵 Souverain
+                  </span>
+                )}
+              </div>
+            </div>
+          ))
+        ) : query.length > 0 ? (
+          <div className="text-center py-20">
+            <p className="text-slate-400 font-medium">Aucun prix trouvé pour "{query}"</p>
+          </div>
+        ) : (
+          <div className="text-center py-20 space-y-4 opacity-30">
+            <span className="text-6xl block">🛒</span>
+            <p className="font-bold uppercase tracking-widest text-xs text-slate-900">Catalogue Horizon v4.7</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default SearchPage;

--- a/frontend/src/pages/Suggestions.tsx
+++ b/frontend/src/pages/Suggestions.tsx
@@ -1,6 +1,7 @@
  
 import React from 'react';
-import { MessageSquarePlus, Lightbulb, Bug, HelpCircle, Database, Sparkles } from 'lucide-react';
+import { Lightbulb, Bug, HelpCircle, Database, Sparkles } from 'lucide-react';
+import { useLocation } from 'react-router-dom';
 import TicketForm from '../components/TicketForm';
 import type { TicketType } from '../types/ticket';
 import { HeroImage } from '../components/ui/HeroImage';
@@ -17,6 +18,7 @@ import { PAGE_HERO_IMAGES } from '../config/imageAssets';
  * - Signaler des erreurs de données
  */
 export default function Suggestions() {
+  const location = useLocation();
   const [selectedType, setSelectedType] = React.useState<TicketType | null>(null);
 
   const ticketTypes = [
@@ -78,6 +80,15 @@ export default function Suggestions() {
     };
     return colors[color] || colors.blue;
   };
+
+  React.useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    const requestedType = params.get('type');
+    const allowedTypes: TicketType[] = ['suggestion', 'feature_request', 'bug_report', 'data_quality', 'question'];
+    if (requestedType && allowedTypes.includes(requestedType as TicketType)) {
+      setSelectedType(requestedType as TicketType);
+    }
+  }, [location.search]);
 
   return (
     <div className="min-h-screen bg-slate-950">

--- a/frontend/src/pages/home-v5/HowItWorksSection.tsx
+++ b/frontend/src/pages/home-v5/HowItWorksSection.tsx
@@ -3,7 +3,7 @@ const HOW_IT_WORKS_STEPS = [
     num: '1',
     emoji: '🔍',
     title: 'Cherchez ou scannez',
-    text: 'Cherchez un produit par son nom, son code-barre (EAN), ou scannez directement un ticket de caisse.',
+    text: 'Cherchez un produit par son nom ou son code-barres, ou scannez directement un ticket de caisse.',
     imgUrl: 'https://images.unsplash.com/photo-1600880292203-757bb62b4baf?auto=format&fit=crop&w=600&q=80',
     imgAlt: 'Personne qui scanne un code-barres avec son téléphone dans un supermarché des Antilles',
   },

--- a/scripts/ai-monitor/monitor.mjs
+++ b/scripts/ai-monitor/monitor.mjs
@@ -65,6 +65,11 @@ const CONFIG = {
     'https://www.franceinfo.fr/france/outre-mer.rss',
     'https://la1ere.franceinfo.fr/actu/rss',
     'https://imazpress.com/feed',
+    'https://www.rci.fm/guadeloupe/rss.xml',
+    'https://www.rci.fm/martinique/rss.xml',
+    'https://la1ere.franceinfo.fr/economie/rss?r=polynesie',
+    'https://la1ere.franceinfo.fr/economie/rss?r=nouvellecaledonie',
+    'https://la1ere.franceinfo.fr/economie/rss?r=saintpierreetmiquelon',
   ],
   /** GitHub repo */
   repo: process.env.GITHUB_REPOSITORY ?? 'teetee971/akiprisaye-web',

--- a/scripts/lettre-hebdo/generate.js
+++ b/scripts/lettre-hebdo/generate.js
@@ -57,6 +57,9 @@ const RSS_FEEDS = [
   { url: 'https://la1ere.franceinfo.fr/economie/rss?r=reunion',      source: 'La1ère Réunion Éco',     territory: 'La Réunion' },
   { url: 'https://la1ere.franceinfo.fr/economie/rss?r=guyane',       source: 'La1ère Guyane Éco',      territory: 'Guyane'     },
   { url: 'https://la1ere.franceinfo.fr/economie/rss?r=mayotte',      source: 'La1ère Mayotte Éco',     territory: 'Mayotte'    },
+  { urls: ['https://la1ere.franceinfo.fr/economie/rss?r=polynesie', 'https://la1ere.franceinfo.fr/polynesie/actu/rss'], source: 'La1ère Polynésie Éco', territory: 'Polynésie française' },
+  { urls: ['https://la1ere.franceinfo.fr/economie/rss?r=nouvellecaledonie', 'https://la1ere.franceinfo.fr/nouvelle-caledonie/actu/rss'], source: 'La1ère Nouvelle-Calédonie Éco', territory: 'Nouvelle-Calédonie' },
+  { urls: ['https://la1ere.franceinfo.fr/economie/rss?r=saintpierreetmiquelon', 'https://la1ere.franceinfo.fr/saint-pierre-et-miquelon/actu/rss'], source: 'La1ère Saint-Pierre-et-Miquelon Éco', territory: 'Saint-Pierre-et-Miquelon' },
   // Société (conditions de vie, social, éducation)
   { url: 'https://la1ere.franceinfo.fr/societe/rss',                 source: 'La1ère — Société DOM',   territory: 'Outre-Mer'  },
   // Martinique actualités complètes
@@ -64,6 +67,9 @@ const RSS_FEEDS = [
   // ── Presse indépendante ───────────────────────────────────────────────────
   // ImazPress — presse indépendante La Réunion
   { url: 'https://imazpress.com/feed',                               source: 'ImazPress Réunion',      territory: 'La Réunion' },
+  // RCI — Antilles (flux principal + fallback WordPress)
+  { urls: ['https://www.rci.fm/guadeloupe/rss.xml', 'https://rci.fm/guadeloupe/rss.xml'], source: 'RCI Guadeloupe', territory: 'Guadeloupe' },
+  { urls: ['https://www.rci.fm/martinique/rss.xml', 'https://rci.fm/martinique/rss.xml'], source: 'RCI Martinique', territory: 'Martinique' },
 ];
 
 // ─── Utilitaires temporels ──────────────────────────────────────────────────────
@@ -93,30 +99,34 @@ function getWeekPeriode(date = new Date()) {
 
 /** Récupère et parse un flux RSS. Retourne une liste d'articles ou [] si échec. */
 async function fetchFeed(feed, parser) {
-  try {
-    const res = await fetch(feed.url, {
-      headers: { 'User-Agent': 'AKiPriSaYe-Bot/1.0 (+https://akiprisaye.pf)' },
-      signal: AbortSignal.timeout(12000),
-    });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const xml = await res.text();
-    const parsed = parser.parse(xml);
-    const rawItems = parsed?.rss?.channel?.item ?? [];
-    const items = Array.isArray(rawItems) ? rawItems : [rawItems];
-    return items.slice(0, 10).map((item) => ({
-      title: stripHtmlToText(item.title ?? '').trim(),
-      description: stripHtmlToText(item.description ?? '')
-        .trim()
-        .slice(0, 350),
-      url: String(item.link ?? item.guid ?? ''),
-      publishedAt: String(item.pubDate ?? ''),
-      source: feed.source,
-      territory: feed.territory,
-    }));
-  } catch (err) {
-    console.warn(`⚠️  Flux ignoré (${feed.source}) : ${err.message}`);
-    return [];
+  const candidates = Array.isArray(feed.urls) ? feed.urls : [feed.url];
+  for (const url of candidates) {
+    try {
+      const res = await fetch(url, {
+        headers: { 'User-Agent': 'AKiPriSaYe-Bot/1.0 (+https://akiprisaye.pf)' },
+        signal: AbortSignal.timeout(12000),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const xml = await res.text();
+      const parsed = parser.parse(xml);
+      const rawItems = parsed?.rss?.channel?.item ?? [];
+      const items = Array.isArray(rawItems) ? rawItems : [rawItems];
+      return items.slice(0, 10).map((item) => ({
+        title: stripHtmlToText(item.title ?? '').trim(),
+        description: stripHtmlToText(item.description ?? '')
+          .trim()
+          .slice(0, 350),
+        url: String(item.link ?? item.guid ?? ''),
+        publishedAt: String(item.pubDate ?? ''),
+        source: feed.source,
+        territory: feed.territory,
+      }));
+    } catch (err) {
+      console.warn(`⚠️  Tentative flux échouée (${feed.source}) [${url}] : ${err.message}`);
+    }
   }
+  console.warn(`⚠️  Flux ignoré (${feed.source}) : aucune URL disponible`);
+  return [];
 }
 
 // ─── Prompt IA ─────────────────────────────────────────────────────────────────

--- a/scripts/lettre-jour/generate.js
+++ b/scripts/lettre-jour/generate.js
@@ -59,6 +59,9 @@ const RSS_FEEDS = [
   { url: 'https://la1ere.franceinfo.fr/economie/rss?r=reunion',      source: 'La1ère Réunion Éco',     territory: 'La Réunion' },
   { url: 'https://la1ere.franceinfo.fr/economie/rss?r=guyane',       source: 'La1ère Guyane Éco',      territory: 'Guyane'     },
   { url: 'https://la1ere.franceinfo.fr/economie/rss?r=mayotte',      source: 'La1ère Mayotte Éco',     territory: 'Mayotte'    },
+  { urls: ['https://la1ere.franceinfo.fr/economie/rss?r=polynesie', 'https://la1ere.franceinfo.fr/polynesie/actu/rss'], source: 'La1ère Polynésie Éco', territory: 'Polynésie française' },
+  { urls: ['https://la1ere.franceinfo.fr/economie/rss?r=nouvellecaledonie', 'https://la1ere.franceinfo.fr/nouvelle-caledonie/actu/rss'], source: 'La1ère Nouvelle-Calédonie Éco', territory: 'Nouvelle-Calédonie' },
+  { urls: ['https://la1ere.franceinfo.fr/economie/rss?r=saintpierreetmiquelon', 'https://la1ere.franceinfo.fr/saint-pierre-et-miquelon/actu/rss'], source: 'La1ère Saint-Pierre-et-Miquelon Éco', territory: 'Saint-Pierre-et-Miquelon' },
   // Société (conditions de vie, social, éducation)
   { url: 'https://la1ere.franceinfo.fr/societe/rss',                 source: 'La1ère — Société DOM',   territory: 'Outre-Mer'  },
   // Martinique actualités complètes
@@ -66,6 +69,9 @@ const RSS_FEEDS = [
   // ── Presse indépendante ───────────────────────────────────────────────────
   // ImazPress — presse indépendante La Réunion
   { url: 'https://imazpress.com/feed',                               source: 'ImazPress Réunion',      territory: 'La Réunion' },
+  // RCI — Antilles (flux principal + fallback WordPress)
+  { urls: ['https://www.rci.fm/guadeloupe/rss.xml', 'https://rci.fm/guadeloupe/rss.xml'], source: 'RCI Guadeloupe', territory: 'Guadeloupe' },
+  { urls: ['https://www.rci.fm/martinique/rss.xml', 'https://rci.fm/martinique/rss.xml'], source: 'RCI Martinique', territory: 'Martinique' },
 ];
 
 // ─── Utilitaires temporels ──────────────────────────────────────────────────────
@@ -89,30 +95,34 @@ function getDayLabel(date = new Date()) {
 
 /** Récupère et parse un flux RSS. Retourne une liste d'articles ou [] si échec. */
 async function fetchFeed(feed, parser) {
-  try {
-    const res = await fetch(feed.url, {
-      headers: { 'User-Agent': 'AKiPriSaYe-Bot/1.0 (+https://akiprisaye.pf)' },
-      signal: AbortSignal.timeout(12000),
-    });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const xml = await res.text();
-    const parsed = parser.parse(xml);
-    const rawItems = parsed?.rss?.channel?.item ?? [];
-    const items = Array.isArray(rawItems) ? rawItems : [rawItems];
-    return items.slice(0, 8).map((item) => ({
-      title: stripHtmlToText(item.title ?? '').trim(),
-      description: stripHtmlToText(item.description ?? '')
-        .trim()
-        .slice(0, 300),
-      url: String(item.link ?? item.guid ?? ''),
-      publishedAt: String(item.pubDate ?? ''),
-      source: feed.source,
-      territory: feed.territory,
-    }));
-  } catch (err) {
-    console.warn(`⚠️  Flux ignoré (${feed.source}) : ${err.message}`);
-    return [];
+  const candidates = Array.isArray(feed.urls) ? feed.urls : [feed.url];
+  for (const url of candidates) {
+    try {
+      const res = await fetch(url, {
+        headers: { 'User-Agent': 'AKiPriSaYe-Bot/1.0 (+https://akiprisaye.pf)' },
+        signal: AbortSignal.timeout(12000),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const xml = await res.text();
+      const parsed = parser.parse(xml);
+      const rawItems = parsed?.rss?.channel?.item ?? [];
+      const items = Array.isArray(rawItems) ? rawItems : [rawItems];
+      return items.slice(0, 8).map((item) => ({
+        title: stripHtmlToText(item.title ?? '').trim(),
+        description: stripHtmlToText(item.description ?? '')
+          .trim()
+          .slice(0, 300),
+        url: String(item.link ?? item.guid ?? ''),
+        publishedAt: String(item.pubDate ?? ''),
+        source: feed.source,
+        territory: feed.territory,
+      }));
+    } catch (err) {
+      console.warn(`⚠️  Tentative flux échouée (${feed.source}) [${url}] : ${err.message}`);
+    }
   }
+  console.warn(`⚠️  Flux ignoré (${feed.source}) : aucune URL disponible`);
+  return [];
 }
 
 // ─── Prompt IA ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Make route snapshot checks more actionable by printing detailed drift information when the generated routes differ from the committed snapshot.
- Surface new UI content and small copy improvements across the frontend (home, footer, demo, conseils, territory signals, producteurs) and add a simple daily highlight and extra service CTAs.
- Provide a simple, local searchable catalogue UI and enable preselecting suggestion types from URL params to improve UX for reporting and discovery.
- Make RSS collection more resilient by adding additional feeds and trying multiple candidate URLs per source to reduce flaky failures in newsletter/monitoring scripts.

### Description
- Updated lint-staged config to run the routes snapshot script when `frontend/src/App.tsx` changes via `npm --prefix frontend run snapshot:routes`.
- Enhanced `frontend/scripts/public-routes-snapshot.mjs` with `extractRoutesFromSnapshot` and `printDriftDetails` to show missing/extra routes and small previews when the snapshot is stale, and updated the snapshot file accordingly.
- Added legacy alias routes in `frontend/src/App.tsx` for `premium`, `plans` and `plan` redirecting to `/pricing` and other small route adjustments.
- Multiple frontend UI/content changes across components and pages including: copy tweaks in `AppDemoShowcase`, updated advice and links in `ConseilBudgetDuJour`, small wording in `TerritorySignal`, rename in `Footer`, and a new `dailyStar` block plus service buttons in `Home.tsx`.
- Major enhancements to `ProducteursLocaux.tsx` including new producer/org data shapes with optional ratings and `source` links, audit/explanatory sections, indicators table and expanded territory coverage badges.
- Replaced the simple search page import with a new `SearchPage` implementation that loads `data/catalogue.json`, normalizes data, and provides client-side search, ranking and a `SOUVERAIN` badge.
- Improved `Suggestions.tsx` to read `?type=` from the URL and preselect the ticket type, and minor copy/UI fixes in `HowItWorksSection.tsx`.
- Made RSS and monitoring scripts (`scripts/ai-monitor/monitor.mjs`, `scripts/lettre-hebdo/generate.js`, `scripts/lettre-jour/generate.js`) more robust by adding additional feeds and changing `fetchFeed` to try an array of candidate URLs per feed with clearer logging on failures.

### Testing
- Ran `npm --prefix frontend run lint` on the modified frontend files and addressed linting; the linter completed successfully.
- Executed the routes snapshot tool in write mode via `node frontend/scripts/public-routes-snapshot.mjs --write` to regenerate `frontend/scripts/public-routes.snapshot.txt` and committed the updated snapshot.
- Verified the updated newsletter/rss fetch logic by static review and local execution of the `fetchFeed` changes which exercised the multi-URL fallback paths and logging (no CI integration tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0e02d832083219bb647123b38cda4)